### PR TITLE
Fix Android splash screen background

### DIFF
--- a/android/app/src/main/res/values-v27/styles.xml
+++ b/android/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LaunchTheme" parent="LaunchThemeBase">
+        <item name="android:windowLightNavigationBar">false</item>
+    </style>
+</resources>

--- a/android/app/src/main/res/values-v31/styles.xml
+++ b/android/app/src/main/res/values-v31/styles.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <style name="LaunchTheme" parent="LaunchThemeBase">
         <item name="android:windowLightNavigationBar">false</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
-    </style>
-
-    <style name="NormalTheme" parent="BaseTheme">
-        <item name="android:defaultFocusHighlightEnabled">false</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowSplashScreenBackground">@color/yubico_green</item>
     </style>
 </resources>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,14 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
 
-    <style name="LaunchThemeBase" parent="Theme.MaterialComponents.DayNight">
+    <style name="BaseTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="colorPrimary">@color/yubico_green</item>
         <item name="colorPrimaryVariant">@color/yubico_green</item>
         <item name="colorPrimaryDark">@color/yubico_green</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
+    </style>
+
+    <style name="LaunchThemeBase" parent="BaseTheme">
         <item name="android:windowBackground">@drawable/launch_background</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:windowTranslucentStatus">true</item>
-        <item name="android:windowLightNavigationBar" tools:targetApi="27">false</item>
         <item name="android:fitsSystemWindows">false</item>
     </style>
 
@@ -16,9 +19,8 @@
         <item name="android:navigationBarColor">@color/yubico_green</item>
     </style>
 
-    <style name="NormalTheme" parent="Theme.MaterialComponents.DayNight">
+    <style name="NormalTheme" parent="BaseTheme">
         <item name="android:windowBackground">?android:colorBackground</item>
-        <item name="android:windowDrawsSystemBarBackgrounds">false</item>
     </style>
 
     <style name="NdefActivityTheme" parent="NormalTheme">


### PR DESCRIPTION
This PR reviews the app styles and adds `android:windowSplashScreenBackground` which sets correct background color specifically on Android 14.