### PR TITLE
[Android] Make sure toast object are not hidden by on-screen keyboard

### DIFF
--- a/lib/exception/apdu_exception.dart
+++ b/lib/exception/apdu_exception.dart
@@ -20,5 +20,10 @@ class ApduException implements Exception {
   final String? details;
 
   ApduException(this.sw, this.message, this.details);
+
+  @override
+  String toString() {
+    return 'ApduException[$message; dec: $sw]';
+  }
 }
 

--- a/lib/widgets/toast.dart
+++ b/lib/widgets/toast.dart
@@ -122,19 +122,24 @@ void Function() showToast(
   }
 
   entry = OverlayEntry(builder: (context) {
-    return SafeArea(
-      child: Align(
-        alignment: Alignment.bottomCenter,
-        child: Container(
-          height: 50,
-          width: 400,
-          margin: const EdgeInsets.all(8),
-          child: Toast(
-            message,
-            duration,
-            backgroundColor: backgroundColor,
-            textStyle: textStyle,
-            onComplete: close,
+    return Positioned(
+      bottom: MediaQuery.of(context).viewInsets.bottom,
+      left: 0,
+      right: 0,
+      child: SafeArea(
+        child: Align(
+          alignment: Alignment.bottomCenter,
+          child: Container(
+            height: 50,
+            width: 400,
+            margin: const EdgeInsets.all(8),
+            child: Toast(
+              message,
+              duration,
+              backgroundColor: backgroundColor,
+              textStyle: textStyle,
+              onComplete: close,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
This PR positions the Toast on top from the on-screen keyboard.

![Screenshot 2023-01-10 at 10 23 54](https://user-images.githubusercontent.com/1954891/211512556-fc034b4f-a35d-4eb4-b03f-ff272364c45b.png)


Added toString to ApduException to get detailed exception info:

```
E/yubico-authenticator( 8799): [oath.view.add_account_page] ERROR: Failed to add account
E/yubico-authenticator( 8799): [oath.view.add_account_page] ERROR(details): ApduException[SW: 0x6f00; dec: 28416]
```

instead of just `Instance of ApduException`