### PR TITLE
Fix linux library path

### DIFF
--- a/helper/helper/qr.py
+++ b/helper/helper/qr.py
@@ -34,10 +34,19 @@ def _capture_screen():
     except ScreenShotError:
         # One common error is that mss doesn't work with Wayland
         if sys.platform.startswith("linux"):
-            # Try gnome-screenshot fallback
+            # Try gnome-screenshot fallback, with original library path
+            env = dict(os.environ)
+            lp = env.get("LD_LIBRARY_PATH_ORIG")
+            if lp is not None:
+                env["LD_LIBRARY_PATH"] = lp
+            else:
+                env.pop("LD_LIBRARY_PATH", None)
             fd, fname = tempfile.mkstemp(suffix=".png")
+
             try:
-                rc = subprocess.call(["gnome-screenshot", "-f", fname])  # nosec
+                rc = subprocess.call(
+                    ["gnome-screenshot", "-f", fname], env=env
+                )  # nosec
                 if rc == 0:
                     return Image.open(fname)
             except FileNotFoundError:


### PR DESCRIPTION
When grabbing screenshots using gnome-screenshot we need to reset the LD_LIBRARY_PATH.

Also adds support for using spectacle (on KDE).