### PR TITLE
Cache the helper between runs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,8 @@ jobs:
   helper:
     name: Build helper
     runs-on: ubuntu-latest
+    env:
+      PYVER: 3.11
     container:
       image: ubuntu:18.04
       env:
@@ -14,20 +16,30 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Cache helper
+      id: cache-helper
+      uses: actions/cache@v3
+      with:
+        path: helper.tar.gz
+        key: ${{ runner.os }}-py${{ env.PYVER }}-${{ hashFiles('helper/**') }}
+
     - name: Install dependencies
+      if: steps.cache-helper.outputs.cache-hit != 'true'
       run: |
         apt-get update
         apt-get install -qq swig libpcsclite-dev software-properties-common build-essential cmake git
         add-apt-repository -y ppa:deadsnakes/ppa
-        apt-get install -qq python3.11-dev python3.11-venv
-        python3.11 -m ensurepip --user
-        python3.11 -m pip install -U pip
-        python3.11 -m pip install poetry
+        apt-get install -qq python$PYVER-dev python$PYVER-venv
+        python$PYVER -m ensurepip --user
+        python$PYVER -m pip install -U pip
+        python$PYVER -m pip install poetry
 
     - name: Build the Helper
+      if: steps.cache-helper.outputs.cache-hit != 'true'
       run: ./build-helper.sh
 
     - name: Create archive
+      if: steps.cache-helper.outputs.cache-hit != 'true'
       run: tar -czf helper.tar.gz build/linux/helper assets/licenses/helper.json
 
     - name: Upload artifact
@@ -44,6 +56,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Check app versions
+      run: |
+        python set-version.py
+        git diff --exit-code
+
     - name: Download helper
       uses: actions/download-artifact@v3
       with:
@@ -52,11 +69,6 @@ jobs:
     - name: Unpack helper
       run: |
         tar -xf helper.tar.gz
-
-    - name: Check app versions
-      run: |
-        python set-version.py
-        git diff --exit-code
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,26 +6,43 @@ jobs:
   build:
 
     runs-on: macos-latest
+    env:
+      PYVER: 3.11
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-
     - name: Check app versions
       run: |
-        python set-version.py
+        python3 set-version.py
         git diff --exit-code
 
+    - name: Cache helper
+      id: cache-helper
+      uses: actions/cache@v3
+      with:
+        path: |
+          build/macos/helper
+          assets/licenses/helper.json
+        key: ${{ runner.os }}-py${{ env.PYVER }}-${{ hashFiles('helper/**') }}
+
+    - name: Set up Python
+      if: steps.cache-helper.outputs.cache-hit != 'true'
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ env.PYVER }}
+
     - name: Install dependencies
+      if: steps.cache-helper.outputs.cache-hit != 'true'
       run: |
         brew update
         brew install swig
         python -m pip install --upgrade pip
         pip install poetry
+
+    - name: Build the Helper
+      if: steps.cache-helper.outputs.cache-hit != 'true'
+      run: ./build-helper.sh
 
     - uses: subosito/flutter-action@v2
       with:
@@ -39,9 +56,6 @@ jobs:
       run: |
         flutter test
         flutter analyze
-
-    - name: Build the Helper
-      run: ./build-helper.sh
 
     - name: Build the app
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,26 +6,40 @@ jobs:
   build:
 
     runs-on: windows-latest
+    env:
+      PYVER: 3.11
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
 
       - name: Check app versions
         run: |
           python set-version.py
           git diff --exit-code
 
+      - name: Cache helper
+        id: cache-helper
+        uses: actions/cache@v3
+        with:
+          path: |
+            build/windows/helper
+            assets/licenses/helper.json
+          key: ${{ runner.os }}-py${{ env.PYVER }}-${{ hashFiles('helper/**') }}
+
+      - name: Set up Python
+        if: steps.cache-helper.outputs.cache-hit != 'true'
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYVER }}
+
       - name: Install dependencies
+        if: steps.cache-helper.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install poetry
 
       - name: Build the Helper
+        if: steps.cache-helper.outputs.cache-hit != 'true'
         run: |
           # Needed to shorten the path for zxing-cpp build
           $env:TMPDIR = "C:\e"
@@ -58,7 +72,6 @@ jobs:
           cp $dest\helper\MSVCP140.dll $dest\
           cp $dest\helper\VCRUNTIME140.dll $dest\
           cp $dest\helper\VCRUNTIME140_1.dll $dest\
-
 
       - name: Create an unsigned .msi installer package
         run: |


### PR DESCRIPTION
This adds caching of the helper binary, rebuilding it anytime something changes under the `helper/` directory.
For builds where the helper is cached, this cuts down build time by about 50%.