### PR TITLE
Fix onResume USB YubiKey detection in multi-window environments

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -233,7 +233,7 @@ class MainActivity : FlutterFragmentActivity() {
                     startUsbDiscovery()
                 }
             }
-        } else if (viewModel.connectedYubiKey.value == null) {
+        } else {
             // if any YubiKeys are connected, use them directly
             val deviceIterator = usbManager.deviceList.values.iterator()
             while (deviceIterator.hasNext()) {


### PR DESCRIPTION
We stop and start USB discovery in `onPause()`/`onResume()`, which effectively updates the value of `connectedYubiKey` in the view model. In multi-window environments, i.e. ChromeOS or Android split-view, the `onResume()` method does not see correct value of the variable: we are using `postValue()`, which is executed on main thread *after* `onResume()` has been called. This causes, that in the multi-window environments, `onResume()` does not restart the usb discovery and for example caused issue with adding accounts through `otpoath://` links.

This fix removes the condition where we check the value of `connectedYubiKey`. This is safe as in onResume we know that there is no `connectedYubiKey`, because it has been nulled in onPause.

The fix has been tested on Phones and Chromebooks.