### PR TITLE
Fix release scripting for macos and win

### DIFF
--- a/macos/release-macos.sh
+++ b/macos/release-macos.sh
@@ -1,30 +1,32 @@
 #!/bin/sh
 
-if [ -z "$1" ]
-then
-	echo "No username given"
-	exit
-fi
-
-if [ -z "$2" ]
-then
-	echo "No password given"
-	exit
-fi
-
 if ! command -v create-dmg &> /dev/null
 then
 	echo "create-dmg could not be found"
 	exit
 fi
 
-
 echo "# Extract .app from .tar.gz"
-tar -xzvf yubioath-desktop*.tar.gz
+tar -xzf yubioath-desktop*.tar.gz
 
-echo "# Sign the main binaries, with the entitlements"
-codesign -f --timestamp --options runtime --entitlements helper.entitlements --sign 'Application' Yubico\ Authenticator.app/Contents/Resources/helper/authenticator-helper
-codesign -f --timestamp --options runtime --entitlements helper.entitlements --sign 'Application' Yubico\ Authenticator.app/Contents/Resources/helper-arm64/authenticator-helper
+if [ -n "$1" ] && [ -n "$2" ] # Standalone
+then
+	echo "#################"
+	echo "# Two parameters have been given, this will be a standalone"
+	echo "#################"
+	echo
+	echo "# Sign the main binaries, with the entitlements"
+	codesign -f --timestamp --options runtime --entitlements helper.entitlements --sign 'Application' Yubico\ Authenticator.app/Contents/Resources/helper/authenticator-helper
+	codesign -f --timestamp --options runtime --entitlements helper.entitlements --sign 'Application' Yubico\ Authenticator.app/Contents/Resources/helper-arm64/authenticator-helper
+else
+	echo "#################"
+	echo "# No parameters given, this will be app store"
+	echo "#################"
+	echo
+	echo "# Sign the main binaries, with sandbox enabled, without hardened runtime"
+	codesign -f --timestamp --entitlements helper-sandbox.entitlements --sign 'Application' Yubico\ Authenticator.app/Contents/Resources/helper/authenticator-helper
+	codesign -f --timestamp --entitlements helper-sandbox.entitlements --sign 'Application' Yubico\ Authenticator.app/Contents/Resources/helper-arm64/authenticator-helper
+fi
 
 echo "# Sign the dylib and so files, without entitlements"
 cd Yubico\ Authenticator.app/
@@ -39,43 +41,49 @@ codesign -f --timestamp --options runtime --sign 'Application' Yubico\ Authentic
 echo "# Sign the GUI"
 codesign -f --timestamp --options runtime --sign 'Application' --entitlements Release.entitlements --deep "Yubico Authenticator.app"
 
-echo "# Compress the .app to .zip and notarize"
-ditto -c -k --sequesterRsrc --keepParent "Yubico Authenticator.app" "Yubico Authenticator.zip" 
-RES=$(xcrun altool -t osx -f "Yubico Authenticator.zip" --primary-bundle-id com.yubico.authenticator --notarize-app -u $1 -p $2)
-echo ${RES}
-ERRORS=${RES:0:9}
-if [ "$ERRORS" != "No errors" ]; then
-	echo "Error uploading for notarization"
-	exit
-fi
-UUID=${RES#*=}
-STATUS=$(xcrun altool --notarization-info $UUID -u $1 -p $2)
-
-while true
-do
-	if [[ "$STATUS" == *"in progress"* ]]; then
-		echo "Notarization still in progress. Sleep 30s."
-		sleep 30
-		echo "Retrieving status again."
-		STATUS=$(xcrun altool --notarization-info $UUID -u $1 -p $2)
-	else
-		echo "Status changed."
-		break
+if [ -n "$1" ] && [ -n "$2" ] # Standalone
+then
+	echo "# Compress the .app to .zip and notarize"
+	ditto -c -k --sequesterRsrc --keepParent "Yubico Authenticator.app" "Yubico Authenticator.zip" 
+	RES=$(xcrun altool -t osx -f "Yubico Authenticator.zip" --primary-bundle-id com.yubico.authenticator --notarize-app -u $1 -p $2)
+	echo ${RES}
+	ERRORS=${RES:0:9}
+	if [ "$ERRORS" != "No errors" ]; then
+		echo "Error uploading for notarization"
+		exit
 	fi
-done
+	UUID=${RES#*=}
+	STATUS=$(xcrun altool --notarization-info $UUID -u $1 -p $2)
 
-echo "${STATUS}"
+	while true
+	do
+		if [[ "$STATUS" == *"in progress"* ]]; then
+			echo "Notarization still in progress. Sleep 30s."
+			sleep 30
+			echo "Retrieving status again."
+			STATUS=$(xcrun altool --notarization-info $UUID -u $1 -p $2)
+		else
+			echo "Status changed."
+			break
+		fi
+	done
 
-if [[ "$STATUS" == *"success"* ]]; then
-	echo "Notarization successfull. Staple the .app"
-	xcrun stapler staple -v "Yubico Authenticator.app"
+	echo "${STATUS}"
 
-	echo "# Create dmg"
-	rm yubioath-desktop.dmg # Remove old .dmg
-	mkdir source_folder
-	mv "Yubico Authenticator.app" source_folder
-	sh create-dmg.sh
-	echo "# .dmg created. Everything should be ready for release!"
+	if [[ "$STATUS" == *"success"* ]]; then
+		echo "Notarization successfull. Staple the .app"
+		xcrun stapler staple -v "Yubico Authenticator.app"
+
+		echo "# Create dmg"
+		rm yubioath-desktop.dmg # Remove old .dmg
+		mkdir source_folder
+		mv "Yubico Authenticator.app" source_folder
+		sh create-dmg.sh
+		echo "# .dmg created. Everything should be ready for release!"
+	fi
+else # App store
+	echo "# Build the package for AppStore submission"
+	productbuild --sign 'Installer' --component "Yubico Authenticator.app" /Applications/ output-appstore.pkg
 fi
 
 echo "# End of script"

--- a/resources/win/release-win.ps1
+++ b/resources/win/release-win.ps1
@@ -1,5 +1,11 @@
 $version="6.0.3-dev.0"
 
+echo "Clean-up of old files"
+rm *.msi
+rm *.wixobj
+rm *.wxs
+rm *.wixpdb
+
 echo "Renaming the Actions folder and moving it"
 mv yubioath-desktop-* release
 


### PR DESCRIPTION
For a standalone app we need two arguments in order to notarize. For the app store we do not need anything at all. 