### PR TITLE
Fix tests: oath tests open dialog

### DIFF
--- a/integration_test/oath_test_util.dart
+++ b/integration_test/oath_test_util.dart
@@ -112,6 +112,7 @@ extension OathFunctions on WidgetTester {
     }
 
     await shortWait();
+
     /// find an AccountView with issuer/name in the account list
     var matchingAccounts = find.descendant(
         of: findAccountList(),
@@ -146,8 +147,11 @@ extension OathFunctions on WidgetTester {
     expect(accountView, isNotNull);
 
     if (accountView != null) {
-      await ensureVisible(find.byWidget(accountView));
-      await tap(find.byWidget(accountView));
+      final accountFinder = find.byWidget(accountView);
+      await ensureVisible(accountFinder);
+      final codeButtonFinder = find.descendant(
+          of: accountFinder, matching: find.bySubtype<FilledButton>());
+      await tap(codeButtonFinder);
       await shortWait();
     }
   }

--- a/lib/oath/views/account_dialog.dart
+++ b/lib/oath/views/account_dialog.dart
@@ -156,7 +156,10 @@ class AccountDialog extends ConsumerWidget {
         if (helper.code == null &&
             (isDesktop || node.transport == Transport.usb)) {
           Timer.run(() {
-            Actions.invoke(context, const CalculateIntent());
+            // Only call if credential hasn't been deleted/renamed
+            if (ref.read(credentialsProvider)?.contains(credential) == true) {
+              Actions.invoke(context, const CalculateIntent());
+            }
           });
         }
         return FocusScope(


### PR DESCRIPTION
The "open code dialog" functionality in tests was broken due to changing the clickable area to open it.
This PR also fixes an exception that was thrown (but did not impact usage) after deleting or renaming an account with the account dialog open.