### PR TITLE
Fix provider usage in systray

### DIFF
--- a/lib/desktop/systray.dart
+++ b/lib/desktop/systray.dart
@@ -41,7 +41,7 @@ final _favoriteAccounts =
     final deviceData = ref.watch(currentDeviceDataProvider).valueOrNull;
     if (deviceData != null) {
       final credentials =
-          ref.watch(desktopOathCredentialListProvider(deviceData.node.path));
+          ref.watch(credentialListProvider(deviceData.node.path));
       final favorites = ref.watch(favoritesProvider);
       final listed = credentials
               ?.map((e) => e.credential)


### PR DESCRIPTION
This fixes following issue:

- connect a YubiKey with accounts
- delete one account
- wait for "refresh"

Expected: accounts are refreshed, key LED diode will turn off after it computed the codes

What really happens: the key is accesses constantly, making the LED diode flash permanently.

The reason for this behaviour: `_favoriteAccounts` created a dependency on a provider override `desktopOathCredentialListProvider`. Doing this, riverpod created 2 instances of the `credentialListProvider` which were running in parallel, including account refresh functionality. More over, manipulating the credential lists, for example deleting an account, would affect only one instance, making the other instance containing old data (expired code) and causing the permanent refreshes.

Fix: using the base provider (`credentialListProvider`) fixes this as riverpod can track the object correctly, not creating a duplicate.