### PR TITLE
Ignore pending action on USB connect

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -45,6 +45,7 @@ import com.yubico.authenticator.oath.keystore.KeyStoreProvider
 import com.yubico.authenticator.oath.keystore.SharedPrefProvider
 import com.yubico.authenticator.yubikit.getDeviceInfo
 import com.yubico.authenticator.yubikit.withConnection
+import com.yubico.yubikit.android.transport.nfc.NfcYubiKeyDevice
 import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
 import com.yubico.yubikit.core.Transport
 import com.yubico.yubikit.core.YubiKeyDevice
@@ -244,7 +245,7 @@ class OathManager(
                 tryToUnlockOathSession(session)
 
                 val previousId = oathViewModel.sessionState.value?.deviceId
-                if (session.deviceId == previousId) {
+                if (session.deviceId == previousId && device is NfcYubiKeyDevice) {
                     // Run any pending action
                     pendingAction?.let { action ->
                         action.invoke(Result.success(session))


### PR DESCRIPTION
This fixes following issue: accounts which require Touch will not show dialog "Touch Required" dialog if using YubiKey over NFC and then connecting the same YubiKey over USB.

Because of different required behaviour for NFC and USB connections, connecting a key is now treated as a new session and any pending NFC action is disabled.