### PR TITLE
Correctly use DeviceInfo.getSupportedCapabilities

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/device/Info.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/device/Info.kt
@@ -18,9 +18,14 @@ package com.yubico.authenticator.device
 
 import com.yubico.yubikit.core.Transport
 import com.yubico.yubikit.management.DeviceInfo
-import com.yubico.yubikit.management.FormFactor
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+private fun DeviceInfo.capabilitiesFor(transport: Transport) : Int? =
+    when {
+        hasTransport(transport) -> getSupportedCapabilities(transport)
+        else -> null
+    }
 
 @Serializable
 data class Info(
@@ -59,8 +64,8 @@ data class Info(
         isNfc = isNfc,
         usbPid = usbPid,
         supportedCapabilities = Capabilities(
-            nfc = deviceInfo.getSupportedCapabilities(Transport.NFC),
-            usb = deviceInfo.getSupportedCapabilities(Transport.USB)
+            nfc = deviceInfo.capabilitiesFor(Transport.NFC),
+            usb = deviceInfo.capabilitiesFor(Transport.USB),
         )
     )
 }

--- a/android/app/src/test/java/com/yubico/authenticator/device/CapabilitiesTest.kt
+++ b/android/app/src/test/java/com/yubico/authenticator/device/CapabilitiesTest.kt
@@ -22,6 +22,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -46,8 +47,11 @@ class CapabilitiesTest {
         // test that keys are correct in serialized json
         assertTrue(serialize(Capabilities()).isEmpty())
         assertTrue(serialize(Capabilities(0)).containsKey(TAG_USB))
+        assertFalse(serialize(Capabilities(0)).containsKey(TAG_NFC))
         assertTrue(serialize(Capabilities(usb = 0)).containsKey(TAG_USB))
+        assertFalse(serialize(Capabilities(usb = 0)).containsKey(TAG_NFC))
         assertTrue(serialize(Capabilities(nfc = 0)).containsKey(TAG_NFC))
+        assertFalse(serialize(Capabilities(nfc = 0)).containsKey(TAG_USB))
         assertTrue(with(serialize(Capabilities(0, 0))) {
             containsKey(TAG_NFC) and containsKey(TAG_USB)
         })

--- a/android/app/src/test/java/com/yubico/authenticator/device/ConfigTest.kt
+++ b/android/app/src/test/java/com/yubico/authenticator/device/ConfigTest.kt
@@ -126,7 +126,7 @@ class ConfigTest {
 
     @Test
     fun `deviceFlags value`() {
-        val deviceConfig = Mockito.mock(DeviceConfig::class.java)
+        val deviceConfig = deviceConfigMock
 
         Mockito.`when`(deviceConfig.deviceFlags).thenReturn(null)
         assertEquals(Config(deviceConfig).deviceFlags, null)
@@ -137,7 +137,7 @@ class ConfigTest {
 
     @Test
     fun `challengeResponseTimeout value`() {
-        val deviceConfig = Mockito.mock(DeviceConfig::class.java)
+        val deviceConfig = deviceConfigMock
 
         Mockito.`when`(deviceConfig.challengeResponseTimeout).thenReturn(null)
         assertEquals(Config(deviceConfig).challengeResponseTimeout, null)
@@ -157,7 +157,7 @@ class ConfigTest {
 
     @Test
     fun `autoEjectTimeout value`() {
-        val deviceConfig = Mockito.mock(DeviceConfig::class.java)
+        val deviceConfig = deviceConfigMock
 
         Mockito.`when`(deviceConfig.autoEjectTimeout).thenReturn(null)
         assertEquals(Config(deviceConfig).autoEjectTimeout, null)

--- a/android/app/src/test/java/com/yubico/authenticator/device/DeviceConfigMock.kt
+++ b/android/app/src/test/java/com/yubico/authenticator/device/DeviceConfigMock.kt
@@ -1,0 +1,14 @@
+package com.yubico.authenticator.device
+
+import com.yubico.yubikit.core.Transport
+import com.yubico.yubikit.management.DeviceConfig
+import org.mockito.Mockito
+
+val deviceConfigMock: DeviceConfig
+    get() = Mockito.mock(DeviceConfig::class.java).also {
+        Mockito.`when`(it.autoEjectTimeout).thenReturn(null)
+        Mockito.`when`(it.challengeResponseTimeout).thenReturn(null)
+        Mockito.`when`(it.deviceFlags).thenReturn(null)
+        Mockito.`when`(it.getEnabledCapabilities(Transport.NFC)).thenReturn(null)
+        Mockito.`when`(it.getEnabledCapabilities(Transport.USB)).thenReturn(null)
+    }

--- a/android/app/src/test/java/com/yubico/authenticator/device/DeviceInfoMock.kt
+++ b/android/app/src/test/java/com/yubico/authenticator/device/DeviceInfoMock.kt
@@ -1,0 +1,23 @@
+package com.yubico.authenticator.device
+
+import com.yubico.yubikit.core.Transport
+import com.yubico.yubikit.core.Version
+import com.yubico.yubikit.management.DeviceInfo
+import com.yubico.yubikit.management.FormFactor
+import org.mockito.Mockito
+
+val deviceInfoMock: DeviceInfo
+    get() = Mockito.mock(DeviceInfo::class.java).also {
+        val deviceConfig = deviceConfigMock
+        Mockito.`when`(it.config).thenReturn(deviceConfig)
+        Mockito.`when`(it.version).thenReturn(Version(0, 0, 0))
+        Mockito.`when`(it.serialNumber).thenReturn(0)
+        Mockito.`when`(it.formFactor).thenReturn(FormFactor.USB_A_NANO)
+        Mockito.`when`(it.isLocked).thenReturn(false)
+        Mockito.`when`(it.isSky).thenReturn(false)
+        Mockito.`when`(it.isFips).thenReturn(false)
+        Mockito.`when`(it.hasTransport(Transport.NFC)).thenReturn(false)
+        Mockito.`when`(it.hasTransport(Transport.USB)).thenReturn(false)
+        Mockito.`when`(it.getSupportedCapabilities(Transport.USB)).thenReturn(0)
+        Mockito.`when`(it.getSupportedCapabilities(Transport.NFC)).thenReturn(0)
+    }


### PR DESCRIPTION
Fix to #978 

The original code was ignoring value of `DeviceInfo.hasTransport()` and this caused that created `Info()` objects had wrong value for supported capabilities. This caused the issue described in #978 when a YubiKey 5C is rendered as YubiKey 5C NFC in UI.

This PR also reviews and enhances unit-tests related to Capabilities and Info classes. 