### PR TITLE
Android bite-size updates

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -170,18 +170,17 @@ class MainActivity : FlutterFragmentActivity() {
     @SuppressLint("WrongConstant")
     override fun onStart() {
         super.onStart()
-        val receiverFlags = ContextCompat.RECEIVER_NOT_EXPORTED
         ContextCompat.registerReceiver(
             this,
             qrScannerCameraClosedBR,
             QRScannerCameraClosedBR.intentFilter,
-            receiverFlags
+            ContextCompat.RECEIVER_NOT_EXPORTED
         )
         ContextCompat.registerReceiver(
             this,
             nfcAdapterStateChangeBR,
             NfcAdapterStateChangedBR.intentFilter,
-            receiverFlags
+            ContextCompat.RECEIVER_EXPORTED
         )
     }
 
@@ -351,6 +350,7 @@ class MainActivity : FlutterFragmentActivity() {
         }
 
         override fun onReceive(context: Context?, intent: Intent?) {
+            Log.d(TAG, "Restarting nfc discovery after camera was closed.")
             (context as? MainActivity)?.startNfcDiscovery()
         }
     }

--- a/lib/oath/icon_provider/icon_cache.dart
+++ b/lib/oath/icon_provider/icon_cache.dart
@@ -30,15 +30,15 @@ class IconCacheFs {
     final file = await _getFile(fileName);
     final exists = await file.exists();
     if (exists) {
-      _log.debug('File $fileName exists in cache');
+      _log.traffic('File $fileName exists in cache');
     } else {
-      _log.debug('File $fileName does not exist in cache');
+      _log.traffic('File $fileName does not exist in cache');
     }
     return exists ? (await file.readAsBytes()).buffer.asByteData() : null;
   }
 
   Future<void> write(String fileName, Uint8List data) async {
-    _log.debug('Writing $fileName to cache');
+    _log.traffic('Writing $fileName to cache');
     final file = await _getFile(fileName);
     if (!await file.exists()) {
       await file.create(recursive: true, exclusive: false);
@@ -52,7 +52,7 @@ class IconCacheFs {
       try {
         await cacheDirectory.delete(recursive: true);
       } catch (e) {
-        _log.error(
+        _log.traffic(
             'Failed to delete cache directory ${cacheDirectory.path}', e);
       }
     }

--- a/lib/oath/icon_provider/icon_file_loader.dart
+++ b/lib/oath/icon_provider/icon_file_loader.dart
@@ -45,7 +45,7 @@ class IconFileLoader extends BytesLoader {
     // check if the requested file exists in memory cache
     var cachedData = memCache.read(cacheFileName);
     if (cachedData != null) {
-      _log.debug('Returning $cacheFileName image data from memory cache');
+      _log.traffic('Returning $cacheFileName image data from memory cache');
       return cachedData;
     }
 
@@ -55,7 +55,7 @@ class IconFileLoader extends BytesLoader {
     cachedData = await fsCache.read(cacheFileName);
     if (cachedData != null) {
       memCache.write(cacheFileName, cachedData.buffer.asUint8List());
-      _log.debug('Returning $cacheFileName image data from fs cache');
+      _log.traffic('Returning $cacheFileName image data from fs cache');
       return cachedData;
     }
 

--- a/lib/oath/icon_provider/icon_pack_manager.dart
+++ b/lib/oath/icon_provider/icon_pack_manager.dart
@@ -48,10 +48,10 @@ class IconPackManager extends StateNotifier<AsyncValue<IconPack?>> {
     final packFile =
         File(join(packDirectory.path, getLocalIconFileName('pack.json')));
 
-    _log.debug('Looking for file: ${packFile.path}');
+    _log.traffic('Looking for file: ${packFile.path}');
 
     if (!await packFile.exists()) {
-      _log.debug('Failed to find icons pack ${packFile.path}');
+      _log.traffic('Failed to find icons pack ${packFile.path}');
       state = AsyncValue.error(
           'Failed to find icon pack ${packFile.path}', StackTrace.current);
       return;
@@ -76,10 +76,10 @@ class IconPackManager extends StateNotifier<AsyncValue<IconPack?>> {
           directory: packDirectory,
           icons: icons));
 
-      _log.debug(
+      _log.traffic(
           'Parsed ${state.value?.name} with ${state.value?.icons.length} icons');
     } catch (e) {
-      _log.debug('Failed to parse icons pack ${packFile.path}');
+      _log.traffic('Failed to parse icons pack ${packFile.path}');
       state = AsyncValue.error(
           'Failed to parse icon pack ${packFile.path}', StackTrace.current);
       return;
@@ -123,7 +123,7 @@ class IconPackManager extends StateNotifier<AsyncValue<IconPack?>> {
         final data = file.content as List<int>;
         final extractedFile =
             File(join(unpackDirectory.path, getLocalIconFileName(filename)));
-        _log.debug('Writing file: ${extractedFile.path} (size: ${file.size})');
+        _log.traffic('Writing file: ${extractedFile.path} (size: ${file.size})');
         final createdFile = await extractedFile.create(recursive: true);
         await createdFile.writeAsBytes(data);
       }

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import '../../desktop/models.dart';
 import '../../management/models.dart';
 import '../../widgets/choice_filter_chip.dart';
 import '../../widgets/file_drop_target.dart';
+import '../../widgets/focus_utils.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../../widgets/utf8_utils.dart';
 import '../keys.dart' as keys;
@@ -175,6 +176,9 @@ class _OathAddAccountPageState extends ConsumerState<OathAddAccountPage> {
       {DevicePath? devicePath, required Uri credUri}) async {
     final l10n = AppLocalizations.of(context)!;
     try {
+
+      FocusUtils.unfocus(context);
+
       if (devicePath == null) {
         assert(isAndroid, 'devicePath is only optional for Android');
         await ref

--- a/lib/oath/views/manage_password_dialog.dart
+++ b/lib/oath/views/manage_password_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
+import '../../widgets/focus_utils.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../models.dart';
 import '../state.dart';
@@ -42,6 +43,9 @@ class _ManagePasswordDialogState extends ConsumerState<ManagePasswordDialog> {
   bool _currentIsWrong = false;
 
   _submit() async {
+
+    FocusUtils.unfocus(context);
+
     final result = await ref
         .read(oathStateProvider(widget.path).notifier)
         .setPassword(_currentPassword, _newPassword);

--- a/lib/oath/views/rename_account_dialog.dart
+++ b/lib/oath/views/rename_account_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../exception/cancellation_exception.dart';
 import '../../desktop/models.dart';
+import '../../widgets/focus_utils.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../../widgets/utf8_utils.dart';
 import '../models.dart';
@@ -60,6 +61,9 @@ class _RenameAccountDialogState extends ConsumerState<RenameAccountDialog> {
   void _submit() async {
     final l10n = AppLocalizations.of(context)!;
     try {
+
+      FocusUtils.unfocus(context);
+
       // Rename credentials
       final renamed = await ref
           .read(credentialListProvider(widget.device.path).notifier)

--- a/lib/widgets/focus_utils.dart
+++ b/lib/widgets/focus_utils.dart
@@ -1,0 +1,18 @@
+
+import 'package:flutter/cupertino.dart';
+import 'package:logging/logging.dart';
+
+import '../app/logging.dart';
+
+final _log = Logger('FocusUtils');
+
+class FocusUtils {
+  static void unfocus(BuildContext context) {
+    FocusScopeNode currentFocus = FocusScope.of(context);
+
+    if (!currentFocus.hasPrimaryFocus) {
+      _log.debug('Removing focus...');
+      currentFocus.unfocus();
+    }
+  }
+}


### PR DESCRIPTION
Contains following fixes:
- use correct flags for nfs adapter status change. This receiver must be exported to be able to receive system updates.
- in pages where we write text I unfocus text fields on submit. This fixes user experience on Android, when the virtual keyboard is shown again for a split second.
- changed log level of icon pack log messages from debug to traffic. They were too many.