### PR TITLE
Fix UI state after resetting OATH

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -382,15 +382,17 @@ class OathManager(
         }
     }
 
-    private suspend fun reset(): String {
+    private suspend fun reset(): String =
         useOathSession("Reset YubiKey") {
             // note, it is ok to reset locked session
             it.reset()
             keyManager.removeKey(it.deviceId)
-            oathViewModel.setSessionState(Session(it, false))
+            oathViewModel.resetOathSession(
+                Session(it, false),
+                calculateOathCodes(it)
+            )
+            NULL
         }
-        return NULL
-    }
 
     private suspend fun unlock(password: String, remember: Boolean): String =
         useOathSession("Unlocking") {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathViewModel.kt
@@ -28,6 +28,13 @@ class OathViewModel: ViewModel() {
     private val _sessionState = MutableLiveData<Session?>()
     val sessionState: LiveData<Session?> = _sessionState
 
+    // Sets session and credentials after performing OATH reset
+    // Note: we cannot use [setSessionState] because resetting OATH changes deviceId
+    fun resetOathSession(sessionState: Session, credentials: Map<Credential, Code?>) {
+        _sessionState.postValue(sessionState)
+        updateCredentials(credentials)
+    }
+
     fun setSessionState(sessionState: Session?) {
         val oldDeviceId = _sessionState.value?.deviceId
         _sessionState.postValue(sessionState)


### PR DESCRIPTION
Fixes issue, when after executing Configure YubiKey -> Reset OATH -> Reset, the app was showing a progressbar.

When an OATH session is reset, it gets a new value for `deviceId`. Our code tracks `deviceId` changes and [stops credential stream subscription](https://github.com/Yubico/yubioath-flutter/blob/6.2.0/lib/android/oath/state.dart#L173) when they happen, for example when tapping differnet NFC YubiKeys. 

In the case of OATH reset, we don't want to stop the subscription: the fix is to treat resetting OATH as a special case and ignore the `deviceId` difference.