### PR TITLE
Management screen icon padding

### DIFF
--- a/lib/management/views/management_screen.dart
+++ b/lib/management/views/management_screen.dart
@@ -115,13 +115,9 @@ class _CapabilitiesForm extends StatelessWidget {
       children: [
         if (usbCapabilities != 0) ...[
           ListTile(
-            leading: const Padding(
-              padding: EdgeInsets.only(right: 8.0),
-              child: Icon(Icons.usb),
-            ),
+            leading: const Icon(Icons.usb),
             title: Text(l10n.s_usb),
             contentPadding: const EdgeInsets.only(bottom: 8),
-            horizontalTitleGap: 0,
           ),
           _CapabilityForm(
             type: _CapabilityType.usb,
@@ -139,13 +135,9 @@ class _CapabilitiesForm extends StatelessWidget {
               child: Divider(),
             ),
           ListTile(
-            leading: Padding(
-              padding: const EdgeInsets.only(right: 8.0),
-              child: nfcIcon,
-            ),
+            leading: nfcIcon,
             title: Text(l10n.s_nfc),
             contentPadding: const EdgeInsets.only(bottom: 8),
-            horizontalTitleGap: 0,
           ),
           _CapabilityForm(
             type: _CapabilityType.nfc,

--- a/lib/management/views/management_screen.dart
+++ b/lib/management/views/management_screen.dart
@@ -115,7 +115,10 @@ class _CapabilitiesForm extends StatelessWidget {
       children: [
         if (usbCapabilities != 0) ...[
           ListTile(
-            leading: const Icon(Icons.usb),
+            leading: const Padding(
+              padding: EdgeInsets.only(right: 8.0),
+              child: Icon(Icons.usb),
+            ),
             title: Text(l10n.s_usb),
             contentPadding: const EdgeInsets.only(bottom: 8),
             horizontalTitleGap: 0,
@@ -136,7 +139,10 @@ class _CapabilitiesForm extends StatelessWidget {
               child: Divider(),
             ),
           ListTile(
-            leading: nfcIcon,
+            leading: Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: nfcIcon,
+            ),
             title: Text(l10n.s_nfc),
             contentPadding: const EdgeInsets.only(bottom: 8),
             horizontalTitleGap: 0,


### PR DESCRIPTION
Updates gap between leading icon and title on Management screen.

Original:
![management_orig](https://github.com/Yubico/yubioath-flutter/assets/1954891/2bee6a73-3aee-411f-8f85-5cfa11b207da)

Fix:
![image](https://github.com/Yubico/yubioath-flutter/assets/1954891/f9536e19-998c-452e-847b-756961bed71c)

