### PR TITLE
[Android] handle exceptions when creating connections

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/ConnectionHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/ConnectionHelper.kt
@@ -18,14 +18,16 @@ package com.yubico.authenticator.yubikit
 
 import com.yubico.yubikit.core.YubiKeyConnection
 import com.yubico.yubikit.core.YubiKeyDevice
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 suspend inline fun <reified C : YubiKeyConnection, T> YubiKeyDevice.withConnection(
     crossinline block: (C) -> T
 ): T = suspendCoroutine { continuation ->
     requestConnection(C::class.java) {
-        continuation.resumeWith(runCatching {
-            block(it.value)
-        })
+        runCatching { block(it.value) }
+            .onSuccess { result -> continuation.resume(result) }
+            .onFailure { exception -> continuation.resumeWithException(exception) }
     }
 }


### PR DESCRIPTION
When `requestConnection` has a problem, it is stored in `Result<C, IOException>` and will be thrown by accessing the `value` property (see [Result.java](https://github.com/Yubico/yubikit-android/blob/2.1.0/core/src/main/java/com/yubico/yubikit/core/util/Result.java#L51)). `runCatching` would swallow all these exceptions. 

This is fixed in this PR by resuming the continuation with the exceptions caught by `runCatching` and clients of `withConnection` can do the handling appropriately.


