### PR TITLE
Fix rendering of input fields when adding new account

### DIFF
--- a/lib/widgets/utf8_utils.dart
+++ b/lib/widgets/utf8_utils.dart
@@ -28,10 +28,18 @@ int byteLength(String value) => utf8.encode(value).length;
 /// used rather than number of characters. [currentValue] should always match
 /// the input text value to measure.
 InputCounterWidgetBuilder buildByteCounterFor(String currentValue) =>
-    (context, {required currentLength, required isFocused, maxLength}) => Text(
-          maxLength != null ? '${byteLength(currentValue)}/$maxLength' : '',
-          style: Theme.of(context).textTheme.caption,
-        );
+    (context, {required currentLength, required isFocused, maxLength}) {
+      final theme = Theme.of(context);
+      final caption = theme.textTheme.caption;
+      final style = (byteLength(currentValue) <= (maxLength ?? 0))
+          ? caption
+          : caption?.copyWith(color: theme.errorColor);
+      return Text(
+        maxLength != null ? '${byteLength(currentValue)}/$maxLength' : '',
+        style: style,
+        semanticsLabel: 'Character count',
+      );
+    };
 
 /// Limits the input in length based on the byte length when encoded.
 /// This is generally used together with [buildByteCounterFor].


### PR DESCRIPTION
When scanning a QR code (or using `otpauth://` scheme on Android), the Add account dialog will be pre-filled with parsed information.

This PR fixes issue when name and issuer strings are too long to fit to a YubiKey and the TextField widgets are not highlighted.

Wrong, because the text in issuer and name fields is too long:

![image](https://user-images.githubusercontent.com/1954891/203289447-cf31448b-ec19-4e99-980b-dc033013a979.png)


Correct - the fields are emphasised and the character count has correct colour:
![image](https://user-images.githubusercontent.com/1954891/203289152-dfde43de-6ae4-42c3-9a81-5ec3d8198024.png)

This issue was introduced by using `buildCounter` in our TextFields, as described in this [flutter issue](https://github.com/flutter/flutter/issues/115815). 