### PR TITLE
Fix disappearing accounts

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -166,6 +166,7 @@ class MainActivity : FlutterFragmentActivity() {
 
         appPreferences.unregisterListener(sharedPreferencesListener)
 
+        stopUsbDiscovery()
         stopNfcDiscovery()
         if (!appPreferences.openAppOnUsb) {
             enableAliasMainActivityComponent(false)


### PR DESCRIPTION
Fixes an issue when accounts disappeared while the user left and came back to the app with USB YubiKey connected.