### PR TITLE
Pin Python version including patch number

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      PYVER: 3.11
+      PYVER: '3.11.3'
       FLUTTER: '3.7.10'
     container:
       image: ubuntu:18.04
@@ -17,13 +17,27 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
+        export PYVER_MINOR=${PYVER%.*}
+        echo "PYVER_MINOR: $PYVER_MINOR"
         apt-get update
         apt-get install -qq software-properties-common libnotify-dev libayatana-appindicator3-dev patchelf
         add-apt-repository -y ppa:git-core/ppa
         add-apt-repository -y ppa:deadsnakes/ppa
-        apt-get install -qq git python$PYVER-dev python$PYVER-venv
+        apt-get install -qq git python$PYVER_MINOR-dev python$PYVER_MINOR-venv
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        ln -s `which python$PYVER` /usr/local/bin/python
+        ln -s `which python$PYVER_MINOR` /usr/local/bin/python
+        PYVER_TEMP=`/usr/local/bin/python --version`
+        export PYVERINST=${PYVER_TEMP#* }
+        echo "PYVERINST=$PYVERINST" >> $GITHUB_ENV
+        echo "Installed python version: $PYVERINST"
+
+    - name: Verify Python version
+      if: ${{ env.PYVERINST != env.PYVER }}
+      run: |
+        echo "Python version not compatible"
+        echo "Installed python version: $PYVERINST"
+        echo "Expected: $PYVER"
+        exit 1
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: macos-latest
     env:
-      PYVER: 3.11
+      PYVER: '3.11.3'
       MACOSX_DEPLOYMENT_TARGET: "10.15"
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
 
     runs-on: windows-latest
     env:
-      PYVER: 3.11
+      PYVER: '3.11.3'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Forces specific version of Python, including PATCH version to be installed on build system.

This PR also pins the python version to `3.11.3`.

In future, when we want to pin a specific version we will use `PYVER: 'MAJOR.MINOR.PATCH'` instead of `PYVER: MAJOR.MINOR` (for example `PYVER: '3.11.3'` instead of `PYVER: 3.11`)

Note: we cannot use `actions/setup-python@v4` on Linux, so we install exiting MAJOR.MINOR (for example 3.11) from deadsnakes ppa and verify it matches our required version. If the required version does not exists on deadsnakes, we cannot use that version and need to wait before updating - The log will contain following error:
```
Python version not compatible
Installed python version: 3.11.3
Expected: 3.11.0
Error: Process completed with exit code 1.
```

How to test:
- Run the app, Help & About -> Run Diagnostics.
- The python version in diagnostics should be correct (for example:

```
{
    “ykman”: “5.0.1”,
    “Python”: “3.11.3 (v3.11.3:f3909b8bc8, Apr  4 2023, 20:12:10) [Clang 13.0.0 (clang-1300.0.29.30)]“,
    “Platform”: “darwin”,
    “Arch”: “x86_64",
    “System date”: “2023-04-17",
    “Running as admin”: false
  },
```