### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,11 +24,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
-          # Needed to shorten the path for zxing-cpp build
-          poetry config virtualenvs.path C:\e
 
       - name: Build the Helper
-        run: .\build-helper.bat
+        run: |
+          # Needed to shorten the path for zxing-cpp build
+          $env:TMPDIR = "C:\e"
+          poetry config virtualenvs.path C:\e
+          .\build-helper.bat
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,6 +24,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install poetry
+          # Needed to shorten the path for zxing-cpp build
+          poetry config virtualenvs.path C:\e
 
       - name: Build the Helper
         run: .\build-helper.bat

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,9 +22,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          choco install swig
           python -m pip install --upgrade pip
           pip install poetry
+
+      - name: Build the Helper
+        run: .\build-helper.bat
 
       - uses: subosito/flutter-action@v2
         with:
@@ -37,9 +39,6 @@ jobs:
         run: |
           flutter test
           flutter analyze
-
-      - name: Build the Helper
-        run: .\build-helper.bat
 
       - name: Build the app
         run: |

--- a/build-helper.bat
+++ b/build-helper.bat
@@ -2,18 +2,23 @@
 
 echo Building authenticator-helper for Windows...
 cd helper
-poetry install
+poetry install || goto :error
 rmdir /s /q ..\build\windows\helper
-poetry run pyinstaller authenticator-helper.spec --distpath ..\build\windows
+poetry run pyinstaller authenticator-helper.spec --distpath ..\build\windows || goto :error
 
 echo Generating license files...
 rmdir /s /q ..\build\windows\helper-license-venv
-poetry build
-poetry run python -m venv ..\build\windows\helper-license-venv
-..\build\windows\helper-license-venv\Scripts\python -m pip install --upgrade pip wheel
-..\build\windows\helper-license-venv\Scripts\python -m pip install dist\authenticator_helper-0.1.0-py3-none-any.whl pip-licenses
-..\build\windows\helper-license-venv\Scripts\pip-licenses --format=json --no-license-path --with-license-file --ignore-packages authenticator-helper zxing-cpp --output-file ..\assets\licenses\helper.json
+poetry build || goto :error
+poetry run python -m venv ..\build\windows\helper-license-venv || goto :error
+..\build\windows\helper-license-venv\Scripts\python -m pip install --upgrade pip wheel || goto :error
+..\build\windows\helper-license-venv\Scripts\python -m pip install dist\authenticator_helper-0.1.0-py3-none-any.whl pip-licenses || goto :error
+..\build\windows\helper-license-venv\Scripts\pip-licenses --format=json --no-license-path --with-license-file --ignore-packages authenticator-helper zxing-cpp --output-file ..\assets\licenses\helper.json || goto :error
 
 cd ..
 
 echo All done, output in build/windows/
+goto :EOF
+
+:error
+echo Failed with error #%errorlevel%.
+exit /b %errorlevel%


### PR DESCRIPTION
The Windows build started failing due to paths being too long. This changes some work directories to be shorter.