### PR TITLE
Add Ctrl-Q shortcut to close the app on Linux

### DIFF
--- a/lib/app/shortcuts.dart
+++ b/lib/app/shortcuts.dart
@@ -157,6 +157,10 @@ Widget registerGlobalShortcuts(
             const SingleActivator(LogicalKeyboardKey.comma, meta: true):
                 const SettingsIntent(),
           },
+          if (Platform.isLinux) ...{
+            const SingleActivator(LogicalKeyboardKey.keyQ, control: true):
+                const CloseIntent(),
+          },
         },
         child: child,
       ),


### PR DESCRIPTION
This adds one more way how to close the application on Linux: `Ctrl+Q`
That the app can also be closed by pressing `Alt+F4`

This is related to #1029 