### PR TITLE
Add auto fill hints to secret input fields

### DIFF
--- a/lib/fido/views/locked_page.dart
+++ b/lib/fido/views/locked_page.dart
@@ -145,6 +145,7 @@ class _PinEntryFormState extends ConsumerState<_PinEntryForm> {
             child: TextField(
               autofocus: true,
               obscureText: _isObscure,
+              autofillHints: const [AutofillHints.password],
               controller: _pinController,
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),

--- a/lib/fido/views/pin_dialog.dart
+++ b/lib/fido/views/pin_dialog.dart
@@ -75,6 +75,7 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
                 initialValue: _currentPin,
                 autofocus: true,
                 obscureText: true,
+                autofillHints: const [AutofillHints.password],
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),
                   labelText: l10n.s_current_pin,
@@ -96,6 +97,7 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
               initialValue: _newPin,
               autofocus: !hasPin,
               obscureText: true,
+              autofillHints: const [AutofillHints.password],
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: l10n.s_new_pin,
@@ -114,6 +116,7 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
             TextFormField(
               initialValue: _confirmPin,
               obscureText: true,
+              autofillHints: const [AutofillHints.password],
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: l10n.s_confirm_pin,

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -453,6 +453,7 @@ class _OathAddAccountPageState extends ConsumerState<OathAddAccountPage> {
                       key: keys.secretField,
                       controller: _secretController,
                       obscureText: _isObscure,
+                      autofillHints: isAndroid ? [] : const [AutofillHints.password],
                       inputFormatters: <TextInputFormatter>[
                         FilteringTextInputFormatter.allow(
                             _secretFormatterPattern)

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -453,6 +453,8 @@ class _OathAddAccountPageState extends ConsumerState<OathAddAccountPage> {
                       key: keys.secretField,
                       controller: _secretController,
                       obscureText: _isObscure,
+                      // avoid using autofill hints on Android otherwise Autofill service
+                      // would hint to use saved passwords for this field
                       autofillHints: isAndroid ? [] : const [AutofillHints.password],
                       inputFormatters: <TextInputFormatter>[
                         FilteringTextInputFormatter.allow(

--- a/lib/oath/views/manage_password_dialog.dart
+++ b/lib/oath/views/manage_password_dialog.dart
@@ -82,6 +82,7 @@ class _ManagePasswordDialogState extends ConsumerState<ManagePasswordDialog> {
               TextField(
                 autofocus: true,
                 obscureText: true,
+                autofillHints: const [AutofillHints.password],
                 key: keys.currentPasswordField,
                 decoration: InputDecoration(
                     border: const OutlineInputBorder(),
@@ -141,6 +142,7 @@ class _ManagePasswordDialogState extends ConsumerState<ManagePasswordDialog> {
               key: keys.newPasswordField,
               autofocus: !widget.state.hasKey,
               obscureText: true,
+              autofillHints: const [AutofillHints.newPassword],
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: l10n.s_new_password,
@@ -162,6 +164,7 @@ class _ManagePasswordDialogState extends ConsumerState<ManagePasswordDialog> {
             TextField(
               key: keys.confirmPasswordField,
               obscureText: true,
+              autofillHints: const [AutofillHints.newPassword],
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: l10n.s_confirm_password,

--- a/lib/oath/views/unlock_form.dart
+++ b/lib/oath/views/unlock_form.dart
@@ -77,6 +77,7 @@ class _UnlockFormState extends ConsumerState<UnlockForm> {
                 controller: _passwordController,
                 autofocus: true,
                 obscureText: _isObscure,
+                autofillHints: const [AutofillHints.password],
                 decoration: InputDecoration(
                   border: const OutlineInputBorder(),
                   labelText: l10n.s_password,


### PR DESCRIPTION
This is a workaround recommended in https://github.com/flutter/flutter/issues/122300.

Will be effective with future flutter release.

This change also partially enables use of an Autofill Service on Android - currently we can only fill in saved passwords. Saving/Updating new passwords does not work.