### PR TITLE
Fix `Add account` flow when camera permissions are not granted

### DIFF
--- a/lib/android/qr_scanner/qr_scanner_provider.dart
+++ b/lib/android/qr_scanner/qr_scanner_provider.dart
@@ -31,6 +31,7 @@ class AndroidQrScanner implements QrScanner {
         (context) async => await Navigator.of(context).push(PageRouteBuilder(
               pageBuilder: (_, __, ___) =>
                   Theme(data: AppTheme.darkTheme, child: const QrScannerView()),
+              settings: const RouteSettings(name: 'android_qr_scanner_view'),
               transitionDuration: const Duration(seconds: 0),
               reverseTransitionDuration: const Duration(seconds: 0),
             )));

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -63,6 +63,7 @@ class MainPage extends ConsumerWidget {
               'user_interaction_prompt',
               'oath_add_account',
               'oath_icon_pack_dialog',
+              'android_qr_scanner_view',
             ].contains(route.settings.name);
       });
     });

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -57,6 +57,8 @@ Widget oathBuildActions(
         enabled: used != null && (capacity == null || capacity > used),
         onTap: used != null && (capacity == null || capacity > used)
             ? () async {
+                final credentials = ref.read(credentialsProvider);
+                final withContext = ref.read(withContextProvider);
                 Navigator.of(context).pop();
                 CredentialData? otpauth;
                 if (Platform.isAndroid) {
@@ -73,13 +75,13 @@ Widget oathBuildActions(
                     }
                   }
                 }
-                await ref.read(withContextProvider)((context) async {
+                await withContext((context) async {
                   await showBlurDialog(
                     context: context,
                     builder: (context) => OathAddAccountPage(
                       devicePath,
                       oathState,
-                      credentials: ref.watch(credentialsProvider),
+                      credentials: credentials,
                       credentialData: otpauth,
                     ),
                   );


### PR DESCRIPTION
This PR fixes bug which can be reproduced with following steps:

---
1. Install the Android app
2. in App Info → Permissions make sure that Camera Permission is not granted
3. Start the app, connect a YubiKey over USB
4. Tap Configure YubiKey, Add Account
5. System asks for Camera permissions: Don't!

What is expected: an activity showing information about Granting camera permissions/Adding account manually is shown
What really happens: the account list is shown

--- 

The issue is caused by the fact that checking/requesting Camera permissions will cause a pause/resume lifecycle events which will trigger a sequence of livedata events for deviceInfo, oath state and oath credential. The changes in the PR prevent these events to affect the Add account experience.