### PR TITLE
[Android] build scripts

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -38,12 +38,8 @@ jobs:
           flutter analyze
         working-directory: ./app
 
-      - name: Generate Third party licenses
-        run: ./gradlew collectLicenses
-        working-directory: ./app/android
-
       - name: Build the App
-        run: flutter build apk --release --split-per-abi && flutter build apk --release
+        run: android/scripts/build.sh
         env:
           YUBIOATH_STORE_BASE64: ${{ secrets.YUBIOATH_STORE_BASE64 }}
           YUBIOATH_KEY_ALIAS: ${{ secrets.YUBIOATH_KEY_ALIAS }}
@@ -56,30 +52,11 @@ jobs:
         working-directory: ./app
 
       - name: Run android tests
-        run: |
-          ./gradlew test
+        run: ./gradlew test
         working-directory: ./app/android
 
-      - name: Upload artifacts
-        run: |
-          export REF=$(echo ${GITHUB_REF} | cut -d '/' -f 3,4,5,6,7 | sed -r 's/\//_/g')
-          export FLUTTER_APK=build/app/outputs/flutter-apk
-          export NATIVE_LIBS=build/app/intermediates/merged_native_libs/release/out/lib
-
-          mkdir artifacts
-          mv "${FLUTTER_APK}/app-arm64-v8a-release.apk"   artifacts/yubico-authenticator-arm64-v8a-${REF}.apk
-          mv "${FLUTTER_APK}/app-armeabi-v7a-release.apk" artifacts/yubico-authenticator-armeabi-v7a-${REF}.apk
-          mv "${FLUTTER_APK}/app-x86_64-release.apk"      artifacts/yubico-authenticator-x86_64-${REF}.apk
-          mv "${FLUTTER_APK}/app-release.apk"             artifacts/yubico-authenticator-${REF}.apk
-
-          mv build/app/outputs/mapping/release/mapping.txt artifacts/
-
-          pushd "${NATIVE_LIBS}/"
-          zip -r sym-arm64-v8a.zip arm64-v8a/*so
-          zip -r sym-armeabi-v7a.zip armeabi-v7a/*so
-          zip -r sym-x86_64.zip x86_64/*so
-          popd
-          mv "${NATIVE_LIBS}/"*zip artifacts/
+      - name: Collect artifacts
+        run: android/scripts/collect-artifacts.sh ${GITHUB_REF}
         working-directory: ./app
 
       - uses: actions/upload-artifact@v3

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/artifacts/

--- a/android/scripts/build.sh
+++ b/android/scripts/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+
+# Generate Third-party licenses
+pushd android
+./gradlew collectLicenses
+popd
+
+# Build flutter app
+flutter build apk --release --split-per-abi
+flutter build apk --release

--- a/android/scripts/collect-artifacts.sh
+++ b/android/scripts/collect-artifacts.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -x
+
+GITHUB_REF=`git branch --show-current`
+if [ $# -gt 0 ] ; then
+   GITHUB_REF="$1"
+fi
+
+export REF=$(echo ${GITHUB_REF} | cut -d '/' -f 3,4,5,6,7 | sed -r 's/\//_/g')
+export FLUTTER_APK=build/app/outputs/flutter-apk
+export NATIVE_LIBS=build/app/intermediates/merged_native_libs/release/out/lib
+
+rm -rf artifacts
+mkdir artifacts
+cp "${FLUTTER_APK}/app-arm64-v8a-release.apk"   artifacts/yubico-authenticator-arm64-v8a-${REF}.apk
+cp "${FLUTTER_APK}/app-armeabi-v7a-release.apk" artifacts/yubico-authenticator-armeabi-v7a-${REF}.apk
+cp "${FLUTTER_APK}/app-x86_64-release.apk"      artifacts/yubico-authenticator-x86_64-${REF}.apk
+cp "${FLUTTER_APK}/app-release.apk"             artifacts/yubico-authenticator-${REF}.apk
+
+cp build/app/outputs/mapping/release/mapping.txt artifacts/
+
+pushd "${NATIVE_LIBS}/"
+zip -r sym-arm64-v8a.zip arm64-v8a/*so
+zip -r sym-armeabi-v7a.zip armeabi-v7a/*so
+zip -r sym-x86_64.zip x86_64/*so
+popd
+cp "${NATIVE_LIBS}/"*zip artifacts/


### PR DESCRIPTION
Moves build steps out of git hub actions for easier maintainability. 
- `android/scripts/build.sh` creates release APKs
- `android/scripts/collect-artifacts.sh` collects built files to a common directory

The scripts can be run locally on linux/mac host and thus can be used for improving the build flows.

Notes:
- `build.sh` builds a release variant and needs valid `YUBIOATH_STORE_BASE64`,  `YUBIOATH_KEY_ALIAS`, `YUBIOATH_KEY_PASSWORD` and `YUBIOATH_STORE_PASSWORD` env varaiables
- `collect-artifacts.sh` uses output of `build.sh`
- our github action passes `${GITHUB_REF}` to `build.sh`. If run locally, one can omit this parameter and it will get value of `git branch --show-current`. This value is used in the APKs name.