### PR TITLE
Fix to Oath unlock when password is "remembered"

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -101,7 +101,7 @@ class OathManager(
     @TargetApi(Build.VERSION_CODES.M)
     private fun createKeyStoreProviderM(): KeyProvider = KeyStoreProvider()
 
-    private var unlockOnConnect = AtomicBoolean(true)
+    private val unlockOnConnect = AtomicBoolean(true)
     private var pendingAction: OathAction? = null
     private var refreshJob: Job? = null
     private var addToAny = false


### PR DESCRIPTION
This PR fixes following issue:

1. set password on Oath Session
2. restart app, connect YubiKey (USB or NFC) -> app asks for password
3. check "Remember password", type in password, tap "Unlock"
4. restart app, connect YubiKey (USB or NFC)

Expected: no password asked
What really happened: app asks for password

The issue was introduced int #1036 where we explicitly disabled automatic unlock for "unsetPassword". This introduced the described erroneous behaviour, because we moved the automatic unlock away from the `device.withConnection()` calls and the session was not unlocked for the "remembered" cases.

The fix is that we unlock conditionally directly after `device.withConnection()` (both USB and NFC). The condition is set through `useOathSession()` call so we can have this per feature (unsetPassword etc)

This PR also disables the automatic unlock for `setPassword` which is used also when changing passwords and had the same issue as `unsetPassword` (see #1036).

This was tested manually. 