### PR TITLE
[Android] Support only cameras with back facing lens for QR Scanning

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -19,6 +19,7 @@ package com.yubico.authenticator
 import android.content.*
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.content.pm.PackageManager
+import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
@@ -352,7 +353,10 @@ class MainActivity : FlutterFragmentActivity() {
                         val cameraService =
                             getSystemService(Context.CAMERA_SERVICE) as CameraManager
                         result.success(
-                            cameraService.cameraIdList.isNotEmpty()
+                            cameraService.cameraIdList.any {
+                                cameraService.getCameraCharacteristics(it)
+                                    .get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_BACK
+                            }
                         )
                     }
                     else -> Log.w(TAG, "Unknown app method: ${methodCall.method}")


### PR DESCRIPTION
This is a fix to avoid app crashes when running on Chromebooks. The QR Scanner functionality will be only enabled on devices which have a camera with back facing lens.