### PR TITLE
[Android] add metadata to MainActivity alias to get correct theme 

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,6 +62,10 @@
             android:exported="true"
             android:targetActivity=".MainActivity">
 
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
+
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>


### PR DESCRIPTION
This fixes issue when the app got wrong theme when it was opened by plugging in a USB YubiKey.