### PR TITLE
a11y: read issuer, name and code when using VO

### DIFF
--- a/lib/oath/views/account_view.dart
+++ b/lib/oath/views/account_view.dart
@@ -99,6 +99,24 @@ class _AccountViewState extends ConsumerState<AccountView> {
     }).toList();
   }
 
+  String? a11yCredentialLabel(String? issuer, String? name, OathCode? code) {
+    String? label = '';
+    String? tmpIssuer = issuer;
+    String? tmpName = name;
+    String? tmpCode = code?.value;
+    if (tmpIssuer != null) {
+      label += tmpIssuer;
+    }
+    if (tmpName != null) {
+      label += tmpName;
+    }
+    if (tmpCode != null) {
+      label += tmpCode;
+    }
+
+    return label;
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -169,76 +187,80 @@ class _AccountViewState extends ConsumerState<AccountView> {
             );
 
             return Shortcuts(
-              shortcuts: {
-                LogicalKeySet(LogicalKeyboardKey.enter): const OpenIntent(),
-                LogicalKeySet(LogicalKeyboardKey.space): const OpenIntent(),
-              },
-              child: ListTile(
-                focusNode: _focusNode,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(30),
-                ),
-                onTap: () {
-                  if (isDesktop) {
-                    final now = DateTime.now().millisecondsSinceEpoch;
-                    if (now - _lastTap < 500) {
-                      setState(() {
-                        _lastTap = 0;
-                      });
+                shortcuts: {
+                  LogicalKeySet(LogicalKeyboardKey.enter): const OpenIntent(),
+                  LogicalKeySet(LogicalKeyboardKey.space): const OpenIntent(),
+                },
+                child: Semantics(
+                  label: a11yCredentialLabel(
+                      credential.issuer, credential.name, helper.code),
+                  child: ListTile(
+                    focusNode: _focusNode,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                    onTap: () {
+                      if (isDesktop) {
+                        final now = DateTime.now().millisecondsSinceEpoch;
+                        if (now - _lastTap < 500) {
+                          setState(() {
+                            _lastTap = 0;
+                          });
+                          Actions.maybeInvoke(context, const CopyIntent());
+                        } else {
+                          _focusNode.requestFocus();
+                          setState(() {
+                            _lastTap = now;
+                          });
+                        }
+                      } else {
+                        Actions.maybeInvoke<OpenIntent>(
+                            context, const OpenIntent());
+                      }
+                    },
+                    onLongPress: () {
                       Actions.maybeInvoke(context, const CopyIntent());
-                    } else {
-                      _focusNode.requestFocus();
-                      setState(() {
-                        _lastTap = now;
-                      });
-                    }
-                  } else {
-                    Actions.maybeInvoke<OpenIntent>(
-                        context, const OpenIntent());
-                  }
-                },
-                onLongPress: () {
-                  Actions.maybeInvoke(context, const CopyIntent());
-                },
-                leading: showAvatar
-                    ? AccountIcon(
-                        issuer: credential.issuer, defaultWidget: circleAvatar)
-                    : null,
-                title: Text(
-                  helper.title,
-                  overflow: TextOverflow.fade,
-                  maxLines: 1,
-                  softWrap: false,
-                ),
-                subtitle: subtitle != null
-                    ? Text(
-                        subtitle,
-                        overflow: TextOverflow.fade,
-                        maxLines: 1,
-                        softWrap: false,
-                      )
-                    : null,
-                trailing: Focus(
-                  skipTraversal: true,
-                  descendantsAreTraversable: false,
-                  child: helper.code != null
-                      ? FilledButton.tonalIcon(
-                          icon: helper.buildCodeIcon(),
-                          label: helper.buildCodeLabel(),
-                          onPressed: () {
-                            Actions.maybeInvoke<OpenIntent>(
-                                context, const OpenIntent());
-                          },
-                        )
-                      : FilledButton.tonal(
-                          onPressed: () {
-                            Actions.maybeInvoke<OpenIntent>(
-                                context, const OpenIntent());
-                          },
-                          child: helper.buildCodeIcon()),
-                ),
-              ),
-            );
+                    },
+                    leading: showAvatar
+                        ? AccountIcon(
+                            issuer: credential.issuer,
+                            defaultWidget: circleAvatar)
+                        : null,
+                    title: Text(
+                      helper.title,
+                      overflow: TextOverflow.fade,
+                      maxLines: 1,
+                      softWrap: false,
+                    ),
+                    subtitle: subtitle != null
+                        ? Text(
+                            subtitle,
+                            overflow: TextOverflow.fade,
+                            maxLines: 1,
+                            softWrap: false,
+                          )
+                        : null,
+                    trailing: Focus(
+                      skipTraversal: true,
+                      descendantsAreTraversable: false,
+                      child: helper.code != null
+                          ? FilledButton.tonalIcon(
+                              icon: helper.buildCodeIcon(),
+                              label: helper.buildCodeLabel(),
+                              onPressed: () {
+                                Actions.maybeInvoke<OpenIntent>(
+                                    context, const OpenIntent());
+                              },
+                            )
+                          : FilledButton.tonal(
+                              onPressed: () {
+                                Actions.maybeInvoke<OpenIntent>(
+                                    context, const OpenIntent());
+                              },
+                              child: helper.buildCodeIcon()),
+                    ),
+                  ),
+                ));
           }),
         );
       },

--- a/lib/oath/views/account_view.dart
+++ b/lib/oath/views/account_view.dart
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,6 +39,10 @@ class AccountView extends ConsumerStatefulWidget {
 
   @override
   ConsumerState<ConsumerStatefulWidget> createState() => _AccountViewState();
+}
+
+String _a11yCredentialLabel(String? issuer, String name, String? code) {
+  return [issuer, name, code].whereNotNull().join(' ');
 }
 
 class _AccountViewState extends ConsumerState<AccountView> {
@@ -97,24 +102,6 @@ class _AccountViewState extends ConsumerState<AccountView> {
         trailing: e.trailing,
       );
     }).toList();
-  }
-
-  String? a11yCredentialLabel(String? issuer, String? name, OathCode? code) {
-    String? label = '';
-    String? tmpIssuer = issuer;
-    String? tmpName = name;
-    String? tmpCode = code?.value;
-    if (tmpIssuer != null) {
-      label += tmpIssuer;
-    }
-    if (tmpName != null) {
-      label += tmpName;
-    }
-    if (tmpCode != null) {
-      label += tmpCode;
-    }
-
-    return label;
   }
 
   @override
@@ -192,8 +179,8 @@ class _AccountViewState extends ConsumerState<AccountView> {
                   LogicalKeySet(LogicalKeyboardKey.space): const OpenIntent(),
                 },
                 child: Semantics(
-                  label: a11yCredentialLabel(
-                      credential.issuer, credential.name, helper.code),
+                  label: _a11yCredentialLabel(
+                      credential.issuer, credential.name, helper.code?.value),
                   child: ListTile(
                     focusNode: _focusNode,
                     shape: RoundedRectangleBorder(


### PR DESCRIPTION
This is a small PR that basically creates a semantics label for the credentials. The label will contain issuer, name, and the code. With both Narrator (Win) and VoiceOver (macOs) the credentials are read correctly with this fix.