### PR TITLE
Add arb file reformatter

### DIFF
--- a/.github/workflows/check-strings.yml
+++ b/.github/workflows/check-strings.yml
@@ -15,6 +15,10 @@ jobs:
     - name: Ensure main locale is correct
       run: python check_strings.py lib/l10n/app_en.arb
 
+    - name: Reformat arb files
+      run: |
+        find lib/l10n/ -name "*.arb" -print0 | xargs -r -n 1 -0 ./reformat_strings.py
+
     - name: Check remaining locales
       run: |
         find lib/l10n/ -name "app_en.arb" -prune -o -name "*.arb" -print0 | xargs -r -n 1 -0 ./check_strings.py >> $GITHUB_STEP_SUMMARY || echo "::warning::Problems in locales"

--- a/.github/workflows/check-strings.yml
+++ b/.github/workflows/check-strings.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Reformat arb files
       run: |
-        find lib/l10n/ -name "*.arb" -print0 | xargs -r -n 1 -0 ./reformat_strings.py
+        find lib/l10n/ -name "app_en.arb" -prune -o -name "*.arb" -print0 | xargs -r -n 1 -0 ./reformat_strings.py
 
     - name: Check remaining locales
       run: |

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "de",
-
     "@_readme": {
         "notes": [
             "Alle Zeichenketten beginnen mit einem Großbuchstaben.",
@@ -8,438 +7,396 @@
             "Führen Sie check_strings.py für die .arb Datei aus, um Probleme zu finden. Passen Sie @_lint_rules nach Sprache an wie nötig."
         ],
         "prefixes": {
-            "s_": "Ein einzelnes Wort oder wenige Wörter. Sollte kurz genug sein, um auf einer Schaltfläche oder einer Überschrift angezeigt zu werden.",
             "l_": "Eine einzelne Zeile, kann umbgebrochen werden. Sollte nicht mehr als einen Satz umfassen und nicht mit einem Punkt enden.",
             "p_": "Ein oder mehrere ganze Sätze mit allen Satzzeichen.",
-            "q_": "Eine Frage, die mit einem Fragezeichen endet."
+            "q_": "Eine Frage, die mit einem Fragezeichen endet.",
+            "s_": "Ein einzelnes Wort oder wenige Wörter. Sollte kurz genug sein, um auf einer Schaltfläche oder einer Überschrift angezeigt zu werden."
         }
     },
-
     "@_lint_rules": {
-        "s_max_words": 4,
-        "s_max_length": 32
+        "s_max_length": 32,
+        "s_max_words": 4
     },
-
     "app_name": "Yubico Authenticator",
-
-    "s_save": "Speichern",
-    "s_cancel": "Abbrechen",
-    "s_close": "Schließen",
-    "s_delete": "Löschen",
-    "s_quit": "Beenden",
-    "s_unlock": "Entsperren",
-    "s_calculate": "Berechnen",
-    "s_label": "Beschriftung",
-    "s_name": "Name",
-    "s_usb": "USB",
-    "s_nfc": "NFC",
-    "s_show_window": "Fenster anzeigen",
-    "s_hide_window": "Fenster verstecken",
-    "q_rename_target": "{label} umbenennen?",
-    "@q_rename_target" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-
-    "s_about": "Über",
-    "s_appearance": "Aussehen",
-    "s_authenticator": "Authenticator",
-    "s_manage": "Verwalten",
-    "s_setup": "Einrichten",
-    "s_settings": "Einstellungen",
-    "s_webauthn": "WebAuthn",
-    "s_help_and_about": "Hilfe und Über",
-    "s_help_and_feedback": "Hilfe und Feedback",
-    "s_send_feedback": "Senden Sie uns Feedback",
-    "s_i_need_help": "Ich brauche Hilfe",
-    "s_troubleshooting": "Problembehebung",
-    "s_terms_of_use": "Nutzungsbedingungen",
-    "s_privacy_policy": "Datenschutzerklärung",
-    "s_open_src_licenses": "Open Source-Lizenzen",
-    "s_configure_yk": "YubiKey konfigurieren",
-    "s_please_wait": "Bitte warten\u2026",
-    "s_secret_key": "Geheimer Schlüssel",
-    "s_invalid_length": "Ungültige Länge",
-    "s_require_touch": "Berührung ist erforderlich",
-    "q_have_account_info": "Haben Sie Konto-Informationen?",
-    "s_run_diagnostics": "Diagnose ausführen",
-    "s_log_level": "Log-Level: {level}",
-    "@s_log_level": {
-        "placeholders": {
-            "level": {}
-        }
-    },
-    "s_character_count": "Anzahl Zeichen",
-    "s_learn_more": "Mehr\u00a0erfahren",
-
-    "@_language": {},
-    "s_language": "Sprache",
-    "l_enable_community_translations": "Übersetzungen der Gemeinschaft aktivieren",
-    "p_community_translations_desc": "Diese Übersetzungen werden von der Gemeinschaft erstellt und gewartet. Sie könnten Fehler enthalten oder unvollständig sein.",
-
-    "@_theme": {},
-    "s_app_theme": "App Theme",
-    "s_choose_app_theme": "App Theme auswählen",
-    "s_system_default": "Standard des Systems",
-    "s_light_mode": "Heller Modus",
-    "s_dark_mode": "Dunkler Modus",
-
-    "@_yubikey_selection": {},
-    "s_yk_information": "YubiKey Information",
-    "s_select_yk": "YubiKey auswählen",
-    "s_select_to_scan": "Zum Scannen auswählen",
-    "s_hide_device": "Gerät verstecken",
-    "s_show_hidden_devices": "Versteckte Geräte anzeigen",
-    "s_sn_serial": "S/N: {serial}",
-    "@s_sn_serial" : {
-        "placeholders": {
-            "serial": {}
-        }
-    },
-    "s_fw_version": "F/W: {version}",
-    "@s_fw_version" : {
-        "placeholders": {
-            "version": {}
-        }
-    },
-
-    "@_yubikey_interactions": {},
-    "l_insert_yk": "YubiKey anschließen",
-    "l_insert_or_tap_yk": "YubiKey anschließen oder dagegenhalten",
-    "l_unplug_yk": "Entfernen Sie Ihren YubiKey",
-    "l_reinsert_yk": "Schließen Sie Ihren YubiKey wieder an",
-    "l_place_on_nfc_reader": "Halten Sie Ihren YubiKey zum NFC-Leser",
-    "l_replace_yk_on_reader": "Halten Sie Ihren YubiKey wieder zum Leser",
-    "l_remove_yk_from_reader": "Entfernen Sie Ihren YubiKey vom NFC-Leser",
-    "p_try_reinsert_yk": "Versuchen Sie Ihren YubiKey zu entfernen und wieder anzuschließen.",
-    "s_touch_required": "Berührung erforderlich",
-    "l_touch_button_now": "Berühren Sie jetzt die Schaltfläche auf Ihrem YubiKey",
-    "l_keep_touching_yk": "Berühren Sie Ihren YubiKey wiederholt\u2026",
-
-    "@_app_configuration": {},
-    "s_toggle_applications": "Anwendungen umschalten",
-    "l_min_one_interface": "Mindestens ein Interface muss aktiviert sein",
-    "s_reconfiguring_yk": "YubiKey wird neu konfiguriert\u2026",
-    "s_config_updated": "Konfiguration aktualisiert",
-    "l_config_updated_reinsert": "Konfiguration aktualisiert, entfernen Sie Ihren YubiKey und schließen ihn wieder an",
-    "s_app_not_supported": "Anwendung nicht unterstützt",
-    "l_app_not_supported_on_yk": "Der verwendete YubiKey unterstützt die Anwendung '{app}' nicht",
-    "@l_app_not_supported_on_yk" : {
-        "placeholders": {
-            "app": {}
-        }
-    },
-    "l_app_not_supported_desc": "Diese Anwendung wird nicht unterstützt",
-    "s_app_disabled": "Anwendung deaktiviert",
-    "l_app_disabled_desc": "Aktivieren Sie die Anwendung '{app}' auf Ihrem YubiKey für Zugriff",
-    "@l_app_disabled_desc" : {
-        "placeholders": {
-            "app": {}
-        }
-    },
-    "s_fido_disabled": "FIDO2 deaktiviert",
-    "l_webauthn_req_fido2": "WebAuthn erfordert, dass die FIDO2 Anwendung auf Ihrem YubiKey aktiviert ist",
-
-    "@_connectivity_issues": {},
-    "l_helper_not_responding": "Der Helper-Prozess antwortet nicht",
-    "l_yk_no_access": "Auf diesen YubiKey kann nicht zugegriffen werden",
-    "s_yk_inaccessible": "Gerät nicht zugänglich",
-    "l_open_connection_failed": "Konnte keine Verbindung öffnen",
-    "l_ccid_connection_failed": "Konnte keine Smartcard-Verbindung öffnen",
-    "p_ccid_service_unavailable": "Stellen Sie sicher, dass Ihr Smartcard-Service funktioniert.",
-    "p_pcscd_unavailable": "Stellen Sie sicher, dass pcscd installiert ist und ausgeführt wird.",
-    "l_no_yk_present": "Kein YubiKey vorhanden",
-    "s_unknown_type": "Unbekannter Typ",
-    "s_unknown_device": "Unbekanntes Gerät",
-    "s_unsupported_yk": "Nicht unterstützter YubiKey",
-    "s_yk_not_recognized": "Geräte nicht erkannt",
-
-    "@_general_errors": {},
-    "l_error_occured": "Es ist ein Fehler aufgetreten",
-    "s_application_error": "Anwendungs-Fehler",
-    "l_import_error": "Import-Fehler",
-    "l_file_not_found": "Datei nicht gefunden",
-    "l_file_too_big": "Datei ist zu groß",
-    "l_filesystem_error": "Fehler beim Dateisystem-Zugriff",
-
-    "@_pins": {},
-    "s_pin": "PIN",
-    "s_set_pin": "PIN setzen",
-    "s_change_pin": "PIN ändern",
-    "s_current_pin": "Derzeitige PIN",
-    "s_new_pin": "Neue PIN",
-    "s_confirm_pin": "PIN bestätigen",
-    "l_new_pin_len": "Neue PIN muss mindestens {length} Zeichen lang sein",
-    "@l_new_pin_len" : {
-        "placeholders": {
-            "length": {}
-        }
-    },
-    "s_pin_set": "PIN gesetzt",
-    "l_set_pin_failed": "PIN konnte nicht gesetzt werden: {message}",
-    "@l_set_pin_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_wrong_pin_attempts_remaining": "Falsche PIN, {retries} Versuch(e) verbleibend",
-    "@l_wrong_pin_attempts_remaining" : {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "s_fido_pin_protection": "FIDO PIN Schutz",
-    "l_fido_pin_protection_optional": "Optionaler FIDO PIN Schutz",
-    "l_enter_fido2_pin": "Geben Sie die FIDO2 PIN für Ihren YubiKey ein",
-    "l_optionally_set_a_pin": "Setzen Sie optional eine PIN, um den Zugriff auf Ihren YubiKey zu schützen\nAls Sicherheitsschlüssel auf Webseiten registrieren",
-    "l_pin_blocked_reset": "PIN ist blockiert; setzen Sie die FIDO Anwendung auf Werkseinstellung zurück",
-    "l_set_pin_first": "Zuerst ist eine PIN erforderlich",
-    "l_unlock_pin_first": "Zuerst mit PIN entsperren",
-    "l_pin_soft_locked": "PIN wurde blockiert bis der YubiKey entfernt und wieder angeschlossen wird",
-    "p_enter_current_pin_or_reset": "Geben Sie Ihre aktuelle PIN ein. Wenn Sie die PIN nicht wissen, müssen Sie den YubiKey zurücksetzen.",
-    "p_enter_new_fido2_pin": "Geben Sie Ihre neue PIN ein. Eine PIN muss mindestens {length} Zeichen lang sein und kann Buchstaben, Ziffern und spezielle Zeichen enthalten.",
-    "@p_enter_new_fido2_pin" : {
-        "placeholders": {
-            "length": {}
-        }
-    },
-
-    "@_passwords": {},
-    "s_password": "Passwort",
-    "s_manage_password": "Passwort verwalten",
-    "s_set_password": "Passwort setzen",
-    "s_password_set": "Passwort gesetzt",
-    "l_optional_password_protection": "Optionaler Passwortschutz",
-    "s_new_password": "Neues Passwort",
-    "s_current_password": "Aktuelles Passwort",
-    "s_confirm_password": "Passwort bestätigen",
-    "s_wrong_password": "Falsches Passwort",
-    "s_remove_password": "Passwort entfernen",
-    "s_password_removed": "Passwort entfernt",
-    "s_remember_password": "Passwort speichern",
-    "s_clear_saved_password": "Gespeichertes Passwort entfernen",
-    "s_password_forgotten": "Passwort vergessen",
-    "l_keystore_unavailable": "Passwortspeicher des Betriebssystems nicht verfügbar",
-    "l_remember_pw_failed": "Konnte Passwort nicht speichern",
-    "l_unlock_first": "Zuerst mit Passwort entsperren",
-    "l_enter_oath_pw": "Das OATH-Passwort für Ihren YubiKey eingeben",
-    "p_enter_current_password_or_reset": "Geben Sie Ihr aktuelles Passwort ein. Wenn Sie Ihr Passwort nicht wissen, müssen Sie den YubiKey zurücksetzen.",
-    "p_enter_new_password": "Geben Sie Ihr neues Passwort ein. Ein Passwort kann Buchstaben, Ziffern und spezielle Zeichen enthalten.",
-
-    "@_oath_accounts": {},
     "l_account": "Konto: {label}",
-    "@l_account" : {
+    "@l_account": {
         "placeholders": {
             "label": {}
         }
     },
-    "s_accounts": "Konten",
-    "s_no_accounts": "Keine Konten",
-    "s_add_account": "Konto hinzufügen",
-    "s_account_added": "Konto hinzugefügt",
     "l_account_add_failed": "Fehler beim Hinzufügen des Kontos: {message}",
-    "@l_account_add_failed" : {
+    "@l_account_add_failed": {
         "placeholders": {
             "message": {}
         }
     },
     "l_account_name_required": "Ihr Konto muss einen Namen haben",
-    "l_name_already_exists": "Für diesen Aussteller existiert dieser Name bereits",
-    "l_invalid_character_issuer": "Ungültiges Zeichen: ':' ist im Aussteller nicht erlaubt",
-    "s_pinned": "Angepinnt",
-    "s_pin_account": "Konto anpinnen",
-    "s_unpin_account": "Konto nicht mehr anpinnen",
-    "s_no_pinned_accounts": "Keine angepinnten Konten",
-    "s_rename_account": "Konto umbenennen",
-    "s_account_renamed": "Konto umbenannt",
-    "p_rename_will_change_account_displayed": "Das ändert die Anzeige dieses Kontos in der Liste.",
-    "s_delete_account": "Konto löschen",
-    "s_account_deleted": "Konto gelöscht",
-    "p_warning_delete_account": "Vorsicht! Das löscht das Konto von Ihrem YubiKey.",
-    "p_warning_disable_credential": "Sie werden keine OTPs für dieses Konto mehr erstellen können. Deaktivieren Sie diese Anmeldeinformation zuerst auf der Webseite, um nicht aus dem Konto ausgesperrt zu werden.",
-    "s_account_name": "Kontoname",
-    "s_search_accounts": "Konten durchsuchen",
     "l_accounts_used": "{used} von {capacity} Konten verwendet",
-    "@l_accounts_used" : {
+    "@l_accounts_used": {
         "placeholders": {
-            "used": {},
-            "capacity": {}
-        }
-    },
-    "s_num_digits": "{num} Ziffern",
-    "@s_num_digits" : {
-        "placeholders": {
-            "num": {}
-        }
-    },
-    "s_num_sec": "{num} sek",
-    "@s_num_sec" : {
-        "placeholders": {
-            "num": {}
-        }
-    },
-    "s_issuer_optional": "Aussteller (optional)",
-    "s_counter_based": "Zähler-basiert",
-    "s_time_based": "Zeit-basiert",
-
-    "@_fido_credentials": {},
-    "l_credential": "Anmeldeinformation: {label}",
-    "@l_credential" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "s_credentials": "Anmeldeinformationen",
-    "l_ready_to_use": "Bereit zur Verwendung",
-    "l_register_sk_on_websites": "Als Sicherheitsschlüssel auf Webseiten registrieren",
-    "l_no_discoverable_accounts": "Keine erkennbaren Konten",
-    "s_delete_credential": "Anmeldeinformation löschen",
-    "s_credential_deleted": "Anmeldeinformation gelöscht",
-    "p_warning_delete_credential": "Das löscht die Anmeldeinformation von Ihrem YubiKey.",
-
-    "@_fingerprints": {},
-    "l_fingerprint": "Fingerabdruck: {label}",
-    "@l_fingerprint" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "s_fingerprints": "Fingerabdrücke",
-    "l_fingerprint_captured": "Fingerabdruck erfolgreich aufgenommen!",
-    "s_fingerprint_added": "Fingerabdruck hinzugefügt",
-    "l_setting_name_failed": "Fehler beim Setzen des Namens: {message}",
-    "@l_setting_name_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "s_add_fingerprint": "Fingerabdruck hinzufügen",
-    "l_fp_step_1_capture": "Schritt 1/2: Fingerabdruck aufnehmen",
-    "l_fp_step_2_name": "Schritt 2/2: Fingerabdruck benennen",
-    "s_delete_fingerprint": "Fingerabdruck löschen",
-    "s_fingerprint_deleted": "Fingerabdruck gelöscht",
-    "p_warning_delete_fingerprint": "Das löscht den Fingerabdruck von Ihrem YubiKey.",
-    "s_no_fingerprints": "Keine Fingerabdrücke",
-    "l_set_pin_fingerprints": "Setzen Sie eine PIN um Fingerabdrücke zu registrieren",
-    "l_no_fps_added": "Es wurden keine Fingerabdrücke hinzugefügt",
-    "s_rename_fp": "Fingerabdruck umbenennen",
-    "s_fingerprint_renamed": "Fingerabdruck umbenannt",
-    "l_rename_fp_failed": "Fehler beim Umbenennen: {message}",
-    "@l_rename_fp_failed" : {
-        "placeholders": {
-            "message": {}
+            "capacity": {},
+            "used": {}
         }
     },
     "l_add_one_or_more_fps": "Fügen Sie einen oder bis zu fünf Fingerabdrücke hinzu",
+    "l_app_disabled_desc": "Aktivieren Sie die Anwendung '{app}' auf Ihrem YubiKey für Zugriff",
+    "@l_app_disabled_desc": {
+        "placeholders": {
+            "app": {}
+        }
+    },
+    "l_app_not_supported_desc": "Diese Anwendung wird nicht unterstützt",
+    "l_app_not_supported_on_yk": "Der verwendete YubiKey unterstützt die Anwendung '{app}' nicht",
+    "@l_app_not_supported_on_yk": {
+        "placeholders": {
+            "app": {}
+        }
+    },
+    "l_bypass_touch_requirement": "Notwendigkeit zur Berührung umgehen",
+    "l_bypass_touch_requirement_off": "Konten, die Berührung erfordern, benötigen eine zusätzliche NFC-Berührung",
+    "l_bypass_touch_requirement_on": "Konten, die Berührung erfordern, werden automatisch über NFC angezeigt",
+    "l_ccid_connection_failed": "Konnte keine Smartcard-Verbindung öffnen",
+    "l_code_copied_clipboard": "Code in die Zwischenablage kopiert",
+    "l_config_updated_reinsert": "Konfiguration aktualisiert, entfernen Sie Ihren YubiKey und schließen ihn wieder an",
+    "l_copy_otp_clipboard": "OTP in Zwischenablage kopieren",
+    "l_copy_to_clipboard": "In die Zwischenablage kopieren",
+    "l_credential": "Anmeldeinformation: {label}",
+    "@l_credential": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "l_diagnostics_copied": "Diagnosedaten in die Zwischenablage kopiert",
+    "l_elevating_permissions": "Erhöhe Berechtigungen…",
+    "l_enable_community_translations": "Übersetzungen der Gemeinschaft aktivieren",
+    "l_enter_fido2_pin": "Geben Sie die FIDO2 PIN für Ihren YubiKey ein",
+    "l_enter_oath_pw": "Das OATH-Passwort für Ihren YubiKey eingeben",
+    "l_error_occured": "Es ist ein Fehler aufgetreten",
+    "l_factory_reset_this_app": "Anwendung auf Werkseinstellung zurücksetzen",
+    "l_fido_app_reset": "FIDO Anwendung zurückgesetzt",
+    "l_fido_pin_protection_optional": "Optionaler FIDO PIN Schutz",
+    "l_file_not_found": "Datei nicht gefunden",
+    "l_file_too_big": "Datei ist zu groß",
+    "l_filesystem_error": "Fehler beim Dateisystem-Zugriff",
+    "l_fingerprint": "Fingerabdruck: {label}",
+    "@l_fingerprint": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "l_fingerprint_captured": "Fingerabdruck erfolgreich aufgenommen!",
     "l_fingerprints_used": "{used}/5 Fingerabdrücke registriert",
     "@l_fingerprints_used": {
         "placeholders": {
             "used": {}
         }
     },
-    "p_press_fingerprint_begin": "Drücken Sie Ihren Finger gegen den YubiKey um zu beginnen.",
-    "p_will_change_label_fp": "Das ändert die Beschriftung des Fingerabdrucks.",
-
-    "@_permissions": {},
-    "s_enable_nfc": "NFC aktivieren",
-    "s_permission_denied": "Zugriff verweigert",
-    "l_elevating_permissions": "Erhöhe Berechtigungen\u2026",
-    "s_review_permissions": "Berechtigungen überprüfen",
-    "p_elevated_permissions_required": "Die Verwaltung dieses Geräts benötigt erhöhte Berechtigungen.",
-    "p_webauthn_elevated_permissions_required": "WebAuthn-Verwaltung benötigt erhöhte Berechtigungen.",
-    "p_need_camera_permission": "Yubico Authenticator benötigt Zugriff auf die Kamera um QR-Codes aufnehmen zu können.",
-
-    "@_qr_codes": {},
-    "s_qr_scan": "QR-Code aufnehmen",
-    "l_qr_scanned": "QR-Code aufgenommen",
-    "l_invalid_qr": "Ungültiger QR-Code",
-    "l_qr_not_found": "Kein QR-Code gefunden",
-    "l_qr_not_read": "Fehler beim Lesen des QR-Codes: {message}",
-    "@l_qr_not_read" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_point_camera_scan": "Halten Sie Ihre Kamera auf einen QR-Code um ihn aufzunehmen",
-    "q_want_to_scan": "Möchten Sie aufnehmen?",
-    "q_no_qr": "Kein QR-Code?",
-    "s_enter_manually": "Manuell eingeben",
-
-    "@_factory_reset": {},
-    "s_reset": "Zurücksetzen",
-    "s_factory_reset": "Werkseinstellungen",
-    "l_factory_reset_this_app": "Anwendung auf Werkseinstellung zurücksetzen",
-    "s_reset_oath": "OATH zurücksetzen",
-    "l_oath_application_reset": "OATH Anwendung zurücksetzen",
-    "s_reset_fido": "FIDO zurücksetzen",
-    "l_fido_app_reset": "FIDO Anwendung zurückgesetzt",
-    "l_press_reset_to_begin": "Drücken Sie Zurücksetzen um zu beginnen\u2026",
-    "l_reset_failed": "Fehler beim Zurücksetzen: {message}",
-    "@l_reset_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "p_warning_factory_reset": "Achtung! Das löscht alle OATH TOTP/HOTP Konten unwiederbringlich von Ihrem YubiKey.",
-    "p_warning_disable_credentials": "Ihre OATH Anmeldeinformationen und jedes gesetzte Passwort wird von diesem YubiKey entfernt. Deaktivieren Sie diese zuerst auf den zugehörigen Webseiten, um nicht aus ihren Konten ausgesperrt zu werden.",
-    "p_warning_deletes_accounts": "Achtung! Das löscht alle U2F und FIDO2 Konten unwiederbringlich von Ihrem YubiKey.",
-    "p_warning_disable_accounts": "Ihre Anmeldeinformationen und jede gesetzte PIN wird von diesem YubiKey entfernt. Deaktivieren Sie diese zuerst auf den zugehörigen Webseiten, um nicht aus ihren Konten ausgesperrt zu werden.",
-
-    "@_copy_to_clipboard": {},
-    "l_copy_to_clipboard": "In die Zwischenablage kopieren",
-    "s_code_copied": "Code kopiert",
-    "l_code_copied_clipboard": "Code in die Zwischenablage kopiert",
-    "s_copy_log": "Log kopiert",
-    "l_log_copied": "Log in die Zwischenablage kopiert",
-    "l_diagnostics_copied": "Diagnosedaten in die Zwischenablage kopiert",
-    "p_target_copied_clipboard": "{label} in die Zwischenablage kopiert.",
-    "@p_target_copied_clipboard" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-
-    "@_custom_icons": {},
-    "s_custom_icons": "Eigene Icons",
-    "l_set_icons_for_accounts": "Icons für Konten setzen",
-    "p_custom_icons_description": "Icon-Pakete machen Ihre Konten mit bekannten Logos und Farben leichter unterscheidbar.",
-    "s_replace_icon_pack": "Icon-Paket ersetzen",
-    "l_loading_icon_pack": "Lade Icon-Paket\u2026",
-    "s_load_icon_pack": "Icon-Paket laden",
-    "s_remove_icon_pack": "Icon-Paket entfernen",
-    "l_icon_pack_removed": "Icon-Paket entfernt",
-    "l_remove_icon_pack_failed": "Fehler beim Entfernen des Icon-Pakets",
-    "s_choose_icon_pack": "Icon-Paket auswählen",
+    "l_fp_step_1_capture": "Schritt 1/2: Fingerabdruck aufnehmen",
+    "l_fp_step_2_name": "Schritt 2/2: Fingerabdruck benennen",
+    "l_helper_not_responding": "Der Helper-Prozess antwortet nicht",
+    "l_icon_pack_copy_failed": "Kopieren der Dateien des Icon-Pakets fehlgeschlagen",
     "l_icon_pack_imported": "Icon-Paket importiert",
+    "l_icon_pack_removed": "Icon-Paket entfernt",
+    "l_import_error": "Import-Fehler",
     "l_import_icon_pack_failed": "Fehler beim Importieren des Icon-Pakets: {message}",
     "@l_import_icon_pack_failed": {
         "placeholders": {
             "message": {}
         }
     },
+    "l_insert_or_tap_yk": "YubiKey anschließen oder dagegenhalten",
+    "l_insert_yk": "YubiKey anschließen",
+    "l_invalid_character_issuer": "Ungültiges Zeichen: ':' ist im Aussteller nicht erlaubt",
     "l_invalid_icon_pack": "Ungültiges Icon-Paket",
-    "l_icon_pack_copy_failed": "Kopieren der Dateien des Icon-Pakets fehlgeschlagen",
-
-    "@_android_settings": {},
-    "s_nfc_options": "NFC Optionen",
-    "l_on_yk_nfc_tap": "Bei YubiKey NFC-Berührung",
-    "l_launch_ya": "Yubico Authenticator starten",
-    "l_copy_otp_clipboard": "OTP in Zwischenablage kopieren",
-    "l_launch_and_copy_otp": "App starten und OTP kopieren",
+    "l_invalid_qr": "Ungültiger QR-Code",
     "l_kbd_layout_for_static": "Tastaturlayout (für statisches Passwort)",
-    "s_choose_kbd_layout": "Tastaturlayout auswählen",
-    "l_bypass_touch_requirement": "Notwendigkeit zur Berührung umgehen",
-    "l_bypass_touch_requirement_on": "Konten, die Berührung erfordern, werden automatisch über NFC angezeigt",
-    "l_bypass_touch_requirement_off": "Konten, die Berührung erfordern, benötigen eine zusätzliche NFC-Berührung",
-    "s_silence_nfc_sounds": "NFC-Töne stummschalten",
-    "l_silence_nfc_sounds_on": "Keine Töne werden bei NFC-Berührung abgespielt",
-    "l_silence_nfc_sounds_off": "Töne werden bei NFC-Berührung abgespielt",
-    "s_usb_options": "USB Optionen",
+    "l_keep_touching_yk": "Berühren Sie Ihren YubiKey wiederholt…",
+    "l_keystore_unavailable": "Passwortspeicher des Betriebssystems nicht verfügbar",
+    "l_launch_and_copy_otp": "App starten und OTP kopieren",
     "l_launch_app_on_usb": "Starten, wenn YubiKey angesteckt wird",
-    "l_launch_app_on_usb_on": "Das verhindert, dass andere Anwendungen den YubiKey über USB nutzen",
     "l_launch_app_on_usb_off": "Andere Anwendungen können den YubiKey über USB nutzen",
+    "l_launch_app_on_usb_on": "Das verhindert, dass andere Anwendungen den YubiKey über USB nutzen",
+    "l_launch_ya": "Yubico Authenticator starten",
+    "l_loading_icon_pack": "Lade Icon-Paket…",
+    "l_log_copied": "Log in die Zwischenablage kopiert",
+    "l_min_one_interface": "Mindestens ein Interface muss aktiviert sein",
+    "l_name_already_exists": "Für diesen Aussteller existiert dieser Name bereits",
+    "l_new_pin_len": "Neue PIN muss mindestens {length} Zeichen lang sein",
+    "@l_new_pin_len": {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "l_no_discoverable_accounts": "Keine erkennbaren Konten",
+    "l_no_fps_added": "Es wurden keine Fingerabdrücke hinzugefügt",
+    "l_no_yk_present": "Kein YubiKey vorhanden",
+    "l_oath_application_reset": "OATH Anwendung zurücksetzen",
+    "l_on_yk_nfc_tap": "Bei YubiKey NFC-Berührung",
+    "l_open_connection_failed": "Konnte keine Verbindung öffnen",
+    "l_optional_password_protection": "Optionaler Passwortschutz",
+    "l_optionally_set_a_pin": "Setzen Sie optional eine PIN, um den Zugriff auf Ihren YubiKey zu schützen\nAls Sicherheitsschlüssel auf Webseiten registrieren",
+    "l_pin_blocked_reset": "PIN ist blockiert; setzen Sie die FIDO Anwendung auf Werkseinstellung zurück",
+    "l_pin_soft_locked": "PIN wurde blockiert bis der YubiKey entfernt und wieder angeschlossen wird",
+    "l_place_on_nfc_reader": "Halten Sie Ihren YubiKey zum NFC-Leser",
+    "l_point_camera_scan": "Halten Sie Ihre Kamera auf einen QR-Code um ihn aufzunehmen",
+    "l_press_reset_to_begin": "Drücken Sie Zurücksetzen um zu beginnen…",
+    "l_qr_not_found": "Kein QR-Code gefunden",
+    "l_qr_not_read": "Fehler beim Lesen des QR-Codes: {message}",
+    "@l_qr_not_read": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_qr_scanned": "QR-Code aufgenommen",
+    "l_ready_to_use": "Bereit zur Verwendung",
+    "l_register_sk_on_websites": "Als Sicherheitsschlüssel auf Webseiten registrieren",
+    "l_reinsert_yk": "Schließen Sie Ihren YubiKey wieder an",
+    "l_remember_pw_failed": "Konnte Passwort nicht speichern",
+    "l_remove_icon_pack_failed": "Fehler beim Entfernen des Icon-Pakets",
+    "l_remove_yk_from_reader": "Entfernen Sie Ihren YubiKey vom NFC-Leser",
+    "l_rename_fp_failed": "Fehler beim Umbenennen: {message}",
+    "@l_rename_fp_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_replace_yk_on_reader": "Halten Sie Ihren YubiKey wieder zum Leser",
+    "l_reset_failed": "Fehler beim Zurücksetzen: {message}",
+    "@l_reset_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_set_icons_for_accounts": "Icons für Konten setzen",
+    "l_set_pin_failed": "PIN konnte nicht gesetzt werden: {message}",
+    "@l_set_pin_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_set_pin_fingerprints": "Setzen Sie eine PIN um Fingerabdrücke zu registrieren",
+    "l_set_pin_first": "Zuerst ist eine PIN erforderlich",
+    "l_setting_name_failed": "Fehler beim Setzen des Namens: {message}",
+    "@l_setting_name_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_silence_nfc_sounds_off": "Töne werden bei NFC-Berührung abgespielt",
+    "l_silence_nfc_sounds_on": "Keine Töne werden bei NFC-Berührung abgespielt",
+    "l_touch_button_now": "Berühren Sie jetzt die Schaltfläche auf Ihrem YubiKey",
+    "l_unlock_first": "Zuerst mit Passwort entsperren",
+    "l_unlock_pin_first": "Zuerst mit PIN entsperren",
+    "l_unplug_yk": "Entfernen Sie Ihren YubiKey",
+    "l_webauthn_req_fido2": "WebAuthn erfordert, dass die FIDO2 Anwendung auf Ihrem YubiKey aktiviert ist",
+    "l_wrong_pin_attempts_remaining": "Falsche PIN, {retries} Versuch(e) verbleibend",
+    "@l_wrong_pin_attempts_remaining": {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_yk_no_access": "Auf diesen YubiKey kann nicht zugegriffen werden",
+    "p_ccid_service_unavailable": "Stellen Sie sicher, dass Ihr Smartcard-Service funktioniert.",
+    "p_community_translations_desc": "Diese Übersetzungen werden von der Gemeinschaft erstellt und gewartet. Sie könnten Fehler enthalten oder unvollständig sein.",
+    "p_custom_icons_description": "Icon-Pakete machen Ihre Konten mit bekannten Logos und Farben leichter unterscheidbar.",
+    "p_elevated_permissions_required": "Die Verwaltung dieses Geräts benötigt erhöhte Berechtigungen.",
+    "p_enter_current_password_or_reset": "Geben Sie Ihr aktuelles Passwort ein. Wenn Sie Ihr Passwort nicht wissen, müssen Sie den YubiKey zurücksetzen.",
+    "p_enter_current_pin_or_reset": "Geben Sie Ihre aktuelle PIN ein. Wenn Sie die PIN nicht wissen, müssen Sie den YubiKey zurücksetzen.",
+    "p_enter_new_fido2_pin": "Geben Sie Ihre neue PIN ein. Eine PIN muss mindestens {length} Zeichen lang sein und kann Buchstaben, Ziffern und spezielle Zeichen enthalten.",
+    "@p_enter_new_fido2_pin": {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "p_enter_new_password": "Geben Sie Ihr neues Passwort ein. Ein Passwort kann Buchstaben, Ziffern und spezielle Zeichen enthalten.",
+    "p_need_camera_permission": "Yubico Authenticator benötigt Zugriff auf die Kamera um QR-Codes aufnehmen zu können.",
+    "p_pcscd_unavailable": "Stellen Sie sicher, dass pcscd installiert ist und ausgeführt wird.",
+    "p_press_fingerprint_begin": "Drücken Sie Ihren Finger gegen den YubiKey um zu beginnen.",
+    "p_rename_will_change_account_displayed": "Das ändert die Anzeige dieses Kontos in der Liste.",
+    "p_target_copied_clipboard": "{label} in die Zwischenablage kopiert.",
+    "@p_target_copied_clipboard": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "p_try_reinsert_yk": "Versuchen Sie Ihren YubiKey zu entfernen und wieder anzuschließen.",
+    "p_warning_delete_account": "Vorsicht! Das löscht das Konto von Ihrem YubiKey.",
+    "p_warning_delete_credential": "Das löscht die Anmeldeinformation von Ihrem YubiKey.",
+    "p_warning_delete_fingerprint": "Das löscht den Fingerabdruck von Ihrem YubiKey.",
+    "p_warning_deletes_accounts": "Achtung! Das löscht alle U2F und FIDO2 Konten unwiederbringlich von Ihrem YubiKey.",
+    "p_warning_disable_accounts": "Ihre Anmeldeinformationen und jede gesetzte PIN wird von diesem YubiKey entfernt. Deaktivieren Sie diese zuerst auf den zugehörigen Webseiten, um nicht aus ihren Konten ausgesperrt zu werden.",
+    "p_warning_disable_credential": "Sie werden keine OTPs für dieses Konto mehr erstellen können. Deaktivieren Sie diese Anmeldeinformation zuerst auf der Webseite, um nicht aus dem Konto ausgesperrt zu werden.",
+    "p_warning_disable_credentials": "Ihre OATH Anmeldeinformationen und jedes gesetzte Passwort wird von diesem YubiKey entfernt. Deaktivieren Sie diese zuerst auf den zugehörigen Webseiten, um nicht aus ihren Konten ausgesperrt zu werden.",
+    "p_warning_factory_reset": "Achtung! Das löscht alle OATH TOTP/HOTP Konten unwiederbringlich von Ihrem YubiKey.",
+    "p_webauthn_elevated_permissions_required": "WebAuthn-Verwaltung benötigt erhöhte Berechtigungen.",
+    "p_will_change_label_fp": "Das ändert die Beschriftung des Fingerabdrucks.",
+    "q_have_account_info": "Haben Sie Konto-Informationen?",
+    "q_no_qr": "Kein QR-Code?",
+    "q_rename_target": "{label} umbenennen?",
+    "@q_rename_target": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "q_want_to_scan": "Möchten Sie aufnehmen?",
+    "s_about": "Über",
+    "s_account_added": "Konto hinzugefügt",
+    "s_account_deleted": "Konto gelöscht",
+    "s_account_name": "Kontoname",
+    "s_account_renamed": "Konto umbenannt",
+    "s_accounts": "Konten",
+    "s_add_account": "Konto hinzufügen",
+    "s_add_fingerprint": "Fingerabdruck hinzufügen",
     "s_allow_screenshots": "Bildschirmfotos erlauben",
-
-    "@_eof": {}
+    "s_app_disabled": "Anwendung deaktiviert",
+    "s_app_not_supported": "Anwendung nicht unterstützt",
+    "s_app_theme": "App Theme",
+    "s_appearance": "Aussehen",
+    "s_application_error": "Anwendungs-Fehler",
+    "s_authenticator": "Authenticator",
+    "s_calculate": "Berechnen",
+    "s_cancel": "Abbrechen",
+    "s_change_pin": "PIN ändern",
+    "s_character_count": "Anzahl Zeichen",
+    "s_choose_app_theme": "App Theme auswählen",
+    "s_choose_icon_pack": "Icon-Paket auswählen",
+    "s_choose_kbd_layout": "Tastaturlayout auswählen",
+    "s_clear_saved_password": "Gespeichertes Passwort entfernen",
+    "s_close": "Schließen",
+    "s_code_copied": "Code kopiert",
+    "s_config_updated": "Konfiguration aktualisiert",
+    "s_configure_yk": "YubiKey konfigurieren",
+    "s_confirm_password": "Passwort bestätigen",
+    "s_confirm_pin": "PIN bestätigen",
+    "s_copy_log": "Log kopiert",
+    "s_counter_based": "Zähler-basiert",
+    "s_credential_deleted": "Anmeldeinformation gelöscht",
+    "s_credentials": "Anmeldeinformationen",
+    "s_current_password": "Aktuelles Passwort",
+    "s_current_pin": "Derzeitige PIN",
+    "s_custom_icons": "Eigene Icons",
+    "s_dark_mode": "Dunkler Modus",
+    "s_delete": "Löschen",
+    "s_delete_account": "Konto löschen",
+    "s_delete_credential": "Anmeldeinformation löschen",
+    "s_delete_fingerprint": "Fingerabdruck löschen",
+    "s_enable_nfc": "NFC aktivieren",
+    "s_enter_manually": "Manuell eingeben",
+    "s_factory_reset": "Werkseinstellungen",
+    "s_fido_disabled": "FIDO2 deaktiviert",
+    "s_fido_pin_protection": "FIDO PIN Schutz",
+    "s_fingerprint_added": "Fingerabdruck hinzugefügt",
+    "s_fingerprint_deleted": "Fingerabdruck gelöscht",
+    "s_fingerprint_renamed": "Fingerabdruck umbenannt",
+    "s_fingerprints": "Fingerabdrücke",
+    "s_fw_version": "F/W: {version}",
+    "@s_fw_version": {
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "s_help_and_about": "Hilfe und Über",
+    "s_help_and_feedback": "Hilfe und Feedback",
+    "s_hide_device": "Gerät verstecken",
+    "s_hide_window": "Fenster verstecken",
+    "s_i_need_help": "Ich brauche Hilfe",
+    "s_invalid_length": "Ungültige Länge",
+    "s_issuer_optional": "Aussteller (optional)",
+    "s_label": "Beschriftung",
+    "s_language": "Sprache",
+    "s_learn_more": "Mehr erfahren",
+    "s_light_mode": "Heller Modus",
+    "s_load_icon_pack": "Icon-Paket laden",
+    "s_log_level": "Log-Level: {level}",
+    "@s_log_level": {
+        "placeholders": {
+            "level": {}
+        }
+    },
+    "s_manage": "Verwalten",
+    "s_manage_password": "Passwort verwalten",
+    "s_name": "Name",
+    "s_new_password": "Neues Passwort",
+    "s_new_pin": "Neue PIN",
+    "s_nfc": "NFC",
+    "s_nfc_options": "NFC Optionen",
+    "s_no_accounts": "Keine Konten",
+    "s_no_fingerprints": "Keine Fingerabdrücke",
+    "s_no_pinned_accounts": "Keine angepinnten Konten",
+    "s_num_digits": "{num} Ziffern",
+    "@s_num_digits": {
+        "placeholders": {
+            "num": {}
+        }
+    },
+    "s_num_sec": "{num} sek",
+    "@s_num_sec": {
+        "placeholders": {
+            "num": {}
+        }
+    },
+    "s_open_src_licenses": "Open Source-Lizenzen",
+    "s_password": "Passwort",
+    "s_password_forgotten": "Passwort vergessen",
+    "s_password_removed": "Passwort entfernt",
+    "s_password_set": "Passwort gesetzt",
+    "s_permission_denied": "Zugriff verweigert",
+    "s_pin": "PIN",
+    "s_pin_account": "Konto anpinnen",
+    "s_pin_set": "PIN gesetzt",
+    "s_pinned": "Angepinnt",
+    "s_please_wait": "Bitte warten…",
+    "s_privacy_policy": "Datenschutzerklärung",
+    "s_qr_scan": "QR-Code aufnehmen",
+    "s_quit": "Beenden",
+    "s_reconfiguring_yk": "YubiKey wird neu konfiguriert…",
+    "s_remember_password": "Passwort speichern",
+    "s_remove_icon_pack": "Icon-Paket entfernen",
+    "s_remove_password": "Passwort entfernen",
+    "s_rename_account": "Konto umbenennen",
+    "s_rename_fp": "Fingerabdruck umbenennen",
+    "s_replace_icon_pack": "Icon-Paket ersetzen",
+    "s_require_touch": "Berührung ist erforderlich",
+    "s_reset": "Zurücksetzen",
+    "s_reset_fido": "FIDO zurücksetzen",
+    "s_reset_oath": "OATH zurücksetzen",
+    "s_review_permissions": "Berechtigungen überprüfen",
+    "s_run_diagnostics": "Diagnose ausführen",
+    "s_save": "Speichern",
+    "s_search_accounts": "Konten durchsuchen",
+    "s_secret_key": "Geheimer Schlüssel",
+    "s_select_to_scan": "Zum Scannen auswählen",
+    "s_select_yk": "YubiKey auswählen",
+    "s_send_feedback": "Senden Sie uns Feedback",
+    "s_set_password": "Passwort setzen",
+    "s_set_pin": "PIN setzen",
+    "s_settings": "Einstellungen",
+    "s_setup": "Einrichten",
+    "s_show_hidden_devices": "Versteckte Geräte anzeigen",
+    "s_show_window": "Fenster anzeigen",
+    "s_silence_nfc_sounds": "NFC-Töne stummschalten",
+    "s_sn_serial": "S/N: {serial}",
+    "@s_sn_serial": {
+        "placeholders": {
+            "serial": {}
+        }
+    },
+    "s_system_default": "Standard des Systems",
+    "s_terms_of_use": "Nutzungsbedingungen",
+    "s_time_based": "Zeit-basiert",
+    "s_toggle_applications": "Anwendungen umschalten",
+    "s_touch_required": "Berührung erforderlich",
+    "s_troubleshooting": "Problembehebung",
+    "s_unknown_device": "Unbekanntes Gerät",
+    "s_unknown_type": "Unbekannter Typ",
+    "s_unlock": "Entsperren",
+    "s_unpin_account": "Konto nicht mehr anpinnen",
+    "s_unsupported_yk": "Nicht unterstützter YubiKey",
+    "s_usb": "USB",
+    "s_usb_options": "USB Optionen",
+    "s_webauthn": "WebAuthn",
+    "s_wrong_password": "Falsches Passwort",
+    "s_yk_inaccessible": "Gerät nicht zugänglich",
+    "s_yk_information": "YubiKey Information",
+    "s_yk_not_recognized": "Geräte nicht erkannt"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "en",
+
     "@_readme": {
         "notes": [
             "All strings start with a Captial letter.",
@@ -7,543 +8,593 @@
             "Run check_strings.py on the .arb file to detect problems, tweak @_lint_rules as needed per language."
         ],
         "prefixes": {
+            "s_": "A single, or few words. Should be short enough to display on a button, or a header.",
             "l_": "A single line, can be wrapped. Should not be more than one sentence, and not end with a period.",
             "p_": "One or more full sentences, with proper punctuation.",
-            "q_": "A question, ending in question mark.",
-            "s_": "A single, or few words. Should be short enough to display on a button, or a header."
+            "q_": "A question, ending in question mark."
         }
     },
+
     "@_lint_rules": {
-        "s_max_length": 32,
-        "s_max_words": 4
+        "s_max_words": 4,
+        "s_max_length": 32
     },
+
     "app_name": "Yubico Authenticator",
-    "l_account": "Account: {label}",
-    "@l_account": {
+
+    "s_save": "Save",
+    "s_cancel": "Cancel",
+    "s_close": "Close",
+    "s_delete": "Delete",
+    "s_quit": "Quit",
+    "s_unlock": "Unlock",
+    "s_calculate": "Calculate",
+    "s_import": "Import",
+    "s_label": "Label",
+    "s_name": "Name",
+    "s_usb": "USB",
+    "s_nfc": "NFC",
+    "s_show_window": "Show window",
+    "s_hide_window": "Hide window",
+    "q_rename_target": "Rename {label}?",
+    "@q_rename_target" : {
         "placeholders": {
             "label": {}
-        }
-    },
-    "l_account_add_failed": "Failed adding account: {message}",
-    "@l_account_add_failed": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_account_already_exists": "This account already exists on the YubiKey",
-    "l_account_name_required": "Your account must have a name",
-    "l_accounts_used": "{used} of {capacity} accounts used",
-    "@l_accounts_used": {
-        "placeholders": {
-            "capacity": {},
-            "used": {}
-        }
-    },
-    "l_add_one_or_more_fps": "Add one or more (up to five) fingerprints",
-    "l_app_disabled_desc": "Enable the '{app}' application on your YubiKey to access",
-    "@l_app_disabled_desc": {
-        "placeholders": {
-            "app": {}
-        }
-    },
-    "l_app_not_supported_desc": "This application is not supported",
-    "l_app_not_supported_on_yk": "The used YubiKey does not support '{app}' application",
-    "@l_app_not_supported_on_yk": {
-        "placeholders": {
-            "app": {}
-        }
-    },
-    "l_attempts_remaining": "{retries} attempt(s) remaining",
-    "@l_attempts_remaining": {
-        "placeholders": {
-            "retries": {}
         }
     },
     "l_bullet": "• {item}",
-    "@l_bullet": {
+    "@l_bullet" : {
         "placeholders": {
             "item": {}
         }
     },
-    "l_bypass_touch_requirement": "Bypass touch requirement",
-    "l_bypass_touch_requirement_off": "Accounts that require touch need an additional tap over NFC",
-    "l_bypass_touch_requirement_on": "Accounts that require touch are automatically shown over NFC",
-    "l_calculate_code_desc": "Get a new code from your YubiKey",
-    "l_ccid_connection_failed": "Failed to open smart card connection",
-    "l_certificate_deleted": "Certificate deleted",
-    "l_certificate_exported": "Certificate exported",
-    "l_change_management_key": "Change management key",
-    "l_code_copied_clipboard": "Code copied to clipboard",
-    "l_config_updated_reinsert": "Configuration updated, remove and reinsert your YubiKey",
-    "l_copy_code_desc": "Easily paste the code into another app",
-    "l_copy_otp_clipboard": "Copy OTP to clipboard",
-    "l_copy_to_clipboard": "Copy to clipboard",
-    "l_default_key_used": "Default management key used",
-    "l_delete_account_desc": "Remove the account from your YubiKey",
-    "l_delete_certificate": "Delete certificate",
-    "l_delete_certificate_desc": "Remove the certificate from your YubiKey",
-    "l_delete_fingerprint_desc": "Remove the fingerprint from the YubiKey",
-    "l_delete_passkey_desc": "Remove the Passkey from the YubiKey",
-    "l_diagnostics_copied": "Diagnostic data copied to clipboard",
-    "l_elevating_permissions": "Elevating permissions…",
-    "l_enable_community_translations": "Enable community translations",
-    "l_enter_fido2_pin": "Enter the FIDO2 PIN for your YubiKey",
-    "l_enter_oath_pw": "Enter the OATH password for your YubiKey",
-    "l_error_occured": "An error has occured",
-    "l_export_certificate": "Export certificate",
-    "l_export_certificate_desc": "Export the certificate to a file",
-    "l_export_certificate_file": "Export certificate to file",
-    "l_export_csr_file": "Save CSR to file",
-    "l_factory_reset_this_app": "Factory reset this application",
-    "l_fido_app_reset": "FIDO application reset",
-    "l_fido_pin_protection_optional": "Optional FIDO PIN protection",
-    "l_file_not_found": "File not found",
-    "l_file_too_big": "File size too big",
-    "l_filesystem_error": "File system operation error",
-    "l_fingerprint": "Fingerprint: {label}",
-    "@l_fingerprint": {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "l_fingerprint_captured": "Fingerprint captured successfully!",
-    "l_fingerprints_used": "{used}/5 fingerprints registered",
-    "@l_fingerprints_used": {
-        "placeholders": {
-            "used": {}
-        }
-    },
-    "l_fp_step_1_capture": "Step 1/2: Capture fingerprint",
-    "l_fp_step_2_name": "Step 2/2: Name fingerprint",
-    "l_generate_desc": "Generate a new certificate or CSR",
-    "l_generating_private_key": "Generating private key…",
-    "l_helper_not_responding": "The Helper process isn't responding",
-    "l_icon_pack_copy_failed": "Failed to copy icon pack files",
-    "l_icon_pack_imported": "Icon pack imported",
-    "l_icon_pack_removed": "Icon pack removed",
-    "l_import_desc": "Import a key and/or certificate",
-    "l_import_error": "Import error",
-    "l_import_file": "Import file",
-    "l_import_icon_pack_failed": "Error importing icon pack: {message}",
-    "@l_import_icon_pack_failed": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_insert_or_tap_yk": "Insert or tap a YubiKey",
-    "l_insert_yk": "Insert your YubiKey",
-    "l_invalid_character_issuer": "Invalid character: ':' is not allowed in issuer",
-    "l_invalid_icon_pack": "Invalid icon pack",
-    "l_invalid_qr": "Invalid QR code",
-    "l_kbd_layout_for_static": "Keyboard layout (for static password)",
-    "l_keep_touching_yk": "Keep touching your YubiKey repeatedly…",
-    "l_key_no_certificate": "Key without certificate loaded",
-    "l_keystore_unavailable": "OS Keystore unavailable",
-    "l_launch_and_copy_otp": "Launch app and copy OTP",
-    "l_launch_app_on_usb": "Launch when YubiKey is connected",
-    "l_launch_app_on_usb_off": "Other apps can use the YubiKey over USB",
-    "l_launch_app_on_usb_on": "This prevents other apps from using the YubiKey over USB",
-    "l_launch_ya": "Launch Yubico Authenticator",
-    "l_loading_icon_pack": "Loading icon pack…",
-    "l_log_copied": "Log copied to clipboard",
-    "l_management_key_changed": "Management key changed",
-    "l_min_one_interface": "At least one interface must be enabled",
-    "l_name_already_exists": "This name already exists for the issuer",
-    "l_new_pin_len": "New PIN must be at least {length} characters",
-    "@l_new_pin_len": {
-        "placeholders": {
-            "length": {}
-        }
-    },
-    "l_no_certificate": "No certificate loaded",
-    "l_no_discoverable_accounts": "No Passkeys stored",
-    "l_no_fps_added": "No fingerprints have been added",
-    "l_no_yk_present": "No YubiKey present",
-    "l_oath_application_reset": "OATH application reset",
-    "l_on_yk_nfc_tap": "On YubiKey NFC tap",
-    "l_open_connection_failed": "Failed to open connection",
-    "l_optional_password_protection": "Optional password protection",
-    "l_optionally_set_a_pin": "Optionally set a PIN to protect access to your YubiKey\nRegister as a Security Key on websites",
-    "l_passkey": "Passkey: {label}",
-    "@l_passkey": {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "l_pin_account_desc": "Keep your important accounts together",
-    "l_pin_blocked_reset": "PIN is blocked; factory reset the FIDO application",
-    "l_pin_protected_key": "PIN can be used instead",
-    "l_pin_soft_locked": "PIN has been blocked until the YubiKey is removed and reinserted",
-    "l_piv_app_reset": "PIV application reset",
-    "l_piv_pin_blocked": "Blocked, use PUK to reset",
-    "l_piv_pin_puk_blocked": "Blocked, factory reset needed",
-    "l_place_on_nfc_reader": "Place your YubiKey on the NFC reader",
-    "l_point_camera_scan": "Point your camera at a QR code to scan it",
-    "l_press_reset_to_begin": "Press reset to begin…",
-    "l_qr_not_found": "No QR code found",
-    "l_qr_not_read": "Failed reading QR code: {message}",
-    "@l_qr_not_read": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_qr_scanned": "Scanned QR code",
-    "l_ready_to_use": "Ready to use",
-    "l_register_sk_on_websites": "Register as a Security Key on websites",
-    "l_reinsert_yk": "Reinsert your YubiKey",
-    "l_remember_pw_failed": "Failed to remember password",
-    "l_remove_icon_pack_failed": "Error removing icon pack",
-    "l_remove_yk_from_reader": "Remove your YubiKey from the NFC reader",
-    "l_rename_account_desc": "Edit the issuer/name of the account",
-    "l_rename_fp_desc": "Change the label",
-    "l_rename_fp_failed": "Error renaming: {message}",
-    "@l_rename_fp_failed": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_replace_yk_on_reader": "Place your YubiKey back on the reader",
-    "l_reset_failed": "Error performing reset: {message}",
-    "@l_reset_failed": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_select_accounts": "Select account(s) to add to the YubiKey",
-    "l_select_import_file": "Select file to import",
-    "l_set_icons_for_accounts": "Set icons for accounts",
-    "l_set_pin_failed": "Failed to set PIN: {message}",
-    "@l_set_pin_failed": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_set_pin_fingerprints": "Set a PIN to register fingerprints",
-    "l_set_pin_first": "A PIN is required first",
-    "l_setting_name_failed": "Error setting name: {message}",
-    "@l_setting_name_failed": {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_silence_nfc_sounds_off": "Sound will play on NFC tap",
-    "l_silence_nfc_sounds_on": "No sounds will be played on NFC tap",
-    "l_touch_button_now": "Touch the button on your YubiKey now",
-    "l_unlock_first": "Unlock with password first",
-    "l_unlock_pin_first": "Unlock with PIN first",
-    "l_unlock_piv_management": "Unlock PIV management",
-    "l_unplug_yk": "Unplug your YubiKey",
-    "l_warning_default_key": "Warning: Default key used",
-    "l_webauthn_req_fido2": "WebAuthn requires the FIDO2 application to be enabled on your YubiKey",
-    "l_wrong_key": "Wrong key",
-    "l_wrong_pin_attempts_remaining": "Wrong PIN, {retries} attempt(s) remaining",
-    "@l_wrong_pin_attempts_remaining": {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "l_wrong_puk_attempts_remaining": "Wrong PUK, {retries} attempt(s) remaining",
-    "@l_wrong_puk_attempts_remaining": {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "l_yk_no_access": "This YubiKey cannot be accessed",
-    "p_add_description": "To scan a QR code, make sure the full code is visible on screen and press the button below. You can also drag a saved image from a folder onto this dialog. If you have the account credential details in writing, use the manual entry instead.",
-    "p_ccid_service_unavailable": "Make sure your smart card service is functioning.",
-    "p_change_management_key_desc": "Change your management key. You can optionally choose to allow the PIN to be used instead of the management key.",
-    "p_community_translations_desc": "These translations are provided and maintained by the community. They may contain errors or be incomplete.",
-    "p_custom_icons_description": "Icon packs can make your accounts more easily distinguishable with familiar logos and colors.",
-    "p_elevated_permissions_required": "Managing this device requires elevated privileges.",
-    "p_enter_current_password_or_reset": "Enter your current password. If you don't know your password, you'll need to reset the YubiKey.",
-    "p_enter_current_pin_or_reset": "Enter your current PIN. If you don't know your PIN, you'll need to unblock it with the PUK or reset the YubiKey.",
-    "p_enter_current_puk_or_reset": "Enter your current PUK. If you don't know your PUK, you'll need to reset the YubiKey.",
-    "p_enter_new_fido2_pin": "Enter your new PIN. A PIN must be at least {length} characters long and may contain letters, numbers and special characters.",
-    "@p_enter_new_fido2_pin": {
-        "placeholders": {
-            "length": {}
-        }
-    },
-    "p_enter_new_password": "Enter your new password. A password may contain letters, numbers and special characters.",
-    "p_enter_new_piv_pin_puk": "Enter a new {name} to set. Must be 6-8 characters.",
-    "@p_enter_new_piv_pin_puk": {
-        "placeholders": {
-            "name": {}
-        }
-    },
-    "p_generate_desc": "This will generate a new key on the YubiKey in PIV slot {slot}. The public key will be embedded into a self-signed certificate stored on the YubiKey, or in a certificate signing request (CSR) saved to file.",
-    "@p_generate_desc": {
-        "placeholders": {
-            "slot": {}
-        }
-    },
-    "p_import_items_desc": "The following items will be imported into PIV slot {slot}.",
-    "@p_import_items_desc": {
-        "placeholders": {
-            "slot": {}
-        }
-    },
-    "p_need_camera_permission": "Yubico Authenticator needs Camera permissions for scanning QR codes.",
-    "p_password_protected_file": "The selected file is password protected. Enter the password to proceed.",
-    "p_pcscd_unavailable": "Make sure pcscd is installed and running.",
-    "p_pin_required_desc": "The action you are about to perform requires the PIV PIN to be entered.",
-    "p_press_fingerprint_begin": "Press your finger against the YubiKey to begin.",
-    "p_rename_will_change_account_displayed": "This will change how the account is displayed in the list.",
-    "p_target_copied_clipboard": "{label} copied to clipboard.",
-    "@p_target_copied_clipboard": {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "p_try_reinsert_yk": "Try to remove and reinsert your YubiKey.",
-    "p_unlock_piv_management_desc": "The action you are about to perform requires the PIV management key. Provide this key to unlock management functionality for this session.",
-    "p_warning_delete_account": "Warning! This action will delete the account from your YubiKey.",
-    "p_warning_delete_certificate": "Warning! This action will delete the certificate from your YubiKey.",
-    "p_warning_delete_fingerprint": "This will delete the fingerprint from your YubiKey.",
-    "p_warning_delete_passkey": "This will delete the Passkey from your YubiKey.",
-    "p_warning_deletes_accounts": "Warning! This will irrevocably delete all U2F and FIDO2 accounts from your YubiKey.",
-    "p_warning_disable_accounts": "Your credentials, as well as any PIN set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
-    "p_warning_disable_credential": "You will no longer be able to generate OTPs for this account. Make sure to first disable this credential from the website to avoid being locked out of your account.",
-    "p_warning_disable_credentials": "Your OATH credentials, as well as any password set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
-    "p_warning_factory_reset": "Warning! This will irrevocably delete all OATH TOTP/HOTP accounts from your YubiKey.",
-    "p_warning_piv_reset": "Warning! All data stored for PIV will be irrevocably deleted from your YubiKey.",
-    "p_warning_piv_reset_desc": "This includes private keys and certificates. Your PIN, PUK, and management key will be reset to their factory default values.",
-    "p_webauthn_elevated_permissions_required": "WebAuthn management requires elevated privileges.",
-    "p_will_change_label_fp": "This will change the label of the fingerprint.",
-    "q_delete_certificate_confirm": "Delete the certficate in PIV slot {slot}?",
-    "@q_delete_certificate_confirm": {
-        "placeholders": {
-            "slot": {}
-        }
-    },
-    "q_have_account_info": "Have account info?",
-    "q_no_qr": "No QR code?",
-    "q_rename_target": "Rename {label}?",
-    "@q_rename_target": {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "q_want_to_scan": "Would like to scan?",
-    "s_about": "About",
-    "s_account_added": "Account added",
-    "s_account_deleted": "Account deleted",
-    "s_account_name": "Account name",
-    "s_account_renamed": "Account renamed",
-    "s_accounts": "Accounts",
-    "s_actions": "Actions",
-    "s_add_account": "Add account",
-    "s_add_accounts": "Add account(s)",
-    "s_add_fingerprint": "Add fingerprint",
-    "s_add_manually": "Add manually",
-    "s_allow_screenshots": "Allow screenshots",
-    "s_app_disabled": "Application disabled",
-    "s_app_not_supported": "Application not supported",
-    "s_app_theme": "App theme",
-    "s_appearance": "Appearance",
-    "s_application_error": "Application error",
-    "s_authenticator": "Authenticator",
-    "s_calculate": "Calculate",
-    "s_calculate_code": "Calculate code",
-    "s_cancel": "Cancel",
-    "s_certificate": "Certificate",
-    "s_certificate_fingerprint": "Fingerprint",
-    "s_certificates": "Certificates",
-    "s_change_pin": "Change PIN",
-    "s_change_puk": "Change PUK",
-    "s_character_count": "Character count",
-    "s_choose_app_theme": "Choose app theme",
-    "s_choose_icon_pack": "Choose icon pack",
-    "s_choose_kbd_layout": "Choose keyboard layout",
-    "s_clear_saved_password": "Clear saved password",
-    "s_close": "Close",
-    "s_code_copied": "Code copied",
-    "s_config_updated": "Configuration updated",
-    "s_configure_yk": "Configure YubiKey",
-    "s_confirm_password": "Confirm password",
-    "s_confirm_pin": "Confirm PIN",
-    "s_confirm_puk": "Confirm PUK",
-    "s_copy_log": "Copy log",
-    "s_counter_based": "Counter based",
-    "s_csr": "CSR",
-    "s_current_management_key": "Current management key",
-    "s_current_password": "Current password",
-    "s_current_pin": "Current PIN",
-    "s_current_puk": "Current PUK",
-    "s_custom_icons": "Custom icons",
-    "s_dark_mode": "Dark mode",
     "s_definition": "{item}:",
-    "@s_definition": {
+    "@s_definition" : {
         "placeholders": {
             "item": {}
         }
     },
-    "s_delete": "Delete",
-    "s_delete_account": "Delete account",
-    "s_delete_fingerprint": "Delete fingerprint",
-    "s_delete_passkey": "Delete Passkey",
-    "s_enable_nfc": "Enable NFC",
-    "s_enter_manually": "Enter manually",
-    "s_factory_reset": "Factory reset",
-    "s_fido_disabled": "FIDO2 disabled",
-    "s_fido_pin_protection": "FIDO PIN protection",
-    "s_fingerprint_added": "Fingerprint added",
-    "s_fingerprint_deleted": "Fingerprint deleted",
-    "s_fingerprint_renamed": "Fingerprint renamed",
-    "s_fingerprints": "Fingerprints",
-    "s_fw_version": "F/W: {version}",
-    "@s_fw_version": {
-        "placeholders": {
-            "version": {}
-        }
-    },
-    "s_generate_key": "Generate key",
+
+    "s_about": "About",
+    "s_appearance": "Appearance",
+    "s_authenticator": "Authenticator",
+    "s_actions": "Actions",
+    "s_manage": "Manage",
+    "s_setup": "Setup",
+    "s_settings": "Settings",
+    "s_piv": "PIV",
+    "s_webauthn": "WebAuthn",
     "s_help_and_about": "Help and about",
     "s_help_and_feedback": "Help and feedback",
-    "s_hide_device": "Hide device",
-    "s_hide_window": "Hide window",
+    "s_send_feedback": "Send us feedback",
     "s_i_need_help": "I need help",
-    "s_import": "Import",
+    "s_troubleshooting": "Troubleshooting",
+    "s_terms_of_use": "Terms of use",
+    "s_privacy_policy": "Privacy policy",
+    "s_open_src_licenses": "Open source licenses",
+    "s_configure_yk": "Configure YubiKey",
+    "s_please_wait": "Please wait\u2026",
+    "s_secret_key": "Secret key",
+    "s_private_key": "Private key",
     "s_invalid_length": "Invalid length",
-    "s_issuer": "Issuer",
-    "s_issuer_optional": "Issuer (optional)",
-    "s_label": "Label",
-    "s_language": "Language",
-    "s_learn_more": "Learn more",
-    "s_light_mode": "Light mode",
-    "s_load_icon_pack": "Load icon pack",
+    "s_require_touch": "Require touch",
+    "q_have_account_info": "Have account info?",
+    "s_run_diagnostics": "Run diagnostics",
     "s_log_level": "Log level: {level}",
     "@s_log_level": {
         "placeholders": {
             "level": {}
         }
     },
-    "s_manage": "Manage",
-    "s_manage_password": "Manage password",
-    "s_management_key": "Management key",
-    "s_name": "Name",
-    "s_new_management_key": "New management key",
-    "s_new_password": "New password",
+    "s_character_count": "Character count",
+    "s_learn_more": "Learn\u00a0more",
+
+    "@_language": {},
+    "s_language": "Language",
+    "l_enable_community_translations": "Enable community translations",
+    "p_community_translations_desc": "These translations are provided and maintained by the community. They may contain errors or be incomplete.",
+
+    "@_theme": {},
+    "s_app_theme": "App theme",
+    "s_choose_app_theme": "Choose app theme",
+    "s_system_default": "System default",
+    "s_light_mode": "Light mode",
+    "s_dark_mode": "Dark mode",
+
+    "@_yubikey_selection": {},
+    "s_yk_information": "YubiKey information",
+    "s_select_yk": "Select YubiKey",
+    "s_select_to_scan": "Select to scan",
+    "s_hide_device": "Hide device",
+    "s_show_hidden_devices": "Show hidden devices",
+    "s_sn_serial": "S/N: {serial}",
+    "@s_sn_serial" : {
+        "placeholders": {
+            "serial": {}
+        }
+    },
+    "s_fw_version": "F/W: {version}",
+    "@s_fw_version" : {
+        "placeholders": {
+            "version": {}
+        }
+    },
+
+    "@_yubikey_interactions": {},
+    "l_insert_yk": "Insert your YubiKey",
+    "l_insert_or_tap_yk": "Insert or tap a YubiKey",
+    "l_unplug_yk": "Unplug your YubiKey",
+    "l_reinsert_yk": "Reinsert your YubiKey",
+    "l_place_on_nfc_reader": "Place your YubiKey on the NFC reader",
+    "l_replace_yk_on_reader": "Place your YubiKey back on the reader",
+    "l_remove_yk_from_reader": "Remove your YubiKey from the NFC reader",
+    "p_try_reinsert_yk": "Try to remove and reinsert your YubiKey.",
+    "s_touch_required": "Touch required",
+    "l_touch_button_now": "Touch the button on your YubiKey now",
+    "l_keep_touching_yk": "Keep touching your YubiKey repeatedly\u2026",
+
+    "@_app_configuration": {},
+    "s_toggle_applications": "Toggle applications",
+    "l_min_one_interface": "At least one interface must be enabled",
+    "s_reconfiguring_yk": "Reconfiguring YubiKey\u2026",
+    "s_config_updated": "Configuration updated",
+    "l_config_updated_reinsert": "Configuration updated, remove and reinsert your YubiKey",
+    "s_app_not_supported": "Application not supported",
+    "l_app_not_supported_on_yk": "The used YubiKey does not support '{app}' application",
+    "@l_app_not_supported_on_yk" : {
+        "placeholders": {
+            "app": {}
+        }
+    },
+    "l_app_not_supported_desc": "This application is not supported",
+    "s_app_disabled": "Application disabled",
+    "l_app_disabled_desc": "Enable the '{app}' application on your YubiKey to access",
+    "@l_app_disabled_desc" : {
+        "placeholders": {
+            "app": {}
+        }
+    },
+    "s_fido_disabled": "FIDO2 disabled",
+    "l_webauthn_req_fido2": "WebAuthn requires the FIDO2 application to be enabled on your YubiKey",
+
+    "@_connectivity_issues": {},
+    "l_helper_not_responding": "The Helper process isn't responding",
+    "l_yk_no_access": "This YubiKey cannot be accessed",
+    "s_yk_inaccessible": "Device inaccessible",
+    "l_open_connection_failed": "Failed to open connection",
+    "l_ccid_connection_failed": "Failed to open smart card connection",
+    "p_ccid_service_unavailable": "Make sure your smart card service is functioning.",
+    "p_pcscd_unavailable": "Make sure pcscd is installed and running.",
+    "l_no_yk_present": "No YubiKey present",
+    "s_unknown_type": "Unknown type",
+    "s_unknown_device": "Unrecognized device",
+    "s_unsupported_yk": "Unsupported YubiKey",
+    "s_yk_not_recognized": "Device not recognized",
+
+    "@_general_errors": {},
+    "l_error_occured": "An error has occured",
+    "s_application_error": "Application error",
+    "l_import_error": "Import error",
+    "l_file_not_found": "File not found",
+    "l_file_too_big": "File size too big",
+    "l_filesystem_error": "File system operation error",
+
+    "@_pins": {},
+    "s_pin": "PIN",
+    "s_puk": "PUK",
+    "s_set_pin": "Set PIN",
+    "s_change_pin": "Change PIN",
+    "s_change_puk": "Change PUK",
+    "s_current_pin": "Current PIN",
+    "s_current_puk": "Current PUK",
     "s_new_pin": "New PIN",
     "s_new_puk": "New PUK",
-    "s_nfc": "NFC",
-    "s_nfc_dialog_oath_add_account": "Action: add new account",
-    "s_nfc_dialog_oath_add_multiple_accounts": "Action: add multiple accounts",
-    "s_nfc_dialog_oath_calculate_code": "Action: calculate OATH code",
-    "s_nfc_dialog_oath_delete_account": "Action: delete account",
-    "s_nfc_dialog_oath_failure": "OATH operation failed",
-    "s_nfc_dialog_oath_rename_account": "Action: rename account",
-    "s_nfc_dialog_oath_reset": "Action: reset OATH applet",
-    "s_nfc_dialog_oath_set_password": "Action: set OATH password",
-    "s_nfc_dialog_oath_unlock": "Action: unlock OATH applet",
-    "s_nfc_dialog_oath_unset_password": "Action: remove OATH password",
-    "s_nfc_dialog_operation_failed": "Failed",
-    "s_nfc_dialog_operation_success": "Success",
-    "s_nfc_dialog_tap_key": "Tap your key",
-    "s_nfc_options": "NFC options",
+    "s_confirm_pin": "Confirm PIN",
+    "s_confirm_puk": "Confirm PUK",
+    "s_unblock_pin": "Unblock PIN",
+    "l_new_pin_len": "New PIN must be at least {length} characters",
+    "@l_new_pin_len" : {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "s_pin_set": "PIN set",
+    "s_puk_set": "PUK set",
+    "l_set_pin_failed": "Failed to set PIN: {message}",
+    "@l_set_pin_failed" : {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_attempts_remaining": "{retries} attempt(s) remaining",
+    "@l_attempts_remaining" : {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_wrong_pin_attempts_remaining": "Wrong PIN, {retries} attempt(s) remaining",
+    "@l_wrong_pin_attempts_remaining" : {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_wrong_puk_attempts_remaining": "Wrong PUK, {retries} attempt(s) remaining",
+    "@l_wrong_puk_attempts_remaining" : {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "s_fido_pin_protection": "FIDO PIN protection",
+    "l_fido_pin_protection_optional": "Optional FIDO PIN protection",
+    "l_enter_fido2_pin": "Enter the FIDO2 PIN for your YubiKey",
+    "l_optionally_set_a_pin": "Optionally set a PIN to protect access to your YubiKey\nRegister as a Security Key on websites",
+    "l_pin_blocked_reset": "PIN is blocked; factory reset the FIDO application",
+    "l_set_pin_first": "A PIN is required first",
+    "l_unlock_pin_first": "Unlock with PIN first",
+    "l_pin_soft_locked": "PIN has been blocked until the YubiKey is removed and reinserted",
+    "p_enter_current_pin_or_reset": "Enter your current PIN. If you don't know your PIN, you'll need to unblock it with the PUK or reset the YubiKey.",
+    "p_enter_current_puk_or_reset": "Enter your current PUK. If you don't know your PUK, you'll need to reset the YubiKey.",
+    "p_enter_new_fido2_pin": "Enter your new PIN. A PIN must be at least {length} characters long and may contain letters, numbers and special characters.",
+    "@p_enter_new_fido2_pin" : {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "s_pin_required": "PIN required",
+    "p_pin_required_desc": "The action you are about to perform requires the PIV PIN to be entered.",
+    "l_piv_pin_blocked": "Blocked, use PUK to reset",
+    "l_piv_pin_puk_blocked": "Blocked, factory reset needed",
+    "p_enter_new_piv_pin_puk": "Enter a new {name} to set. Must be 6-8 characters.",
+    "@p_enter_new_piv_pin_puk" : {
+        "placeholders": {
+            "name": {}
+        }
+    },
+
+    "@_passwords": {},
+    "s_password": "Password",
+    "s_manage_password": "Manage password",
+    "s_set_password": "Set password",
+    "s_password_set": "Password set",
+    "l_optional_password_protection": "Optional password protection",
+    "s_new_password": "New password",
+    "s_current_password": "Current password",
+    "s_confirm_password": "Confirm password",
+    "s_wrong_password": "Wrong password",
+    "s_remove_password": "Remove password",
+    "s_password_removed": "Password removed",
+    "s_remember_password": "Remember password",
+    "s_clear_saved_password": "Clear saved password",
+    "s_password_forgotten": "Password forgotten",
+    "l_keystore_unavailable": "OS Keystore unavailable",
+    "l_remember_pw_failed": "Failed to remember password",
+    "l_unlock_first": "Unlock with password first",
+    "l_enter_oath_pw": "Enter the OATH password for your YubiKey",
+    "p_enter_current_password_or_reset": "Enter your current password. If you don't know your password, you'll need to reset the YubiKey.",
+    "p_enter_new_password": "Enter your new password. A password may contain letters, numbers and special characters.",
+
+    "@_management_key": {},
+    "s_management_key": "Management key",
+    "s_current_management_key": "Current management key",
+    "s_new_management_key": "New management key",
+    "l_change_management_key": "Change management key",
+    "p_change_management_key_desc": "Change your management key. You can optionally choose to allow the PIN to be used instead of the management key.",
+    "l_management_key_changed": "Management key changed",
+    "l_default_key_used": "Default management key used",
+    "l_warning_default_key": "Warning: Default key used",
+    "s_protect_key": "Protect with PIN",
+    "l_pin_protected_key": "PIN can be used instead",
+    "l_wrong_key": "Wrong key",
+    "l_unlock_piv_management": "Unlock PIV management",
+    "p_unlock_piv_management_desc": "The action you are about to perform requires the PIV management key. Provide this key to unlock management functionality for this session.",
+
+    "@_oath_accounts": {},
+    "l_account": "Account: {label}",
+    "@l_account" : {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "s_accounts": "Accounts",
     "s_no_accounts": "No accounts",
-    "s_no_fingerprints": "No fingerprints",
+    "s_add_account": "Add account",
+    "s_add_accounts" : "Add account(s)",
+    "p_add_description" : "To scan a QR code, make sure the full code is visible on screen and press the button below. You can also drag a saved image from a folder onto this dialog. If you have the account credential details in writing, use the manual entry instead.",
+    "s_add_manually" : "Add manually",
+    "s_account_added": "Account added",
+    "l_account_add_failed": "Failed adding account: {message}",
+    "@l_account_add_failed" : {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_account_name_required": "Your account must have a name",
+    "l_name_already_exists": "This name already exists for the issuer",
+    "l_account_already_exists": "This account already exists on the YubiKey",
+    "l_invalid_character_issuer": "Invalid character: ':' is not allowed in issuer",
+    "l_select_accounts" : "Select account(s) to add to the YubiKey",
+    "s_pinned": "Pinned",
+    "s_pin_account": "Pin account",
+    "s_unpin_account": "Unpin account",
     "s_no_pinned_accounts": "No pinned accounts",
+    "l_pin_account_desc": "Keep your important accounts together",
+    "s_rename_account": "Rename account",
+    "l_rename_account_desc": "Edit the issuer/name of the account",
+    "s_account_renamed": "Account renamed",
+    "p_rename_will_change_account_displayed": "This will change how the account is displayed in the list.",
+    "s_delete_account": "Delete account",
+    "l_delete_account_desc": "Remove the account from your YubiKey",
+    "s_account_deleted": "Account deleted",
+    "p_warning_delete_account": "Warning! This action will delete the account from your YubiKey.",
+    "p_warning_disable_credential": "You will no longer be able to generate OTPs for this account. Make sure to first disable this credential from the website to avoid being locked out of your account.",
+    "s_account_name": "Account name",
+    "s_search_accounts": "Search accounts",
+    "l_accounts_used": "{used} of {capacity} accounts used",
+    "@l_accounts_used" : {
+        "placeholders": {
+            "used": {},
+            "capacity": {}
+        }
+    },
     "s_num_digits": "{num} digits",
-    "@s_num_digits": {
+    "@s_num_digits" : {
         "placeholders": {
             "num": {}
         }
     },
     "s_num_sec": "{num} sec",
-    "@s_num_sec": {
+    "@s_num_sec" : {
         "placeholders": {
             "num": {}
         }
     },
-    "s_open_src_licenses": "Open source licenses",
-    "s_passkey_deleted": "Passkey deleted",
+    "s_issuer_optional": "Issuer (optional)",
+    "s_counter_based": "Counter based",
+    "s_time_based": "Time based",
+    "l_copy_code_desc": "Easily paste the code into another app",
+    "s_calculate_code": "Calculate code",
+    "l_calculate_code_desc": "Get a new code from your YubiKey",
+
+    "@_fido_credentials": {},
+    "l_passkey": "Passkey: {label}",
+    "@l_passkey" : {
+        "placeholders": {
+            "label": {}
+        }
+    },
     "s_passkeys": "Passkeys",
-    "s_password": "Password",
-    "s_password_forgotten": "Password forgotten",
-    "s_password_removed": "Password removed",
-    "s_password_set": "Password set",
-    "s_permission_denied": "Permission denied",
-    "s_pin": "PIN",
-    "s_pin_account": "Pin account",
-    "s_pin_required": "PIN required",
-    "s_pin_set": "PIN set",
-    "s_pinned": "Pinned",
-    "s_piv": "PIV",
-    "s_please_wait": "Please wait…",
-    "s_privacy_policy": "Privacy policy",
-    "s_private_key": "Private key",
-    "s_private_key_generated": "Private key generated",
-    "s_protect_key": "Protect with PIN",
-    "s_puk": "PUK",
-    "s_puk_set": "PUK set",
-    "s_qr_scan": "Scan QR code",
-    "s_quit": "Quit",
-    "s_reconfiguring_yk": "Reconfiguring YubiKey…",
-    "s_remember_password": "Remember password",
-    "s_remove_icon_pack": "Remove icon pack",
-    "s_remove_password": "Remove password",
-    "s_rename_account": "Rename account",
+    "l_ready_to_use": "Ready to use",
+    "l_register_sk_on_websites": "Register as a Security Key on websites",
+    "l_no_discoverable_accounts": "No Passkeys stored",
+    "s_delete_passkey": "Delete Passkey",
+    "l_delete_passkey_desc": "Remove the Passkey from the YubiKey",
+    "s_passkey_deleted": "Passkey deleted",
+    "p_warning_delete_passkey": "This will delete the Passkey from your YubiKey.",
+
+    "@_fingerprints": {},
+    "l_fingerprint": "Fingerprint: {label}",
+    "@l_fingerprint" : {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "s_fingerprints": "Fingerprints",
+    "l_fingerprint_captured": "Fingerprint captured successfully!",
+    "s_fingerprint_added": "Fingerprint added",
+    "l_setting_name_failed": "Error setting name: {message}",
+    "@l_setting_name_failed" : {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "s_add_fingerprint": "Add fingerprint",
+    "l_fp_step_1_capture": "Step 1/2: Capture fingerprint",
+    "l_fp_step_2_name": "Step 2/2: Name fingerprint",
+    "s_delete_fingerprint": "Delete fingerprint",
+    "l_delete_fingerprint_desc": "Remove the fingerprint from the YubiKey",
+    "s_fingerprint_deleted": "Fingerprint deleted",
+    "p_warning_delete_fingerprint": "This will delete the fingerprint from your YubiKey.",
+    "s_no_fingerprints": "No fingerprints",
+    "l_set_pin_fingerprints": "Set a PIN to register fingerprints",
+    "l_no_fps_added": "No fingerprints have been added",
     "s_rename_fp": "Rename fingerprint",
-    "s_replace_icon_pack": "Replace icon pack",
-    "s_require_touch": "Require touch",
-    "s_reset": "Reset",
-    "s_reset_fido": "Reset FIDO",
-    "s_reset_oath": "Reset OATH",
-    "s_reset_piv": "Reset PIV",
-    "s_review_permissions": "Review permissions",
-    "s_run_diagnostics": "Run diagnostics",
-    "s_save": "Save",
-    "s_search_accounts": "Search accounts",
-    "s_secret_key": "Secret key",
-    "s_select_to_scan": "Select to scan",
-    "s_select_yk": "Select YubiKey",
-    "s_send_feedback": "Send us feedback",
+    "l_rename_fp_desc": "Change the label",
+    "s_fingerprint_renamed": "Fingerprint renamed",
+    "l_rename_fp_failed": "Error renaming: {message}",
+    "@l_rename_fp_failed" : {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_add_one_or_more_fps": "Add one or more (up to five) fingerprints",
+    "l_fingerprints_used": "{used}/5 fingerprints registered",
+    "@l_fingerprints_used": {
+        "placeholders": {
+            "used": {}
+        }
+    },
+    "p_press_fingerprint_begin": "Press your finger against the YubiKey to begin.",
+    "p_will_change_label_fp": "This will change the label of the fingerprint.",
+
+    "@_certificates": {},
+    "s_certificate": "Certificate",
+    "s_certificates": "Certificates",
+    "s_csr": "CSR",
+    "s_subject": "Subject",
+    "l_export_csr_file": "Save CSR to file",
+    "l_select_import_file": "Select file to import",
+    "l_export_certificate": "Export certificate",
+    "l_export_certificate_file": "Export certificate to file",
+    "l_export_certificate_desc": "Export the certificate to a file",
+    "l_certificate_exported": "Certificate exported",
+    "l_import_file": "Import file",
+    "l_import_desc": "Import a key and/or certificate",
+    "l_delete_certificate": "Delete certificate",
+    "l_delete_certificate_desc": "Remove the certificate from your YubiKey",
+    "s_issuer": "Issuer",
     "s_serial": "Serial",
-    "s_set_password": "Set password",
-    "s_set_pin": "Set PIN",
-    "s_settings": "Settings",
-    "s_setup": "Setup",
-    "s_show_hidden_devices": "Show hidden devices",
-    "s_show_window": "Show window",
-    "s_silence_nfc_sounds": "Silence NFC sounds",
+    "s_certificate_fingerprint": "Fingerprint",
+    "s_valid_from": "Valid from",
+    "s_valid_to": "Valid to",
+    "l_no_certificate": "No certificate loaded",
+    "l_key_no_certificate": "Key without certificate loaded",
+    "s_generate_key": "Generate key",
+    "l_generate_desc": "Generate a new certificate or CSR",
+    "p_generate_desc": "This will generate a new key on the YubiKey in PIV slot {slot}. The public key will be embedded into a self-signed certificate stored on the YubiKey, or in a certificate signing request (CSR) saved to file.",
+    "@p_generate_desc" : {
+        "placeholders": {
+            "slot": {}
+        }
+    },
+    "l_generating_private_key": "Generating private key\u2026",
+    "s_private_key_generated": "Private key generated",
+    "p_warning_delete_certificate": "Warning! This action will delete the certificate from your YubiKey.",
+    "q_delete_certificate_confirm": "Delete the certficate in PIV slot {slot}?",
+    "@q_delete_certificate_confirm" : {
+        "placeholders": {
+            "slot": {}
+        }
+    },
+    "l_certificate_deleted": "Certificate deleted",
+    "p_password_protected_file": "The selected file is password protected. Enter the password to proceed.",
+    "p_import_items_desc": "The following items will be imported into PIV slot {slot}.",
+    "@p_import_items_desc" : {
+        "placeholders": {
+            "slot": {}
+        }
+    },
+
+    "@_piv_slots": {},
+    "s_slot_display_name": "{name} ({hexid})",
+    "@s_slot_display_name" : {
+        "placeholders": {
+            "name": {},
+            "hexid": {}
+        }
+    },
     "s_slot_9a": "Authentication",
     "s_slot_9c": "Digital Signature",
     "s_slot_9d": "Key Management",
     "s_slot_9e": "Card Authentication",
-    "s_slot_display_name": "{name} ({hexid})",
-    "@s_slot_display_name": {
+
+    "@_permissions": {},
+    "s_enable_nfc": "Enable NFC",
+    "s_permission_denied": "Permission denied",
+    "l_elevating_permissions": "Elevating permissions\u2026",
+    "s_review_permissions": "Review permissions",
+    "p_elevated_permissions_required": "Managing this device requires elevated privileges.",
+    "p_webauthn_elevated_permissions_required": "WebAuthn management requires elevated privileges.",
+    "p_need_camera_permission": "Yubico Authenticator needs Camera permissions for scanning QR codes.",
+
+    "@_qr_codes": {},
+    "s_qr_scan": "Scan QR code",
+    "l_qr_scanned": "Scanned QR code",
+    "l_invalid_qr": "Invalid QR code",
+    "l_qr_not_found": "No QR code found",
+    "l_qr_not_read": "Failed reading QR code: {message}",
+    "@l_qr_not_read" : {
         "placeholders": {
-            "hexid": {},
-            "name": {}
+            "message": {}
         }
     },
-    "s_sn_serial": "S/N: {serial}",
-    "@s_sn_serial": {
+    "l_point_camera_scan": "Point your camera at a QR code to scan it",
+    "q_want_to_scan": "Would like to scan?",
+    "q_no_qr": "No QR code?",
+    "s_enter_manually": "Enter manually",
+
+    "@_factory_reset": {},
+    "s_reset": "Reset",
+    "s_factory_reset": "Factory reset",
+    "l_factory_reset_this_app": "Factory reset this application",
+    "s_reset_oath": "Reset OATH",
+    "l_oath_application_reset": "OATH application reset",
+    "s_reset_fido": "Reset FIDO",
+    "l_fido_app_reset": "FIDO application reset",
+    "l_press_reset_to_begin": "Press reset to begin\u2026",
+    "l_reset_failed": "Error performing reset: {message}",
+    "@l_reset_failed" : {
         "placeholders": {
-            "serial": {}
+            "message": {}
         }
     },
-    "s_subject": "Subject",
-    "s_system_default": "System default",
-    "s_terms_of_use": "Terms of use",
-    "s_time_based": "Time based",
-    "s_toggle_applications": "Toggle applications",
-    "s_touch_required": "Touch required",
-    "s_troubleshooting": "Troubleshooting",
-    "s_unblock_pin": "Unblock PIN",
-    "s_unknown_device": "Unrecognized device",
-    "s_unknown_type": "Unknown type",
-    "s_unlock": "Unlock",
-    "s_unpin_account": "Unpin account",
-    "s_unsupported_yk": "Unsupported YubiKey",
-    "s_usb": "USB",
+    "s_reset_piv": "Reset PIV",
+    "l_piv_app_reset": "PIV application reset",
+    "p_warning_factory_reset": "Warning! This will irrevocably delete all OATH TOTP/HOTP accounts from your YubiKey.",
+    "p_warning_disable_credentials": "Your OATH credentials, as well as any password set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
+    "p_warning_deletes_accounts": "Warning! This will irrevocably delete all U2F and FIDO2 accounts from your YubiKey.",
+    "p_warning_disable_accounts": "Your credentials, as well as any PIN set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
+    "p_warning_piv_reset": "Warning! All data stored for PIV will be irrevocably deleted from your YubiKey.",
+    "p_warning_piv_reset_desc": "This includes private keys and certificates. Your PIN, PUK, and management key will be reset to their factory default values.",
+
+    "@_copy_to_clipboard": {},
+    "l_copy_to_clipboard": "Copy to clipboard",
+    "s_code_copied": "Code copied",
+    "l_code_copied_clipboard": "Code copied to clipboard",
+    "s_copy_log": "Copy log",
+    "l_log_copied": "Log copied to clipboard",
+    "l_diagnostics_copied": "Diagnostic data copied to clipboard",
+    "p_target_copied_clipboard": "{label} copied to clipboard.",
+    "@p_target_copied_clipboard" : {
+        "placeholders": {
+            "label": {}
+        }
+    },
+
+    "@_custom_icons": {},
+    "s_custom_icons": "Custom icons",
+    "l_set_icons_for_accounts": "Set icons for accounts",
+    "p_custom_icons_description": "Icon packs can make your accounts more easily distinguishable with familiar logos and colors.",
+    "s_replace_icon_pack": "Replace icon pack",
+    "l_loading_icon_pack": "Loading icon pack\u2026",
+    "s_load_icon_pack": "Load icon pack",
+    "s_remove_icon_pack": "Remove icon pack",
+    "l_icon_pack_removed": "Icon pack removed",
+    "l_remove_icon_pack_failed": "Error removing icon pack",
+    "s_choose_icon_pack": "Choose icon pack",
+    "l_icon_pack_imported": "Icon pack imported",
+    "l_import_icon_pack_failed": "Error importing icon pack: {message}",
+    "@l_import_icon_pack_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_invalid_icon_pack": "Invalid icon pack",
+    "l_icon_pack_copy_failed": "Failed to copy icon pack files",
+
+    "@_android_settings": {},
+    "s_nfc_options": "NFC options",
+    "l_on_yk_nfc_tap": "On YubiKey NFC tap",
+    "l_launch_ya": "Launch Yubico Authenticator",
+    "l_copy_otp_clipboard": "Copy OTP to clipboard",
+    "l_launch_and_copy_otp": "Launch app and copy OTP",
+    "l_kbd_layout_for_static": "Keyboard layout (for static password)",
+    "s_choose_kbd_layout": "Choose keyboard layout",
+    "l_bypass_touch_requirement": "Bypass touch requirement",
+    "l_bypass_touch_requirement_on": "Accounts that require touch are automatically shown over NFC",
+    "l_bypass_touch_requirement_off": "Accounts that require touch need an additional tap over NFC",
+    "s_silence_nfc_sounds": "Silence NFC sounds",
+    "l_silence_nfc_sounds_on": "No sounds will be played on NFC tap",
+    "l_silence_nfc_sounds_off": "Sound will play on NFC tap",
     "s_usb_options": "USB options",
-    "s_valid_from": "Valid from",
-    "s_valid_to": "Valid to",
-    "s_webauthn": "WebAuthn",
-    "s_wrong_password": "Wrong password",
-    "s_yk_inaccessible": "Device inaccessible",
-    "s_yk_information": "YubiKey information",
-    "s_yk_not_recognized": "Device not recognized"
+    "l_launch_app_on_usb": "Launch when YubiKey is connected",
+    "l_launch_app_on_usb_on": "This prevents other apps from using the YubiKey over USB",
+    "l_launch_app_on_usb_off": "Other apps can use the YubiKey over USB",
+    "s_allow_screenshots": "Allow screenshots",
+
+    "s_nfc_dialog_tap_key": "Tap your key",
+    "s_nfc_dialog_operation_success": "Success",
+    "s_nfc_dialog_operation_failed": "Failed",
+
+    "s_nfc_dialog_oath_reset": "Action: reset OATH applet",
+    "s_nfc_dialog_oath_unlock": "Action: unlock OATH applet",
+    "s_nfc_dialog_oath_set_password": "Action: set OATH password",
+    "s_nfc_dialog_oath_unset_password": "Action: remove OATH password",
+    "s_nfc_dialog_oath_add_account": "Action: add new account",
+    "s_nfc_dialog_oath_rename_account": "Action: rename account",
+    "s_nfc_dialog_oath_delete_account": "Action: delete account",
+    "s_nfc_dialog_oath_calculate_code": "Action: calculate OATH code",
+    "s_nfc_dialog_oath_failure": "OATH operation failed",
+    "s_nfc_dialog_oath_add_multiple_accounts": "Action: add multiple accounts",
+
+    "@_eof": {}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "en",
-
     "@_readme": {
         "notes": [
             "All strings start with a Captial letter.",
@@ -8,593 +7,543 @@
             "Run check_strings.py on the .arb file to detect problems, tweak @_lint_rules as needed per language."
         ],
         "prefixes": {
-            "s_": "A single, or few words. Should be short enough to display on a button, or a header.",
             "l_": "A single line, can be wrapped. Should not be more than one sentence, and not end with a period.",
             "p_": "One or more full sentences, with proper punctuation.",
-            "q_": "A question, ending in question mark."
+            "q_": "A question, ending in question mark.",
+            "s_": "A single, or few words. Should be short enough to display on a button, or a header."
         }
     },
-
     "@_lint_rules": {
-        "s_max_words": 4,
-        "s_max_length": 32
+        "s_max_length": 32,
+        "s_max_words": 4
     },
-
     "app_name": "Yubico Authenticator",
-
-    "s_save": "Save",
-    "s_cancel": "Cancel",
-    "s_close": "Close",
-    "s_delete": "Delete",
-    "s_quit": "Quit",
-    "s_unlock": "Unlock",
-    "s_calculate": "Calculate",
-    "s_import": "Import",
-    "s_label": "Label",
-    "s_name": "Name",
-    "s_usb": "USB",
-    "s_nfc": "NFC",
-    "s_show_window": "Show window",
-    "s_hide_window": "Hide window",
-    "q_rename_target": "Rename {label}?",
-    "@q_rename_target" : {
+    "l_account": "Account: {label}",
+    "@l_account": {
         "placeholders": {
             "label": {}
         }
     },
-    "l_bullet": "• {item}",
-    "@l_bullet" : {
+    "l_account_add_failed": "Failed adding account: {message}",
+    "@l_account_add_failed": {
         "placeholders": {
-            "item": {}
+            "message": {}
         }
     },
-    "s_definition": "{item}:",
-    "@s_definition" : {
+    "l_account_already_exists": "This account already exists on the YubiKey",
+    "l_account_name_required": "Your account must have a name",
+    "l_accounts_used": "{used} of {capacity} accounts used",
+    "@l_accounts_used": {
         "placeholders": {
-            "item": {}
+            "capacity": {},
+            "used": {}
         }
     },
-
-    "s_about": "About",
-    "s_appearance": "Appearance",
-    "s_authenticator": "Authenticator",
-    "s_actions": "Actions",
-    "s_manage": "Manage",
-    "s_setup": "Setup",
-    "s_settings": "Settings",
-    "s_piv": "PIV",
-    "s_webauthn": "WebAuthn",
-    "s_help_and_about": "Help and about",
-    "s_help_and_feedback": "Help and feedback",
-    "s_send_feedback": "Send us feedback",
-    "s_i_need_help": "I need help",
-    "s_troubleshooting": "Troubleshooting",
-    "s_terms_of_use": "Terms of use",
-    "s_privacy_policy": "Privacy policy",
-    "s_open_src_licenses": "Open source licenses",
-    "s_configure_yk": "Configure YubiKey",
-    "s_please_wait": "Please wait\u2026",
-    "s_secret_key": "Secret key",
-    "s_private_key": "Private key",
-    "s_invalid_length": "Invalid length",
-    "s_require_touch": "Require touch",
-    "q_have_account_info": "Have account info?",
-    "s_run_diagnostics": "Run diagnostics",
-    "s_log_level": "Log level: {level}",
-    "@s_log_level": {
-        "placeholders": {
-            "level": {}
-        }
-    },
-    "s_character_count": "Character count",
-    "s_learn_more": "Learn\u00a0more",
-
-    "@_language": {},
-    "s_language": "Language",
-    "l_enable_community_translations": "Enable community translations",
-    "p_community_translations_desc": "These translations are provided and maintained by the community. They may contain errors or be incomplete.",
-
-    "@_theme": {},
-    "s_app_theme": "App theme",
-    "s_choose_app_theme": "Choose app theme",
-    "s_system_default": "System default",
-    "s_light_mode": "Light mode",
-    "s_dark_mode": "Dark mode",
-
-    "@_yubikey_selection": {},
-    "s_yk_information": "YubiKey information",
-    "s_select_yk": "Select YubiKey",
-    "s_select_to_scan": "Select to scan",
-    "s_hide_device": "Hide device",
-    "s_show_hidden_devices": "Show hidden devices",
-    "s_sn_serial": "S/N: {serial}",
-    "@s_sn_serial" : {
-        "placeholders": {
-            "serial": {}
-        }
-    },
-    "s_fw_version": "F/W: {version}",
-    "@s_fw_version" : {
-        "placeholders": {
-            "version": {}
-        }
-    },
-
-    "@_yubikey_interactions": {},
-    "l_insert_yk": "Insert your YubiKey",
-    "l_insert_or_tap_yk": "Insert or tap a YubiKey",
-    "l_unplug_yk": "Unplug your YubiKey",
-    "l_reinsert_yk": "Reinsert your YubiKey",
-    "l_place_on_nfc_reader": "Place your YubiKey on the NFC reader",
-    "l_replace_yk_on_reader": "Place your YubiKey back on the reader",
-    "l_remove_yk_from_reader": "Remove your YubiKey from the NFC reader",
-    "p_try_reinsert_yk": "Try to remove and reinsert your YubiKey.",
-    "s_touch_required": "Touch required",
-    "l_touch_button_now": "Touch the button on your YubiKey now",
-    "l_keep_touching_yk": "Keep touching your YubiKey repeatedly\u2026",
-
-    "@_app_configuration": {},
-    "s_toggle_applications": "Toggle applications",
-    "l_min_one_interface": "At least one interface must be enabled",
-    "s_reconfiguring_yk": "Reconfiguring YubiKey\u2026",
-    "s_config_updated": "Configuration updated",
-    "l_config_updated_reinsert": "Configuration updated, remove and reinsert your YubiKey",
-    "s_app_not_supported": "Application not supported",
-    "l_app_not_supported_on_yk": "The used YubiKey does not support '{app}' application",
-    "@l_app_not_supported_on_yk" : {
+    "l_add_one_or_more_fps": "Add one or more (up to five) fingerprints",
+    "l_app_disabled_desc": "Enable the '{app}' application on your YubiKey to access",
+    "@l_app_disabled_desc": {
         "placeholders": {
             "app": {}
         }
     },
     "l_app_not_supported_desc": "This application is not supported",
-    "s_app_disabled": "Application disabled",
-    "l_app_disabled_desc": "Enable the '{app}' application on your YubiKey to access",
-    "@l_app_disabled_desc" : {
+    "l_app_not_supported_on_yk": "The used YubiKey does not support '{app}' application",
+    "@l_app_not_supported_on_yk": {
         "placeholders": {
             "app": {}
         }
     },
-    "s_fido_disabled": "FIDO2 disabled",
-    "l_webauthn_req_fido2": "WebAuthn requires the FIDO2 application to be enabled on your YubiKey",
-
-    "@_connectivity_issues": {},
-    "l_helper_not_responding": "The Helper process isn't responding",
-    "l_yk_no_access": "This YubiKey cannot be accessed",
-    "s_yk_inaccessible": "Device inaccessible",
-    "l_open_connection_failed": "Failed to open connection",
+    "l_attempts_remaining": "{retries} attempt(s) remaining",
+    "@l_attempts_remaining": {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_bullet": "• {item}",
+    "@l_bullet": {
+        "placeholders": {
+            "item": {}
+        }
+    },
+    "l_bypass_touch_requirement": "Bypass touch requirement",
+    "l_bypass_touch_requirement_off": "Accounts that require touch need an additional tap over NFC",
+    "l_bypass_touch_requirement_on": "Accounts that require touch are automatically shown over NFC",
+    "l_calculate_code_desc": "Get a new code from your YubiKey",
     "l_ccid_connection_failed": "Failed to open smart card connection",
-    "p_ccid_service_unavailable": "Make sure your smart card service is functioning.",
-    "p_pcscd_unavailable": "Make sure pcscd is installed and running.",
-    "l_no_yk_present": "No YubiKey present",
-    "s_unknown_type": "Unknown type",
-    "s_unknown_device": "Unrecognized device",
-    "s_unsupported_yk": "Unsupported YubiKey",
-    "s_yk_not_recognized": "Device not recognized",
-
-    "@_general_errors": {},
+    "l_certificate_deleted": "Certificate deleted",
+    "l_certificate_exported": "Certificate exported",
+    "l_change_management_key": "Change management key",
+    "l_code_copied_clipboard": "Code copied to clipboard",
+    "l_config_updated_reinsert": "Configuration updated, remove and reinsert your YubiKey",
+    "l_copy_code_desc": "Easily paste the code into another app",
+    "l_copy_otp_clipboard": "Copy OTP to clipboard",
+    "l_copy_to_clipboard": "Copy to clipboard",
+    "l_default_key_used": "Default management key used",
+    "l_delete_account_desc": "Remove the account from your YubiKey",
+    "l_delete_certificate": "Delete certificate",
+    "l_delete_certificate_desc": "Remove the certificate from your YubiKey",
+    "l_delete_fingerprint_desc": "Remove the fingerprint from the YubiKey",
+    "l_delete_passkey_desc": "Remove the Passkey from the YubiKey",
+    "l_diagnostics_copied": "Diagnostic data copied to clipboard",
+    "l_elevating_permissions": "Elevating permissions…",
+    "l_enable_community_translations": "Enable community translations",
+    "l_enter_fido2_pin": "Enter the FIDO2 PIN for your YubiKey",
+    "l_enter_oath_pw": "Enter the OATH password for your YubiKey",
     "l_error_occured": "An error has occured",
-    "s_application_error": "Application error",
-    "l_import_error": "Import error",
+    "l_export_certificate": "Export certificate",
+    "l_export_certificate_desc": "Export the certificate to a file",
+    "l_export_certificate_file": "Export certificate to file",
+    "l_export_csr_file": "Save CSR to file",
+    "l_factory_reset_this_app": "Factory reset this application",
+    "l_fido_app_reset": "FIDO application reset",
+    "l_fido_pin_protection_optional": "Optional FIDO PIN protection",
     "l_file_not_found": "File not found",
     "l_file_too_big": "File size too big",
     "l_filesystem_error": "File system operation error",
-
-    "@_pins": {},
-    "s_pin": "PIN",
-    "s_puk": "PUK",
-    "s_set_pin": "Set PIN",
-    "s_change_pin": "Change PIN",
-    "s_change_puk": "Change PUK",
-    "s_current_pin": "Current PIN",
-    "s_current_puk": "Current PUK",
-    "s_new_pin": "New PIN",
-    "s_new_puk": "New PUK",
-    "s_confirm_pin": "Confirm PIN",
-    "s_confirm_puk": "Confirm PUK",
-    "s_unblock_pin": "Unblock PIN",
-    "l_new_pin_len": "New PIN must be at least {length} characters",
-    "@l_new_pin_len" : {
-        "placeholders": {
-            "length": {}
-        }
-    },
-    "s_pin_set": "PIN set",
-    "s_puk_set": "PUK set",
-    "l_set_pin_failed": "Failed to set PIN: {message}",
-    "@l_set_pin_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_attempts_remaining": "{retries} attempt(s) remaining",
-    "@l_attempts_remaining" : {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "l_wrong_pin_attempts_remaining": "Wrong PIN, {retries} attempt(s) remaining",
-    "@l_wrong_pin_attempts_remaining" : {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "l_wrong_puk_attempts_remaining": "Wrong PUK, {retries} attempt(s) remaining",
-    "@l_wrong_puk_attempts_remaining" : {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "s_fido_pin_protection": "FIDO PIN protection",
-    "l_fido_pin_protection_optional": "Optional FIDO PIN protection",
-    "l_enter_fido2_pin": "Enter the FIDO2 PIN for your YubiKey",
-    "l_optionally_set_a_pin": "Optionally set a PIN to protect access to your YubiKey\nRegister as a Security Key on websites",
-    "l_pin_blocked_reset": "PIN is blocked; factory reset the FIDO application",
-    "l_set_pin_first": "A PIN is required first",
-    "l_unlock_pin_first": "Unlock with PIN first",
-    "l_pin_soft_locked": "PIN has been blocked until the YubiKey is removed and reinserted",
-    "p_enter_current_pin_or_reset": "Enter your current PIN. If you don't know your PIN, you'll need to unblock it with the PUK or reset the YubiKey.",
-    "p_enter_current_puk_or_reset": "Enter your current PUK. If you don't know your PUK, you'll need to reset the YubiKey.",
-    "p_enter_new_fido2_pin": "Enter your new PIN. A PIN must be at least {length} characters long and may contain letters, numbers and special characters.",
-    "@p_enter_new_fido2_pin" : {
-        "placeholders": {
-            "length": {}
-        }
-    },
-    "s_pin_required": "PIN required",
-    "p_pin_required_desc": "The action you are about to perform requires the PIV PIN to be entered.",
-    "l_piv_pin_blocked": "Blocked, use PUK to reset",
-    "l_piv_pin_puk_blocked": "Blocked, factory reset needed",
-    "p_enter_new_piv_pin_puk": "Enter a new {name} to set. Must be 6-8 characters.",
-    "@p_enter_new_piv_pin_puk" : {
-        "placeholders": {
-            "name": {}
-        }
-    },
-
-    "@_passwords": {},
-    "s_password": "Password",
-    "s_manage_password": "Manage password",
-    "s_set_password": "Set password",
-    "s_password_set": "Password set",
-    "l_optional_password_protection": "Optional password protection",
-    "s_new_password": "New password",
-    "s_current_password": "Current password",
-    "s_confirm_password": "Confirm password",
-    "s_wrong_password": "Wrong password",
-    "s_remove_password": "Remove password",
-    "s_password_removed": "Password removed",
-    "s_remember_password": "Remember password",
-    "s_clear_saved_password": "Clear saved password",
-    "s_password_forgotten": "Password forgotten",
-    "l_keystore_unavailable": "OS Keystore unavailable",
-    "l_remember_pw_failed": "Failed to remember password",
-    "l_unlock_first": "Unlock with password first",
-    "l_enter_oath_pw": "Enter the OATH password for your YubiKey",
-    "p_enter_current_password_or_reset": "Enter your current password. If you don't know your password, you'll need to reset the YubiKey.",
-    "p_enter_new_password": "Enter your new password. A password may contain letters, numbers and special characters.",
-
-    "@_management_key": {},
-    "s_management_key": "Management key",
-    "s_current_management_key": "Current management key",
-    "s_new_management_key": "New management key",
-    "l_change_management_key": "Change management key",
-    "p_change_management_key_desc": "Change your management key. You can optionally choose to allow the PIN to be used instead of the management key.",
-    "l_management_key_changed": "Management key changed",
-    "l_default_key_used": "Default management key used",
-    "l_warning_default_key": "Warning: Default key used",
-    "s_protect_key": "Protect with PIN",
-    "l_pin_protected_key": "PIN can be used instead",
-    "l_wrong_key": "Wrong key",
-    "l_unlock_piv_management": "Unlock PIV management",
-    "p_unlock_piv_management_desc": "The action you are about to perform requires the PIV management key. Provide this key to unlock management functionality for this session.",
-
-    "@_oath_accounts": {},
-    "l_account": "Account: {label}",
-    "@l_account" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "s_accounts": "Accounts",
-    "s_no_accounts": "No accounts",
-    "s_add_account": "Add account",
-    "s_add_accounts" : "Add account(s)",
-    "p_add_description" : "To scan a QR code, make sure the full code is visible on screen and press the button below. You can also drag a saved image from a folder onto this dialog. If you have the account credential details in writing, use the manual entry instead.",
-    "s_add_manually" : "Add manually",
-    "s_account_added": "Account added",
-    "l_account_add_failed": "Failed adding account: {message}",
-    "@l_account_add_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_account_name_required": "Your account must have a name",
-    "l_name_already_exists": "This name already exists for the issuer",
-    "l_account_already_exists": "This account already exists on the YubiKey",
-    "l_invalid_character_issuer": "Invalid character: ':' is not allowed in issuer",
-    "l_select_accounts" : "Select account(s) to add to the YubiKey",
-    "s_pinned": "Pinned",
-    "s_pin_account": "Pin account",
-    "s_unpin_account": "Unpin account",
-    "s_no_pinned_accounts": "No pinned accounts",
-    "l_pin_account_desc": "Keep your important accounts together",
-    "s_rename_account": "Rename account",
-    "l_rename_account_desc": "Edit the issuer/name of the account",
-    "s_account_renamed": "Account renamed",
-    "p_rename_will_change_account_displayed": "This will change how the account is displayed in the list.",
-    "s_delete_account": "Delete account",
-    "l_delete_account_desc": "Remove the account from your YubiKey",
-    "s_account_deleted": "Account deleted",
-    "p_warning_delete_account": "Warning! This action will delete the account from your YubiKey.",
-    "p_warning_disable_credential": "You will no longer be able to generate OTPs for this account. Make sure to first disable this credential from the website to avoid being locked out of your account.",
-    "s_account_name": "Account name",
-    "s_search_accounts": "Search accounts",
-    "l_accounts_used": "{used} of {capacity} accounts used",
-    "@l_accounts_used" : {
-        "placeholders": {
-            "used": {},
-            "capacity": {}
-        }
-    },
-    "s_num_digits": "{num} digits",
-    "@s_num_digits" : {
-        "placeholders": {
-            "num": {}
-        }
-    },
-    "s_num_sec": "{num} sec",
-    "@s_num_sec" : {
-        "placeholders": {
-            "num": {}
-        }
-    },
-    "s_issuer_optional": "Issuer (optional)",
-    "s_counter_based": "Counter based",
-    "s_time_based": "Time based",
-    "l_copy_code_desc": "Easily paste the code into another app",
-    "s_calculate_code": "Calculate code",
-    "l_calculate_code_desc": "Get a new code from your YubiKey",
-
-    "@_fido_credentials": {},
-    "l_passkey": "Passkey: {label}",
-    "@l_passkey" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "s_passkeys": "Passkeys",
-    "l_ready_to_use": "Ready to use",
-    "l_register_sk_on_websites": "Register as a Security Key on websites",
-    "l_no_discoverable_accounts": "No Passkeys stored",
-    "s_delete_passkey": "Delete Passkey",
-    "l_delete_passkey_desc": "Remove the Passkey from the YubiKey",
-    "s_passkey_deleted": "Passkey deleted",
-    "p_warning_delete_passkey": "This will delete the Passkey from your YubiKey.",
-
-    "@_fingerprints": {},
     "l_fingerprint": "Fingerprint: {label}",
-    "@l_fingerprint" : {
+    "@l_fingerprint": {
         "placeholders": {
             "label": {}
         }
     },
-    "s_fingerprints": "Fingerprints",
     "l_fingerprint_captured": "Fingerprint captured successfully!",
-    "s_fingerprint_added": "Fingerprint added",
-    "l_setting_name_failed": "Error setting name: {message}",
-    "@l_setting_name_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "s_add_fingerprint": "Add fingerprint",
-    "l_fp_step_1_capture": "Step 1/2: Capture fingerprint",
-    "l_fp_step_2_name": "Step 2/2: Name fingerprint",
-    "s_delete_fingerprint": "Delete fingerprint",
-    "l_delete_fingerprint_desc": "Remove the fingerprint from the YubiKey",
-    "s_fingerprint_deleted": "Fingerprint deleted",
-    "p_warning_delete_fingerprint": "This will delete the fingerprint from your YubiKey.",
-    "s_no_fingerprints": "No fingerprints",
-    "l_set_pin_fingerprints": "Set a PIN to register fingerprints",
-    "l_no_fps_added": "No fingerprints have been added",
-    "s_rename_fp": "Rename fingerprint",
-    "l_rename_fp_desc": "Change the label",
-    "s_fingerprint_renamed": "Fingerprint renamed",
-    "l_rename_fp_failed": "Error renaming: {message}",
-    "@l_rename_fp_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_add_one_or_more_fps": "Add one or more (up to five) fingerprints",
     "l_fingerprints_used": "{used}/5 fingerprints registered",
     "@l_fingerprints_used": {
         "placeholders": {
             "used": {}
         }
     },
-    "p_press_fingerprint_begin": "Press your finger against the YubiKey to begin.",
-    "p_will_change_label_fp": "This will change the label of the fingerprint.",
-
-    "@_certificates": {},
-    "s_certificate": "Certificate",
-    "s_certificates": "Certificates",
-    "s_csr": "CSR",
-    "s_subject": "Subject",
-    "l_export_csr_file": "Save CSR to file",
-    "l_select_import_file": "Select file to import",
-    "l_export_certificate": "Export certificate",
-    "l_export_certificate_file": "Export certificate to file",
-    "l_export_certificate_desc": "Export the certificate to a file",
-    "l_certificate_exported": "Certificate exported",
-    "l_import_file": "Import file",
-    "l_import_desc": "Import a key and/or certificate",
-    "l_delete_certificate": "Delete certificate",
-    "l_delete_certificate_desc": "Remove the certificate from your YubiKey",
-    "s_issuer": "Issuer",
-    "s_serial": "Serial",
-    "s_certificate_fingerprint": "Fingerprint",
-    "s_valid_from": "Valid from",
-    "s_valid_to": "Valid to",
-    "l_no_certificate": "No certificate loaded",
-    "l_key_no_certificate": "Key without certificate loaded",
-    "s_generate_key": "Generate key",
+    "l_fp_step_1_capture": "Step 1/2: Capture fingerprint",
+    "l_fp_step_2_name": "Step 2/2: Name fingerprint",
     "l_generate_desc": "Generate a new certificate or CSR",
-    "p_generate_desc": "This will generate a new key on the YubiKey in PIV slot {slot}. The public key will be embedded into a self-signed certificate stored on the YubiKey, or in a certificate signing request (CSR) saved to file.",
-    "@p_generate_desc" : {
-        "placeholders": {
-            "slot": {}
-        }
-    },
-    "l_generating_private_key": "Generating private key\u2026",
-    "s_private_key_generated": "Private key generated",
-    "p_warning_delete_certificate": "Warning! This action will delete the certificate from your YubiKey.",
-    "q_delete_certificate_confirm": "Delete the certficate in PIV slot {slot}?",
-    "@q_delete_certificate_confirm" : {
-        "placeholders": {
-            "slot": {}
-        }
-    },
-    "l_certificate_deleted": "Certificate deleted",
-    "p_password_protected_file": "The selected file is password protected. Enter the password to proceed.",
-    "p_import_items_desc": "The following items will be imported into PIV slot {slot}.",
-    "@p_import_items_desc" : {
-        "placeholders": {
-            "slot": {}
-        }
-    },
-
-    "@_piv_slots": {},
-    "s_slot_display_name": "{name} ({hexid})",
-    "@s_slot_display_name" : {
-        "placeholders": {
-            "name": {},
-            "hexid": {}
-        }
-    },
-    "s_slot_9a": "Authentication",
-    "s_slot_9c": "Digital Signature",
-    "s_slot_9d": "Key Management",
-    "s_slot_9e": "Card Authentication",
-
-    "@_permissions": {},
-    "s_enable_nfc": "Enable NFC",
-    "s_permission_denied": "Permission denied",
-    "l_elevating_permissions": "Elevating permissions\u2026",
-    "s_review_permissions": "Review permissions",
-    "p_elevated_permissions_required": "Managing this device requires elevated privileges.",
-    "p_webauthn_elevated_permissions_required": "WebAuthn management requires elevated privileges.",
-    "p_need_camera_permission": "Yubico Authenticator needs Camera permissions for scanning QR codes.",
-
-    "@_qr_codes": {},
-    "s_qr_scan": "Scan QR code",
-    "l_qr_scanned": "Scanned QR code",
-    "l_invalid_qr": "Invalid QR code",
-    "l_qr_not_found": "No QR code found",
-    "l_qr_not_read": "Failed reading QR code: {message}",
-    "@l_qr_not_read" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_point_camera_scan": "Point your camera at a QR code to scan it",
-    "q_want_to_scan": "Would like to scan?",
-    "q_no_qr": "No QR code?",
-    "s_enter_manually": "Enter manually",
-
-    "@_factory_reset": {},
-    "s_reset": "Reset",
-    "s_factory_reset": "Factory reset",
-    "l_factory_reset_this_app": "Factory reset this application",
-    "s_reset_oath": "Reset OATH",
-    "l_oath_application_reset": "OATH application reset",
-    "s_reset_fido": "Reset FIDO",
-    "l_fido_app_reset": "FIDO application reset",
-    "l_press_reset_to_begin": "Press reset to begin\u2026",
-    "l_reset_failed": "Error performing reset: {message}",
-    "@l_reset_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "s_reset_piv": "Reset PIV",
-    "l_piv_app_reset": "PIV application reset",
-    "p_warning_factory_reset": "Warning! This will irrevocably delete all OATH TOTP/HOTP accounts from your YubiKey.",
-    "p_warning_disable_credentials": "Your OATH credentials, as well as any password set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
-    "p_warning_deletes_accounts": "Warning! This will irrevocably delete all U2F and FIDO2 accounts from your YubiKey.",
-    "p_warning_disable_accounts": "Your credentials, as well as any PIN set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
-    "p_warning_piv_reset": "Warning! All data stored for PIV will be irrevocably deleted from your YubiKey.",
-    "p_warning_piv_reset_desc": "This includes private keys and certificates. Your PIN, PUK, and management key will be reset to their factory default values.",
-
-    "@_copy_to_clipboard": {},
-    "l_copy_to_clipboard": "Copy to clipboard",
-    "s_code_copied": "Code copied",
-    "l_code_copied_clipboard": "Code copied to clipboard",
-    "s_copy_log": "Copy log",
-    "l_log_copied": "Log copied to clipboard",
-    "l_diagnostics_copied": "Diagnostic data copied to clipboard",
-    "p_target_copied_clipboard": "{label} copied to clipboard.",
-    "@p_target_copied_clipboard" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-
-    "@_custom_icons": {},
-    "s_custom_icons": "Custom icons",
-    "l_set_icons_for_accounts": "Set icons for accounts",
-    "p_custom_icons_description": "Icon packs can make your accounts more easily distinguishable with familiar logos and colors.",
-    "s_replace_icon_pack": "Replace icon pack",
-    "l_loading_icon_pack": "Loading icon pack\u2026",
-    "s_load_icon_pack": "Load icon pack",
-    "s_remove_icon_pack": "Remove icon pack",
-    "l_icon_pack_removed": "Icon pack removed",
-    "l_remove_icon_pack_failed": "Error removing icon pack",
-    "s_choose_icon_pack": "Choose icon pack",
+    "l_generating_private_key": "Generating private key…",
+    "l_helper_not_responding": "The Helper process isn't responding",
+    "l_icon_pack_copy_failed": "Failed to copy icon pack files",
     "l_icon_pack_imported": "Icon pack imported",
+    "l_icon_pack_removed": "Icon pack removed",
+    "l_import_desc": "Import a key and/or certificate",
+    "l_import_error": "Import error",
+    "l_import_file": "Import file",
     "l_import_icon_pack_failed": "Error importing icon pack: {message}",
     "@l_import_icon_pack_failed": {
         "placeholders": {
             "message": {}
         }
     },
+    "l_insert_or_tap_yk": "Insert or tap a YubiKey",
+    "l_insert_yk": "Insert your YubiKey",
+    "l_invalid_character_issuer": "Invalid character: ':' is not allowed in issuer",
     "l_invalid_icon_pack": "Invalid icon pack",
-    "l_icon_pack_copy_failed": "Failed to copy icon pack files",
-
-    "@_android_settings": {},
-    "s_nfc_options": "NFC options",
-    "l_on_yk_nfc_tap": "On YubiKey NFC tap",
-    "l_launch_ya": "Launch Yubico Authenticator",
-    "l_copy_otp_clipboard": "Copy OTP to clipboard",
-    "l_launch_and_copy_otp": "Launch app and copy OTP",
+    "l_invalid_qr": "Invalid QR code",
     "l_kbd_layout_for_static": "Keyboard layout (for static password)",
-    "s_choose_kbd_layout": "Choose keyboard layout",
-    "l_bypass_touch_requirement": "Bypass touch requirement",
-    "l_bypass_touch_requirement_on": "Accounts that require touch are automatically shown over NFC",
-    "l_bypass_touch_requirement_off": "Accounts that require touch need an additional tap over NFC",
-    "s_silence_nfc_sounds": "Silence NFC sounds",
-    "l_silence_nfc_sounds_on": "No sounds will be played on NFC tap",
-    "l_silence_nfc_sounds_off": "Sound will play on NFC tap",
-    "s_usb_options": "USB options",
+    "l_keep_touching_yk": "Keep touching your YubiKey repeatedly…",
+    "l_key_no_certificate": "Key without certificate loaded",
+    "l_keystore_unavailable": "OS Keystore unavailable",
+    "l_launch_and_copy_otp": "Launch app and copy OTP",
     "l_launch_app_on_usb": "Launch when YubiKey is connected",
-    "l_launch_app_on_usb_on": "This prevents other apps from using the YubiKey over USB",
     "l_launch_app_on_usb_off": "Other apps can use the YubiKey over USB",
+    "l_launch_app_on_usb_on": "This prevents other apps from using the YubiKey over USB",
+    "l_launch_ya": "Launch Yubico Authenticator",
+    "l_loading_icon_pack": "Loading icon pack…",
+    "l_log_copied": "Log copied to clipboard",
+    "l_management_key_changed": "Management key changed",
+    "l_min_one_interface": "At least one interface must be enabled",
+    "l_name_already_exists": "This name already exists for the issuer",
+    "l_new_pin_len": "New PIN must be at least {length} characters",
+    "@l_new_pin_len": {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "l_no_certificate": "No certificate loaded",
+    "l_no_discoverable_accounts": "No Passkeys stored",
+    "l_no_fps_added": "No fingerprints have been added",
+    "l_no_yk_present": "No YubiKey present",
+    "l_oath_application_reset": "OATH application reset",
+    "l_on_yk_nfc_tap": "On YubiKey NFC tap",
+    "l_open_connection_failed": "Failed to open connection",
+    "l_optional_password_protection": "Optional password protection",
+    "l_optionally_set_a_pin": "Optionally set a PIN to protect access to your YubiKey\nRegister as a Security Key on websites",
+    "l_passkey": "Passkey: {label}",
+    "@l_passkey": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "l_pin_account_desc": "Keep your important accounts together",
+    "l_pin_blocked_reset": "PIN is blocked; factory reset the FIDO application",
+    "l_pin_protected_key": "PIN can be used instead",
+    "l_pin_soft_locked": "PIN has been blocked until the YubiKey is removed and reinserted",
+    "l_piv_app_reset": "PIV application reset",
+    "l_piv_pin_blocked": "Blocked, use PUK to reset",
+    "l_piv_pin_puk_blocked": "Blocked, factory reset needed",
+    "l_place_on_nfc_reader": "Place your YubiKey on the NFC reader",
+    "l_point_camera_scan": "Point your camera at a QR code to scan it",
+    "l_press_reset_to_begin": "Press reset to begin…",
+    "l_qr_not_found": "No QR code found",
+    "l_qr_not_read": "Failed reading QR code: {message}",
+    "@l_qr_not_read": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_qr_scanned": "Scanned QR code",
+    "l_ready_to_use": "Ready to use",
+    "l_register_sk_on_websites": "Register as a Security Key on websites",
+    "l_reinsert_yk": "Reinsert your YubiKey",
+    "l_remember_pw_failed": "Failed to remember password",
+    "l_remove_icon_pack_failed": "Error removing icon pack",
+    "l_remove_yk_from_reader": "Remove your YubiKey from the NFC reader",
+    "l_rename_account_desc": "Edit the issuer/name of the account",
+    "l_rename_fp_desc": "Change the label",
+    "l_rename_fp_failed": "Error renaming: {message}",
+    "@l_rename_fp_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_replace_yk_on_reader": "Place your YubiKey back on the reader",
+    "l_reset_failed": "Error performing reset: {message}",
+    "@l_reset_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_select_accounts": "Select account(s) to add to the YubiKey",
+    "l_select_import_file": "Select file to import",
+    "l_set_icons_for_accounts": "Set icons for accounts",
+    "l_set_pin_failed": "Failed to set PIN: {message}",
+    "@l_set_pin_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_set_pin_fingerprints": "Set a PIN to register fingerprints",
+    "l_set_pin_first": "A PIN is required first",
+    "l_setting_name_failed": "Error setting name: {message}",
+    "@l_setting_name_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_silence_nfc_sounds_off": "Sound will play on NFC tap",
+    "l_silence_nfc_sounds_on": "No sounds will be played on NFC tap",
+    "l_touch_button_now": "Touch the button on your YubiKey now",
+    "l_unlock_first": "Unlock with password first",
+    "l_unlock_pin_first": "Unlock with PIN first",
+    "l_unlock_piv_management": "Unlock PIV management",
+    "l_unplug_yk": "Unplug your YubiKey",
+    "l_warning_default_key": "Warning: Default key used",
+    "l_webauthn_req_fido2": "WebAuthn requires the FIDO2 application to be enabled on your YubiKey",
+    "l_wrong_key": "Wrong key",
+    "l_wrong_pin_attempts_remaining": "Wrong PIN, {retries} attempt(s) remaining",
+    "@l_wrong_pin_attempts_remaining": {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_wrong_puk_attempts_remaining": "Wrong PUK, {retries} attempt(s) remaining",
+    "@l_wrong_puk_attempts_remaining": {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_yk_no_access": "This YubiKey cannot be accessed",
+    "p_add_description": "To scan a QR code, make sure the full code is visible on screen and press the button below. You can also drag a saved image from a folder onto this dialog. If you have the account credential details in writing, use the manual entry instead.",
+    "p_ccid_service_unavailable": "Make sure your smart card service is functioning.",
+    "p_change_management_key_desc": "Change your management key. You can optionally choose to allow the PIN to be used instead of the management key.",
+    "p_community_translations_desc": "These translations are provided and maintained by the community. They may contain errors or be incomplete.",
+    "p_custom_icons_description": "Icon packs can make your accounts more easily distinguishable with familiar logos and colors.",
+    "p_elevated_permissions_required": "Managing this device requires elevated privileges.",
+    "p_enter_current_password_or_reset": "Enter your current password. If you don't know your password, you'll need to reset the YubiKey.",
+    "p_enter_current_pin_or_reset": "Enter your current PIN. If you don't know your PIN, you'll need to unblock it with the PUK or reset the YubiKey.",
+    "p_enter_current_puk_or_reset": "Enter your current PUK. If you don't know your PUK, you'll need to reset the YubiKey.",
+    "p_enter_new_fido2_pin": "Enter your new PIN. A PIN must be at least {length} characters long and may contain letters, numbers and special characters.",
+    "@p_enter_new_fido2_pin": {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "p_enter_new_password": "Enter your new password. A password may contain letters, numbers and special characters.",
+    "p_enter_new_piv_pin_puk": "Enter a new {name} to set. Must be 6-8 characters.",
+    "@p_enter_new_piv_pin_puk": {
+        "placeholders": {
+            "name": {}
+        }
+    },
+    "p_generate_desc": "This will generate a new key on the YubiKey in PIV slot {slot}. The public key will be embedded into a self-signed certificate stored on the YubiKey, or in a certificate signing request (CSR) saved to file.",
+    "@p_generate_desc": {
+        "placeholders": {
+            "slot": {}
+        }
+    },
+    "p_import_items_desc": "The following items will be imported into PIV slot {slot}.",
+    "@p_import_items_desc": {
+        "placeholders": {
+            "slot": {}
+        }
+    },
+    "p_need_camera_permission": "Yubico Authenticator needs Camera permissions for scanning QR codes.",
+    "p_password_protected_file": "The selected file is password protected. Enter the password to proceed.",
+    "p_pcscd_unavailable": "Make sure pcscd is installed and running.",
+    "p_pin_required_desc": "The action you are about to perform requires the PIV PIN to be entered.",
+    "p_press_fingerprint_begin": "Press your finger against the YubiKey to begin.",
+    "p_rename_will_change_account_displayed": "This will change how the account is displayed in the list.",
+    "p_target_copied_clipboard": "{label} copied to clipboard.",
+    "@p_target_copied_clipboard": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "p_try_reinsert_yk": "Try to remove and reinsert your YubiKey.",
+    "p_unlock_piv_management_desc": "The action you are about to perform requires the PIV management key. Provide this key to unlock management functionality for this session.",
+    "p_warning_delete_account": "Warning! This action will delete the account from your YubiKey.",
+    "p_warning_delete_certificate": "Warning! This action will delete the certificate from your YubiKey.",
+    "p_warning_delete_fingerprint": "This will delete the fingerprint from your YubiKey.",
+    "p_warning_delete_passkey": "This will delete the Passkey from your YubiKey.",
+    "p_warning_deletes_accounts": "Warning! This will irrevocably delete all U2F and FIDO2 accounts from your YubiKey.",
+    "p_warning_disable_accounts": "Your credentials, as well as any PIN set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
+    "p_warning_disable_credential": "You will no longer be able to generate OTPs for this account. Make sure to first disable this credential from the website to avoid being locked out of your account.",
+    "p_warning_disable_credentials": "Your OATH credentials, as well as any password set, will be removed from this YubiKey. Make sure to first disable these from their respective web sites to avoid being locked out of your accounts.",
+    "p_warning_factory_reset": "Warning! This will irrevocably delete all OATH TOTP/HOTP accounts from your YubiKey.",
+    "p_warning_piv_reset": "Warning! All data stored for PIV will be irrevocably deleted from your YubiKey.",
+    "p_warning_piv_reset_desc": "This includes private keys and certificates. Your PIN, PUK, and management key will be reset to their factory default values.",
+    "p_webauthn_elevated_permissions_required": "WebAuthn management requires elevated privileges.",
+    "p_will_change_label_fp": "This will change the label of the fingerprint.",
+    "q_delete_certificate_confirm": "Delete the certficate in PIV slot {slot}?",
+    "@q_delete_certificate_confirm": {
+        "placeholders": {
+            "slot": {}
+        }
+    },
+    "q_have_account_info": "Have account info?",
+    "q_no_qr": "No QR code?",
+    "q_rename_target": "Rename {label}?",
+    "@q_rename_target": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "q_want_to_scan": "Would like to scan?",
+    "s_about": "About",
+    "s_account_added": "Account added",
+    "s_account_deleted": "Account deleted",
+    "s_account_name": "Account name",
+    "s_account_renamed": "Account renamed",
+    "s_accounts": "Accounts",
+    "s_actions": "Actions",
+    "s_add_account": "Add account",
+    "s_add_accounts": "Add account(s)",
+    "s_add_fingerprint": "Add fingerprint",
+    "s_add_manually": "Add manually",
     "s_allow_screenshots": "Allow screenshots",
-
-    "s_nfc_dialog_tap_key": "Tap your key",
-    "s_nfc_dialog_operation_success": "Success",
-    "s_nfc_dialog_operation_failed": "Failed",
-
-    "s_nfc_dialog_oath_reset": "Action: reset OATH applet",
-    "s_nfc_dialog_oath_unlock": "Action: unlock OATH applet",
-    "s_nfc_dialog_oath_set_password": "Action: set OATH password",
-    "s_nfc_dialog_oath_unset_password": "Action: remove OATH password",
+    "s_app_disabled": "Application disabled",
+    "s_app_not_supported": "Application not supported",
+    "s_app_theme": "App theme",
+    "s_appearance": "Appearance",
+    "s_application_error": "Application error",
+    "s_authenticator": "Authenticator",
+    "s_calculate": "Calculate",
+    "s_calculate_code": "Calculate code",
+    "s_cancel": "Cancel",
+    "s_certificate": "Certificate",
+    "s_certificate_fingerprint": "Fingerprint",
+    "s_certificates": "Certificates",
+    "s_change_pin": "Change PIN",
+    "s_change_puk": "Change PUK",
+    "s_character_count": "Character count",
+    "s_choose_app_theme": "Choose app theme",
+    "s_choose_icon_pack": "Choose icon pack",
+    "s_choose_kbd_layout": "Choose keyboard layout",
+    "s_clear_saved_password": "Clear saved password",
+    "s_close": "Close",
+    "s_code_copied": "Code copied",
+    "s_config_updated": "Configuration updated",
+    "s_configure_yk": "Configure YubiKey",
+    "s_confirm_password": "Confirm password",
+    "s_confirm_pin": "Confirm PIN",
+    "s_confirm_puk": "Confirm PUK",
+    "s_copy_log": "Copy log",
+    "s_counter_based": "Counter based",
+    "s_csr": "CSR",
+    "s_current_management_key": "Current management key",
+    "s_current_password": "Current password",
+    "s_current_pin": "Current PIN",
+    "s_current_puk": "Current PUK",
+    "s_custom_icons": "Custom icons",
+    "s_dark_mode": "Dark mode",
+    "s_definition": "{item}:",
+    "@s_definition": {
+        "placeholders": {
+            "item": {}
+        }
+    },
+    "s_delete": "Delete",
+    "s_delete_account": "Delete account",
+    "s_delete_fingerprint": "Delete fingerprint",
+    "s_delete_passkey": "Delete Passkey",
+    "s_enable_nfc": "Enable NFC",
+    "s_enter_manually": "Enter manually",
+    "s_factory_reset": "Factory reset",
+    "s_fido_disabled": "FIDO2 disabled",
+    "s_fido_pin_protection": "FIDO PIN protection",
+    "s_fingerprint_added": "Fingerprint added",
+    "s_fingerprint_deleted": "Fingerprint deleted",
+    "s_fingerprint_renamed": "Fingerprint renamed",
+    "s_fingerprints": "Fingerprints",
+    "s_fw_version": "F/W: {version}",
+    "@s_fw_version": {
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "s_generate_key": "Generate key",
+    "s_help_and_about": "Help and about",
+    "s_help_and_feedback": "Help and feedback",
+    "s_hide_device": "Hide device",
+    "s_hide_window": "Hide window",
+    "s_i_need_help": "I need help",
+    "s_import": "Import",
+    "s_invalid_length": "Invalid length",
+    "s_issuer": "Issuer",
+    "s_issuer_optional": "Issuer (optional)",
+    "s_label": "Label",
+    "s_language": "Language",
+    "s_learn_more": "Learn more",
+    "s_light_mode": "Light mode",
+    "s_load_icon_pack": "Load icon pack",
+    "s_log_level": "Log level: {level}",
+    "@s_log_level": {
+        "placeholders": {
+            "level": {}
+        }
+    },
+    "s_manage": "Manage",
+    "s_manage_password": "Manage password",
+    "s_management_key": "Management key",
+    "s_name": "Name",
+    "s_new_management_key": "New management key",
+    "s_new_password": "New password",
+    "s_new_pin": "New PIN",
+    "s_new_puk": "New PUK",
+    "s_nfc": "NFC",
     "s_nfc_dialog_oath_add_account": "Action: add new account",
-    "s_nfc_dialog_oath_rename_account": "Action: rename account",
-    "s_nfc_dialog_oath_delete_account": "Action: delete account",
-    "s_nfc_dialog_oath_calculate_code": "Action: calculate OATH code",
-    "s_nfc_dialog_oath_failure": "OATH operation failed",
     "s_nfc_dialog_oath_add_multiple_accounts": "Action: add multiple accounts",
-
-    "@_eof": {}
+    "s_nfc_dialog_oath_calculate_code": "Action: calculate OATH code",
+    "s_nfc_dialog_oath_delete_account": "Action: delete account",
+    "s_nfc_dialog_oath_failure": "OATH operation failed",
+    "s_nfc_dialog_oath_rename_account": "Action: rename account",
+    "s_nfc_dialog_oath_reset": "Action: reset OATH applet",
+    "s_nfc_dialog_oath_set_password": "Action: set OATH password",
+    "s_nfc_dialog_oath_unlock": "Action: unlock OATH applet",
+    "s_nfc_dialog_oath_unset_password": "Action: remove OATH password",
+    "s_nfc_dialog_operation_failed": "Failed",
+    "s_nfc_dialog_operation_success": "Success",
+    "s_nfc_dialog_tap_key": "Tap your key",
+    "s_nfc_options": "NFC options",
+    "s_no_accounts": "No accounts",
+    "s_no_fingerprints": "No fingerprints",
+    "s_no_pinned_accounts": "No pinned accounts",
+    "s_num_digits": "{num} digits",
+    "@s_num_digits": {
+        "placeholders": {
+            "num": {}
+        }
+    },
+    "s_num_sec": "{num} sec",
+    "@s_num_sec": {
+        "placeholders": {
+            "num": {}
+        }
+    },
+    "s_open_src_licenses": "Open source licenses",
+    "s_passkey_deleted": "Passkey deleted",
+    "s_passkeys": "Passkeys",
+    "s_password": "Password",
+    "s_password_forgotten": "Password forgotten",
+    "s_password_removed": "Password removed",
+    "s_password_set": "Password set",
+    "s_permission_denied": "Permission denied",
+    "s_pin": "PIN",
+    "s_pin_account": "Pin account",
+    "s_pin_required": "PIN required",
+    "s_pin_set": "PIN set",
+    "s_pinned": "Pinned",
+    "s_piv": "PIV",
+    "s_please_wait": "Please wait…",
+    "s_privacy_policy": "Privacy policy",
+    "s_private_key": "Private key",
+    "s_private_key_generated": "Private key generated",
+    "s_protect_key": "Protect with PIN",
+    "s_puk": "PUK",
+    "s_puk_set": "PUK set",
+    "s_qr_scan": "Scan QR code",
+    "s_quit": "Quit",
+    "s_reconfiguring_yk": "Reconfiguring YubiKey…",
+    "s_remember_password": "Remember password",
+    "s_remove_icon_pack": "Remove icon pack",
+    "s_remove_password": "Remove password",
+    "s_rename_account": "Rename account",
+    "s_rename_fp": "Rename fingerprint",
+    "s_replace_icon_pack": "Replace icon pack",
+    "s_require_touch": "Require touch",
+    "s_reset": "Reset",
+    "s_reset_fido": "Reset FIDO",
+    "s_reset_oath": "Reset OATH",
+    "s_reset_piv": "Reset PIV",
+    "s_review_permissions": "Review permissions",
+    "s_run_diagnostics": "Run diagnostics",
+    "s_save": "Save",
+    "s_search_accounts": "Search accounts",
+    "s_secret_key": "Secret key",
+    "s_select_to_scan": "Select to scan",
+    "s_select_yk": "Select YubiKey",
+    "s_send_feedback": "Send us feedback",
+    "s_serial": "Serial",
+    "s_set_password": "Set password",
+    "s_set_pin": "Set PIN",
+    "s_settings": "Settings",
+    "s_setup": "Setup",
+    "s_show_hidden_devices": "Show hidden devices",
+    "s_show_window": "Show window",
+    "s_silence_nfc_sounds": "Silence NFC sounds",
+    "s_slot_9a": "Authentication",
+    "s_slot_9c": "Digital Signature",
+    "s_slot_9d": "Key Management",
+    "s_slot_9e": "Card Authentication",
+    "s_slot_display_name": "{name} ({hexid})",
+    "@s_slot_display_name": {
+        "placeholders": {
+            "hexid": {},
+            "name": {}
+        }
+    },
+    "s_sn_serial": "S/N: {serial}",
+    "@s_sn_serial": {
+        "placeholders": {
+            "serial": {}
+        }
+    },
+    "s_subject": "Subject",
+    "s_system_default": "System default",
+    "s_terms_of_use": "Terms of use",
+    "s_time_based": "Time based",
+    "s_toggle_applications": "Toggle applications",
+    "s_touch_required": "Touch required",
+    "s_troubleshooting": "Troubleshooting",
+    "s_unblock_pin": "Unblock PIN",
+    "s_unknown_device": "Unrecognized device",
+    "s_unknown_type": "Unknown type",
+    "s_unlock": "Unlock",
+    "s_unpin_account": "Unpin account",
+    "s_unsupported_yk": "Unsupported YubiKey",
+    "s_usb": "USB",
+    "s_usb_options": "USB options",
+    "s_valid_from": "Valid from",
+    "s_valid_to": "Valid to",
+    "s_webauthn": "WebAuthn",
+    "s_wrong_password": "Wrong password",
+    "s_yk_inaccessible": "Device inaccessible",
+    "s_yk_information": "YubiKey information",
+    "s_yk_not_recognized": "Device not recognized"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -1,6 +1,5 @@
 {
     "@@locale": "pl",
-
     "@_readme": {
         "notes": [
             "Wszystkie ciągi zaczynają się od wielkiej litery.",
@@ -8,438 +7,396 @@
             "Uruchom check_strings.py na pliku .arb, aby wykryć problemy, dostosuj @_lint_rules zgodnie z potrzebami dla danego języka."
         ],
         "prefixes": {
-            "s_": "Jedno lub kilka słów. Powinny być na tyle krótkie, aby można je było wyświetlić na przycisku lub w nagłówku.",
             "l_": "Pojedyncza linia może być zawinięta. Nie powinna być dłuższa niż jedno zdanie i nie powinna kończyć się kropką.",
             "p_": "Jedno lub więcej pełnych zdań z odpowiednią interpunkcją.",
-            "q_": "Pytania kończą się znakiem zapytania."
+            "q_": "Pytania kończą się znakiem zapytania.",
+            "s_": "Jedno lub kilka słów. Powinny być na tyle krótkie, aby można je było wyświetlić na przycisku lub w nagłówku."
         }
     },
-
     "@_lint_rules": {
-        "s_max_words": 4,
-        "s_max_length": 32
+        "s_max_length": 32,
+        "s_max_words": 4
     },
-
     "app_name": "Yubico Authenticator",
-
-    "s_save": "Zapisz",
-    "s_cancel": "Anuluj",
-    "s_close": "Zamknij",
-    "s_delete": "Usuń",
-    "s_quit": "Wyjdź",
-    "s_unlock": "Odblokuj",
-    "s_calculate": "Oblicz",
-    "s_label": "Etykieta",
-    "s_name": "Nazwa",
-    "s_usb": "USB",
-    "s_nfc": "NFC",
-    "s_show_window": "Pokaż okno",
-    "s_hide_window": "Ukryj okno",
-    "q_rename_target": "Zmienić nazwę {label}?",
-    "@q_rename_target" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-
-    "s_about": "O aplikacji",
-    "s_appearance": "Wygląd",
-    "s_authenticator": "Authenticator",
-    "s_manage": "Zarządzaj",
-    "s_setup": "Konfiguruj",
-    "s_settings": "Ustawienia",
-    "s_webauthn": "WebAuthn",
-    "s_help_and_about": "Pomoc i informacje",
-    "s_help_and_feedback": "Pomoc i opinie",
-    "s_send_feedback": "Prześlij opinię",
-    "s_i_need_help": "Pomoc",
-    "s_troubleshooting": "Rozwiązywanie problemów",
-    "s_terms_of_use": "Warunki użytkowania",
-    "s_privacy_policy": "Polityka prywatności",
-    "s_open_src_licenses": "Licencje open source",
-    "s_configure_yk": "Skonfiguruj YubiKey",
-    "s_please_wait": "Proszę czekać\u2026",
-    "s_secret_key": "Tajny klucz",
-    "s_invalid_length": "Nieprawidłowa długość",
-    "s_require_touch": "Wymagaj dotknięcia",
-    "q_have_account_info": "Masz dane konta?",
-    "s_run_diagnostics": "Uruchom diagnostykę",
-    "s_log_level": "Poziom logowania: {level}",
-    "@s_log_level": {
-        "placeholders": {
-            "level": {}
-        }
-    },
-    "s_character_count": "Liczba znaków",
-    "s_learn_more": "Dowiedz się więcej",
-
-    "@_language": {},
-    "s_language": "Język",
-    "l_enable_community_translations": "Włącz tłumaczenia społecznościowe",
-    "p_community_translations_desc": "Tłumaczenia te są dostarczane i utrzymywane przez społeczność. Mogą zawierać błędy lub być niekompletne.",
-
-    "@_theme": {},
-    "s_app_theme": "Motyw aplikacji",
-    "s_choose_app_theme": "Wybierz motyw aplikacji",
-    "s_system_default": "Zgodny z systemem",
-    "s_light_mode": "Jasny",
-    "s_dark_mode": "Ciemny",
-  
-    "@_yubikey_selection": {},
-    "s_yk_information": "Informacja o YubiKey",
-    "s_select_yk": "Wybierz YubiKey",
-    "s_select_to_scan": "Wybierz, aby skanować",
-    "s_hide_device": "Ukryj urządzenie",
-    "s_show_hidden_devices": "Pokaż ukryte urządzenia",
-    "s_sn_serial": "S/N: {serial}",
-    "@s_sn_serial" : {
-        "placeholders": {
-            "serial": {}
-        }
-    },
-    "s_fw_version": "F/W: {version}",
-    "@s_fw_version" : {
-        "placeholders": {
-            "version": {}
-        }
-    },
-
-    "@_yubikey_interactions": {},
-    "l_insert_yk": "Podłącz klucz YubiKey",
-    "l_insert_or_tap_yk": "Podłącz lub przystaw YubiKey",
-    "l_unplug_yk": "Odłącz klucz YubiKey",
-    "l_reinsert_yk": "Ponownie podłącz YubiKey",
-    "l_place_on_nfc_reader": "Przyłóż klucz YubiKey do czytnika NFC",
-    "l_replace_yk_on_reader": "Umieść klucz YubiKey z powrotem na czytniku",
-    "l_remove_yk_from_reader": "Odsuń klucz YubiKey od czytnika NFC",
-    "p_try_reinsert_yk": "Spróbuj ponownie podłączyć klucz YubiKey.",
-    "s_touch_required": "Wymagane dotknięcie",
-    "l_touch_button_now": "Dotknij teraz przycisku na kluczu YubiKey",
-    "l_keep_touching_yk": "Wielokrotnie dotykaj klucza YubiKey\u2026",
-  
-    "@_app_configuration": {},
-    "s_toggle_applications": "Przełączanie funkcji",
-    "l_min_one_interface": "Przynajmniej jeden interfejs musi być włączony",
-    "s_reconfiguring_yk": "Rekonfigurowanie YubiKey\u2026",
-    "s_config_updated": "Zaktualizowano konfigurację",
-    "l_config_updated_reinsert": "Zaktualizowano konfigurację, podłącz ponownie klucz YubiKey",
-    "s_app_not_supported": "Funkcja nie jest obsługiwana",
-    "l_app_not_supported_on_yk": "Używany klucz YubiKey nie obsługuje funkcji „{app}”",
-    "@l_app_not_supported_on_yk" : {
-        "placeholders": {
-            "app": {}
-        }
-    },
-    "l_app_not_supported_desc": "Ta funkcja nie jest obsługiwana",
-    "s_app_disabled": "Wyłączona funkcja",
-    "l_app_disabled_desc": "Włącz funkcję „{app}” w kluczu YubiKey, aby uzyskać dostęp",
-    "@l_app_disabled_desc" : {
-        "placeholders": {
-            "app": {}
-        }
-    },
-    "s_fido_disabled": "FIDO2 wyłączone",
-    "l_webauthn_req_fido2": "WebAuthn wymaga włączenia funkcji FIDO2 w kluczu YubiKey",
-  
-    "@_connectivity_issues": {},
-    "l_helper_not_responding": "Proces pomocnika nie odpowiada",
-    "l_yk_no_access": "Dostęp do tego klucza YubiKey jest niemożliwy",
-    "s_yk_inaccessible": "Urządzenie niedostępne",
-    "l_open_connection_failed": "Nie udało się nawiązać połączenia",
-    "l_ccid_connection_failed": "Nie udało się nawiązać połączenia z kartą inteligentną",
-    "p_ccid_service_unavailable": "Upewnij się, że usługa kart inteligentnych działa.",
-    "p_pcscd_unavailable": "Upewnij się, że pcscd jest zainstalowany i uruchomiony.",
-    "l_no_yk_present": "Klucz YubiKey nie jest obecny",
-    "s_unknown_type": "Nieznany typ",
-    "s_unknown_device": "Nierozpoznane urządzenie",
-    "s_unsupported_yk": "Nieobsługiwany klucz YubiKey",
-    "s_yk_not_recognized": "Urządzenie nie rozpoznane",
-
-    "@_general_errors": {},
-    "l_error_occured": "Wystąpił błąd",
-    "s_application_error": "Błąd funkcji",
-    "l_import_error": "Błąd importowania",
-    "l_file_not_found": "Nie odnaleziono pliku",
-    "l_file_too_big": "Zbyt duży rozmiar pliku",
-    "l_filesystem_error": "Błąd operacji systemu plików",
-  
-    "@_pins": {},
-    "s_pin": "PIN",
-    "s_set_pin": "Ustaw PIN",
-    "s_change_pin": "Zmień PIN",
-    "s_current_pin": "Aktualny PIN",
-    "s_new_pin": "Nowy PIN",
-    "s_confirm_pin": "Potwierdź PIN",
-    "l_new_pin_len": "Nowy PIN musi mieć co najmniej {length} znaków",
-    "@l_new_pin_len" : {
-        "placeholders": {
-            "length": {}
-        }
-    },
-    "s_pin_set": "PIN ustawiony",
-    "l_set_pin_failed": "Nie udało się ustawić kodu PIN: {message}",
-    "@l_set_pin_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_wrong_pin_attempts_remaining": "Błędny PIN, pozostało {retries} prób",
-    "@l_wrong_pin_attempts_remaining" : {
-        "placeholders": {
-            "retries": {}
-        }
-    },
-    "s_fido_pin_protection": "Ochrona FIDO kodem PIN",
-    "l_fido_pin_protection_optional": "Opcjonalna ochrona FIDO kodem PIN",
-    "l_enter_fido2_pin": "Wprowadź kod PIN FIDO2 dla klucza YubiKey",
-    "l_optionally_set_a_pin": "Opcjonalnie ustaw PIN, aby chronić dostęp do YubiKey\nZarejestruj jako klucz bezpieczeństwa na stronach internetowych",
-    "l_pin_blocked_reset": "PIN jest zablokowany; przywróć ustawienia fabryczne funkcji FIDO",
-    "l_set_pin_first": "Najpierw wymagany jest kod PIN",
-    "l_unlock_pin_first": "Najpierw odblokuj kodem PIN",
-    "l_pin_soft_locked": "PIN został zablokowany do momentu ponownego podłączenia klucza YubiKey",
-    "p_enter_current_pin_or_reset": "Wprowadź aktualny kod PIN. Jeśli nie znasz kodu PIN, musisz zresetować klucz YubiKey.",
-    "p_enter_new_fido2_pin": "Wprowadź nowy PIN. Kod PIN musi mieć co najmniej {length} znaków i może zawierać litery, cyfry i znaki specjalne.",
-    "@p_enter_new_fido2_pin" : {
-        "placeholders": {
-            "length": {}
-        }
-    },
-
-    "@_passwords": {},
-    "s_password": "Hasło",
-    "s_manage_password": "Zarządzaj hasłem",
-    "s_set_password": "Ustaw hasło",
-    "s_password_set": "Hasło zostało ustawione",
-    "l_optional_password_protection": "Opcjonalna ochrona hasłem",
-    "s_new_password": "Nowe hasło",
-    "s_current_password": "Aktualne hasło",
-    "s_confirm_password": "Potwierdź hasło",
-    "s_wrong_password": "Błędne hasło",
-    "s_remove_password": "Usuń hasło",
-    "s_password_removed": "Hasło zostało usunięte",
-    "s_remember_password": "Zapamiętaj hasło",
-    "s_clear_saved_password": "Usuń zapisane hasło",
-    "s_password_forgotten": "Hasło zostało zapomniane",
-    "l_keystore_unavailable": "Magazyn kluczy systemu operacyjnego jest niedostępny",
-    "l_remember_pw_failed": "Nie udało się zapamiętać hasła",
-    "l_unlock_first": "Najpierw odblokuj hasłem",
-    "l_enter_oath_pw": "Wprowadź hasło OATH dla klucza YubiKey",
-    "p_enter_current_password_or_reset": "Wprowadź aktualne hasło. Jeśli nie znasz hasła, musisz zresetować klucz YubiKey.",
-    "p_enter_new_password": "Wprowadź nowe hasło. Hasło może zawierać litery, cyfry i znaki specjalne.",
-  
-    "@_oath_accounts": {},
     "l_account": "Konto: {label}",
-    "@l_account" : {
+    "@l_account": {
         "placeholders": {
             "label": {}
         }
     },
-    "s_accounts": "Konta",
-    "s_no_accounts": "Brak kont",
-    "s_add_account": "Dodaj konto",
-    "s_account_added": "Konto zostało dodane",
     "l_account_add_failed": "Nie udało się dodać konta: {message}",
-    "@l_account_add_failed" : {
+    "@l_account_add_failed": {
         "placeholders": {
             "message": {}
         }
     },
     "l_account_name_required": "Twoje konto musi mieć nazwę",
-    "l_name_already_exists": "Ta nazwa już istnieje dla tego wydawcy",
-    "l_invalid_character_issuer": "Nieprawidłowy znak: „:” nie jest dozwolony w polu wydawcy",
-    "s_pinned": "Przypięte",
-    "s_pin_account": "Przypnij konto",
-    "s_unpin_account": "Odepnij konto",
-    "s_no_pinned_accounts": "Brak przypiętych kont",
-    "s_rename_account": "Zmień nazwę konta",
-    "s_account_renamed": "Zmieniono nazwę konta",
-    "p_rename_will_change_account_displayed": "Spowoduje to zmianę sposobu wyświetlania konta na liście.",
-    "s_delete_account": "Usuń konto",
-    "s_account_deleted": "Konto zostało usunięte",
-    "p_warning_delete_account": "Uwaga! Ta czynność spowoduje usunięcie konta z klucza YubiKey.",
-    "p_warning_disable_credential": "Nie będzie już możliwe generowanie OTP dla tego konta. Upewnij się, że najpierw wyłączono te dane uwierzytelniające w witrynie, aby uniknąć zablokowania konta.",
-    "s_account_name": "Nazwa konta",
-    "s_search_accounts": "Wyszukaj konta",
     "l_accounts_used": "Użyto {used} z {capacity} kont",
-    "@l_accounts_used" : {
+    "@l_accounts_used": {
         "placeholders": {
-            "used": {},
-            "capacity": {}
-        }
-    },
-    "s_num_digits": "{num} cyfr",
-    "@s_num_digits" : {
-        "placeholders": {
-            "num": {}
-        }
-    },
-    "s_num_sec": "{num} sek",
-    "@s_num_sec" : {
-        "placeholders": {
-            "num": {}
-        }
-    },
-    "s_issuer_optional": "Wydawca (opcjonalnie)",
-    "s_counter_based": "Na podstawie licznika",
-    "s_time_based": "Na podstawie czasu",
-
-    "@_fido_credentials": {},
-    "l_credential": "Poświadczenie: {label}",
-    "@l_credential" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "s_credentials": "Poświadczenia",
-    "l_ready_to_use": "Gotowe do użycia",
-    "l_register_sk_on_websites": "Zarejestruj jako klucz bezpieczeństwa na stronach internetowych",
-    "l_no_discoverable_accounts": "Nie wykryto kont",
-    "s_delete_credential": "Usuń poświadczenie",
-    "s_credential_deleted": "Poświadczenie zostało usunięte",
-    "p_warning_delete_credential": "Spowoduje to usunięcie poświadczenia z klucza YubiKey.",
-
-    "@_fingerprints": {},
-    "l_fingerprint": "Odcisk palca: {label}",
-    "@l_fingerprint" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-    "s_fingerprints": "Odciski palców",
-    "l_fingerprint_captured": "Odcisk palca zarejestrowany pomyślnie!",
-    "s_fingerprint_added": "Dodano odcisk palca",
-    "l_setting_name_failed": "Błąd ustawienia nazwy: {message}",
-    "@l_setting_name_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "s_add_fingerprint": "Dodaj odcisk palca",
-    "l_fp_step_1_capture": "Krok 1/2: Pobranie odcisku palca",
-    "l_fp_step_2_name": "Krok 2/2: Nazwij odcisk palca",
-    "s_delete_fingerprint": "Usuń odcisk palca",
-    "s_fingerprint_deleted": "Odcisk palca został usunięty",
-    "p_warning_delete_fingerprint": "Spowoduje to usunięcie odcisku palca z twojego YubiKey.",
-    "s_no_fingerprints": "Brak odcisków palców",
-    "l_set_pin_fingerprints": "Ustaw kod PIN, aby zarejestrować odciski palców",
-    "l_no_fps_added": "Nie dodano odcisków palców",
-    "s_rename_fp": "Zmień nazwę odcisku palca",
-    "s_fingerprint_renamed": "Zmieniono nazwę odcisku palca",
-    "l_rename_fp_failed": "Błąd zmiany nazwy: {message}",
-    "@l_rename_fp_failed" : {
-        "placeholders": {
-            "message": {}
+            "capacity": {},
+            "used": {}
         }
     },
     "l_add_one_or_more_fps": "Dodaj jeden lub więcej (do pięciu) odcisków palców",
+    "l_app_disabled_desc": "Włącz funkcję „{app}” w kluczu YubiKey, aby uzyskać dostęp",
+    "@l_app_disabled_desc": {
+        "placeholders": {
+            "app": {}
+        }
+    },
+    "l_app_not_supported_desc": "Ta funkcja nie jest obsługiwana",
+    "l_app_not_supported_on_yk": "Używany klucz YubiKey nie obsługuje funkcji „{app}”",
+    "@l_app_not_supported_on_yk": {
+        "placeholders": {
+            "app": {}
+        }
+    },
+    "l_bypass_touch_requirement": "Obejdź wymóg dotyku",
+    "l_bypass_touch_requirement_off": "Konta, które wymagają dotknięcia, potrzebują dodatkowego przyłożenia do NFC",
+    "l_bypass_touch_requirement_on": "Konta, które wymagają dotknięcia, są automatycznie wyświetlane przez NFC",
+    "l_ccid_connection_failed": "Nie udało się nawiązać połączenia z kartą inteligentną",
+    "l_code_copied_clipboard": "Kod skopiowany do schowka",
+    "l_config_updated_reinsert": "Zaktualizowano konfigurację, podłącz ponownie klucz YubiKey",
+    "l_copy_otp_clipboard": "Skopiuj OTP do schowka",
+    "l_copy_to_clipboard": "Skopiuj do schowka",
+    "l_credential": "Poświadczenie: {label}",
+    "@l_credential": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "l_diagnostics_copied": "Dane diagnostyczne skopiowane do schowka",
+    "l_elevating_permissions": "Podnoszenie uprawnień…",
+    "l_enable_community_translations": "Włącz tłumaczenia społecznościowe",
+    "l_enter_fido2_pin": "Wprowadź kod PIN FIDO2 dla klucza YubiKey",
+    "l_enter_oath_pw": "Wprowadź hasło OATH dla klucza YubiKey",
+    "l_error_occured": "Wystąpił błąd",
+    "l_factory_reset_this_app": "Przywróć ustawienia fabryczne tej funkcji",
+    "l_fido_app_reset": "Reset funkcji FIDO",
+    "l_fido_pin_protection_optional": "Opcjonalna ochrona FIDO kodem PIN",
+    "l_file_not_found": "Nie odnaleziono pliku",
+    "l_file_too_big": "Zbyt duży rozmiar pliku",
+    "l_filesystem_error": "Błąd operacji systemu plików",
+    "l_fingerprint": "Odcisk palca: {label}",
+    "@l_fingerprint": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "l_fingerprint_captured": "Odcisk palca zarejestrowany pomyślnie!",
     "l_fingerprints_used": "Zarejestrowano {used}/5 odcisków palców",
     "@l_fingerprints_used": {
         "placeholders": {
             "used": {}
         }
     },
-    "p_press_fingerprint_begin": "Przytrzymaj palec na kluczu YubiKey, aby rozpocząć.",
-    "p_will_change_label_fp": "Spowoduje to zmianę etykiety odcisku palca.",
-
-    "@_permissions": {},
-    "s_enable_nfc": "Włącz NFC",
-    "s_permission_denied": "Odmowa dostępu",
-    "l_elevating_permissions": "Podnoszenie uprawnień\u2026",
-    "s_review_permissions": "Przegląd uprawnień",
-    "p_elevated_permissions_required": "Zarządzanie tym urządzeniem wymaga podwyższonych uprawnień.",
-    "p_webauthn_elevated_permissions_required": "Zarządzanie WebAuthn wymaga podwyższonych uprawnień.",
-    "p_need_camera_permission": "Yubico Authenticator wymaga dostępu do aparatu w celu skanowania kodów QR.",
-
-    "@_qr_codes": {},
-    "s_qr_scan": "Skanuj kod QR",
-    "l_qr_scanned": "Zeskanowany kod QR",
-    "l_invalid_qr": "Nieprawidłowy kod QR",
-    "l_qr_not_found": "Nie znaleziono kodu QR",
-    "l_qr_not_read": "Odczytanie kodu QR nie powiodło się: {message}",
-    "@l_qr_not_read" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "l_point_camera_scan": "Skieruj aparat na kod QR, by go zeskanować",
-    "q_want_to_scan": "Czy chcesz zeskanować?",
-    "q_no_qr": "Nie masz kodu QR?",
-    "s_enter_manually": "Wprowadź ręcznie",
-  
-    "@_factory_reset": {},
-    "s_reset": "Zresetuj",
-    "s_factory_reset": "Ustawienia fabryczne",
-    "l_factory_reset_this_app": "Przywróć ustawienia fabryczne tej funkcji",
-    "s_reset_oath": "Zresetuj OATH",
-    "l_oath_application_reset": "Reset funkcji OATH",
-    "s_reset_fido": "Zresetuj FIDO",
-    "l_fido_app_reset": "Reset funkcji FIDO",
-    "l_press_reset_to_begin": "Naciśnij reset, aby rozpocząć\u2026",
-    "l_reset_failed": "Błąd podczas resetowania: {message}",
-    "@l_reset_failed" : {
-        "placeholders": {
-            "message": {}
-        }
-    },
-    "p_warning_factory_reset": "Uwaga! Spowoduje to nieodwracalne usunięcie wszystkich kont OATH TOTP/HOTP z klucza YubiKey.",
-    "p_warning_disable_credentials": "Twoje poświadczenia OATH, jak również wszelkie ustawione hasła, zostaną usunięte z tego klucza YubiKey. Upewnij się, że najpierw wyłączono je w odpowiednich witrynach internetowych, aby uniknąć zablokowania kont.",
-    "p_warning_deletes_accounts": "Uwaga! Spowoduje to nieodwracalne usunięcie wszystkich kont U2F i FIDO2 z klucza YubiKey.",
-    "p_warning_disable_accounts": "Twoje poświadczenia, a także wszelkie ustawione kody PIN, zostaną usunięte z tego klucza YubiKey. Upewnij się, że najpierw wyłączono je w odpowiednich witrynach internetowych, aby uniknąć zablokowania kont.",
-  
-    "@_copy_to_clipboard": {},
-    "l_copy_to_clipboard": "Skopiuj do schowka",
-    "s_code_copied": "Kod skopiowany",
-    "l_code_copied_clipboard": "Kod skopiowany do schowka",
-    "s_copy_log": "Kopiuj logi",
-    "l_log_copied": "Logi skopiowane do schowka",
-    "l_diagnostics_copied": "Dane diagnostyczne skopiowane do schowka",
-    "p_target_copied_clipboard": "{label} skopiowano do schowka.",
-    "@p_target_copied_clipboard" : {
-        "placeholders": {
-            "label": {}
-        }
-    },
-
-    "@_custom_icons": {},
-    "s_custom_icons": "Niestandardowe ikony",
-    "l_set_icons_for_accounts": "Ustaw ikony dla kont",
-    "p_custom_icons_description": "Pakiety ikon mogą sprawić, że Twoje konta będą łatwiejsze do odróżnienia dzięki znanym logo i kolorom.",
-    "s_replace_icon_pack": "Zastąp pakiet ikon",
-    "l_loading_icon_pack": "Wczytywanie pakietu ikon\u2026",
-    "s_load_icon_pack": "Wczytaj pakiet ikon",
-    "s_remove_icon_pack": "Usuń pakiet ikon",
-    "l_icon_pack_removed": "Usunięto pakiet ikon",
-    "l_remove_icon_pack_failed": "Błąd podczas usuwania pakietu ikon",
-    "s_choose_icon_pack": "Wybierz pakiet ikon",
+    "l_fp_step_1_capture": "Krok 1/2: Pobranie odcisku palca",
+    "l_fp_step_2_name": "Krok 2/2: Nazwij odcisk palca",
+    "l_helper_not_responding": "Proces pomocnika nie odpowiada",
+    "l_icon_pack_copy_failed": "Nie udało się skopiować plików z pakietu ikon",
     "l_icon_pack_imported": "Zaimportowano pakiet ikon",
+    "l_icon_pack_removed": "Usunięto pakiet ikon",
+    "l_import_error": "Błąd importowania",
     "l_import_icon_pack_failed": "Błąd importu pakietu ikon: {message}",
     "@l_import_icon_pack_failed": {
         "placeholders": {
             "message": {}
         }
     },
+    "l_insert_or_tap_yk": "Podłącz lub przystaw YubiKey",
+    "l_insert_yk": "Podłącz klucz YubiKey",
+    "l_invalid_character_issuer": "Nieprawidłowy znak: „:” nie jest dozwolony w polu wydawcy",
     "l_invalid_icon_pack": "Nieprawidłowy pakiet ikon",
-    "l_icon_pack_copy_failed": "Nie udało się skopiować plików z pakietu ikon",
-
-    "@_android_settings": {},
-    "s_nfc_options": "Opcje NFC",
-    "l_on_yk_nfc_tap": "Podczas kontaktu YubiKey z NFC",
-    "l_launch_ya": "Uruchom Yubico Authenticator",
-    "l_copy_otp_clipboard": "Skopiuj OTP do schowka",
-    "l_launch_and_copy_otp": "Uruchom aplikację i skopiuj OTP",
+    "l_invalid_qr": "Nieprawidłowy kod QR",
     "l_kbd_layout_for_static": "Układ klawiatury (dla hasła statycznego)",
-    "s_choose_kbd_layout": "Wybierz układ klawiatury",
-    "l_bypass_touch_requirement": "Obejdź wymóg dotyku",
-    "l_bypass_touch_requirement_on": "Konta, które wymagają dotknięcia, są automatycznie wyświetlane przez NFC",
-    "l_bypass_touch_requirement_off": "Konta, które wymagają dotknięcia, potrzebują dodatkowego przyłożenia do NFC",
-    "s_silence_nfc_sounds": "Wycisz dźwięki NFC",
-    "l_silence_nfc_sounds_on": "Dźwięki nie będą odtwarzane po przyłożeniu do NFC",
-    "l_silence_nfc_sounds_off": "Dźwięki będą odtwarzane po przyłożeniu do NFC",
-    "s_usb_options": "Opcje USB",
+    "l_keep_touching_yk": "Wielokrotnie dotykaj klucza YubiKey…",
+    "l_keystore_unavailable": "Magazyn kluczy systemu operacyjnego jest niedostępny",
+    "l_launch_and_copy_otp": "Uruchom aplikację i skopiuj OTP",
     "l_launch_app_on_usb": "Uruchom po podłączeniu YubiKey",
-    "l_launch_app_on_usb_on": "Uniemożliwia to innym aplikacjom korzystanie z YubiKey przez USB",
     "l_launch_app_on_usb_off": "Inne aplikacje mogą korzystać z YubiKey przez USB",
+    "l_launch_app_on_usb_on": "Uniemożliwia to innym aplikacjom korzystanie z YubiKey przez USB",
+    "l_launch_ya": "Uruchom Yubico Authenticator",
+    "l_loading_icon_pack": "Wczytywanie pakietu ikon…",
+    "l_log_copied": "Logi skopiowane do schowka",
+    "l_min_one_interface": "Przynajmniej jeden interfejs musi być włączony",
+    "l_name_already_exists": "Ta nazwa już istnieje dla tego wydawcy",
+    "l_new_pin_len": "Nowy PIN musi mieć co najmniej {length} znaków",
+    "@l_new_pin_len": {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "l_no_discoverable_accounts": "Nie wykryto kont",
+    "l_no_fps_added": "Nie dodano odcisków palców",
+    "l_no_yk_present": "Klucz YubiKey nie jest obecny",
+    "l_oath_application_reset": "Reset funkcji OATH",
+    "l_on_yk_nfc_tap": "Podczas kontaktu YubiKey z NFC",
+    "l_open_connection_failed": "Nie udało się nawiązać połączenia",
+    "l_optional_password_protection": "Opcjonalna ochrona hasłem",
+    "l_optionally_set_a_pin": "Opcjonalnie ustaw PIN, aby chronić dostęp do YubiKey\nZarejestruj jako klucz bezpieczeństwa na stronach internetowych",
+    "l_pin_blocked_reset": "PIN jest zablokowany; przywróć ustawienia fabryczne funkcji FIDO",
+    "l_pin_soft_locked": "PIN został zablokowany do momentu ponownego podłączenia klucza YubiKey",
+    "l_place_on_nfc_reader": "Przyłóż klucz YubiKey do czytnika NFC",
+    "l_point_camera_scan": "Skieruj aparat na kod QR, by go zeskanować",
+    "l_press_reset_to_begin": "Naciśnij reset, aby rozpocząć…",
+    "l_qr_not_found": "Nie znaleziono kodu QR",
+    "l_qr_not_read": "Odczytanie kodu QR nie powiodło się: {message}",
+    "@l_qr_not_read": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_qr_scanned": "Zeskanowany kod QR",
+    "l_ready_to_use": "Gotowe do użycia",
+    "l_register_sk_on_websites": "Zarejestruj jako klucz bezpieczeństwa na stronach internetowych",
+    "l_reinsert_yk": "Ponownie podłącz YubiKey",
+    "l_remember_pw_failed": "Nie udało się zapamiętać hasła",
+    "l_remove_icon_pack_failed": "Błąd podczas usuwania pakietu ikon",
+    "l_remove_yk_from_reader": "Odsuń klucz YubiKey od czytnika NFC",
+    "l_rename_fp_failed": "Błąd zmiany nazwy: {message}",
+    "@l_rename_fp_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_replace_yk_on_reader": "Umieść klucz YubiKey z powrotem na czytniku",
+    "l_reset_failed": "Błąd podczas resetowania: {message}",
+    "@l_reset_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_set_icons_for_accounts": "Ustaw ikony dla kont",
+    "l_set_pin_failed": "Nie udało się ustawić kodu PIN: {message}",
+    "@l_set_pin_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_set_pin_fingerprints": "Ustaw kod PIN, aby zarejestrować odciski palców",
+    "l_set_pin_first": "Najpierw wymagany jest kod PIN",
+    "l_setting_name_failed": "Błąd ustawienia nazwy: {message}",
+    "@l_setting_name_failed": {
+        "placeholders": {
+            "message": {}
+        }
+    },
+    "l_silence_nfc_sounds_off": "Dźwięki będą odtwarzane po przyłożeniu do NFC",
+    "l_silence_nfc_sounds_on": "Dźwięki nie będą odtwarzane po przyłożeniu do NFC",
+    "l_touch_button_now": "Dotknij teraz przycisku na kluczu YubiKey",
+    "l_unlock_first": "Najpierw odblokuj hasłem",
+    "l_unlock_pin_first": "Najpierw odblokuj kodem PIN",
+    "l_unplug_yk": "Odłącz klucz YubiKey",
+    "l_webauthn_req_fido2": "WebAuthn wymaga włączenia funkcji FIDO2 w kluczu YubiKey",
+    "l_wrong_pin_attempts_remaining": "Błędny PIN, pozostało {retries} prób",
+    "@l_wrong_pin_attempts_remaining": {
+        "placeholders": {
+            "retries": {}
+        }
+    },
+    "l_yk_no_access": "Dostęp do tego klucza YubiKey jest niemożliwy",
+    "p_ccid_service_unavailable": "Upewnij się, że usługa kart inteligentnych działa.",
+    "p_community_translations_desc": "Tłumaczenia te są dostarczane i utrzymywane przez społeczność. Mogą zawierać błędy lub być niekompletne.",
+    "p_custom_icons_description": "Pakiety ikon mogą sprawić, że Twoje konta będą łatwiejsze do odróżnienia dzięki znanym logo i kolorom.",
+    "p_elevated_permissions_required": "Zarządzanie tym urządzeniem wymaga podwyższonych uprawnień.",
+    "p_enter_current_password_or_reset": "Wprowadź aktualne hasło. Jeśli nie znasz hasła, musisz zresetować klucz YubiKey.",
+    "p_enter_current_pin_or_reset": "Wprowadź aktualny kod PIN. Jeśli nie znasz kodu PIN, musisz zresetować klucz YubiKey.",
+    "p_enter_new_fido2_pin": "Wprowadź nowy PIN. Kod PIN musi mieć co najmniej {length} znaków i może zawierać litery, cyfry i znaki specjalne.",
+    "@p_enter_new_fido2_pin": {
+        "placeholders": {
+            "length": {}
+        }
+    },
+    "p_enter_new_password": "Wprowadź nowe hasło. Hasło może zawierać litery, cyfry i znaki specjalne.",
+    "p_need_camera_permission": "Yubico Authenticator wymaga dostępu do aparatu w celu skanowania kodów QR.",
+    "p_pcscd_unavailable": "Upewnij się, że pcscd jest zainstalowany i uruchomiony.",
+    "p_press_fingerprint_begin": "Przytrzymaj palec na kluczu YubiKey, aby rozpocząć.",
+    "p_rename_will_change_account_displayed": "Spowoduje to zmianę sposobu wyświetlania konta na liście.",
+    "p_target_copied_clipboard": "{label} skopiowano do schowka.",
+    "@p_target_copied_clipboard": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "p_try_reinsert_yk": "Spróbuj ponownie podłączyć klucz YubiKey.",
+    "p_warning_delete_account": "Uwaga! Ta czynność spowoduje usunięcie konta z klucza YubiKey.",
+    "p_warning_delete_credential": "Spowoduje to usunięcie poświadczenia z klucza YubiKey.",
+    "p_warning_delete_fingerprint": "Spowoduje to usunięcie odcisku palca z twojego YubiKey.",
+    "p_warning_deletes_accounts": "Uwaga! Spowoduje to nieodwracalne usunięcie wszystkich kont U2F i FIDO2 z klucza YubiKey.",
+    "p_warning_disable_accounts": "Twoje poświadczenia, a także wszelkie ustawione kody PIN, zostaną usunięte z tego klucza YubiKey. Upewnij się, że najpierw wyłączono je w odpowiednich witrynach internetowych, aby uniknąć zablokowania kont.",
+    "p_warning_disable_credential": "Nie będzie już możliwe generowanie OTP dla tego konta. Upewnij się, że najpierw wyłączono te dane uwierzytelniające w witrynie, aby uniknąć zablokowania konta.",
+    "p_warning_disable_credentials": "Twoje poświadczenia OATH, jak również wszelkie ustawione hasła, zostaną usunięte z tego klucza YubiKey. Upewnij się, że najpierw wyłączono je w odpowiednich witrynach internetowych, aby uniknąć zablokowania kont.",
+    "p_warning_factory_reset": "Uwaga! Spowoduje to nieodwracalne usunięcie wszystkich kont OATH TOTP/HOTP z klucza YubiKey.",
+    "p_webauthn_elevated_permissions_required": "Zarządzanie WebAuthn wymaga podwyższonych uprawnień.",
+    "p_will_change_label_fp": "Spowoduje to zmianę etykiety odcisku palca.",
+    "q_have_account_info": "Masz dane konta?",
+    "q_no_qr": "Nie masz kodu QR?",
+    "q_rename_target": "Zmienić nazwę {label}?",
+    "@q_rename_target": {
+        "placeholders": {
+            "label": {}
+        }
+    },
+    "q_want_to_scan": "Czy chcesz zeskanować?",
+    "s_about": "O aplikacji",
+    "s_account_added": "Konto zostało dodane",
+    "s_account_deleted": "Konto zostało usunięte",
+    "s_account_name": "Nazwa konta",
+    "s_account_renamed": "Zmieniono nazwę konta",
+    "s_accounts": "Konta",
+    "s_add_account": "Dodaj konto",
+    "s_add_fingerprint": "Dodaj odcisk palca",
     "s_allow_screenshots": "Zezwalaj na zrzuty ekranu",
-
-    "@_eof": {}
+    "s_app_disabled": "Wyłączona funkcja",
+    "s_app_not_supported": "Funkcja nie jest obsługiwana",
+    "s_app_theme": "Motyw aplikacji",
+    "s_appearance": "Wygląd",
+    "s_application_error": "Błąd funkcji",
+    "s_authenticator": "Authenticator",
+    "s_calculate": "Oblicz",
+    "s_cancel": "Anuluj",
+    "s_change_pin": "Zmień PIN",
+    "s_character_count": "Liczba znaków",
+    "s_choose_app_theme": "Wybierz motyw aplikacji",
+    "s_choose_icon_pack": "Wybierz pakiet ikon",
+    "s_choose_kbd_layout": "Wybierz układ klawiatury",
+    "s_clear_saved_password": "Usuń zapisane hasło",
+    "s_close": "Zamknij",
+    "s_code_copied": "Kod skopiowany",
+    "s_config_updated": "Zaktualizowano konfigurację",
+    "s_configure_yk": "Skonfiguruj YubiKey",
+    "s_confirm_password": "Potwierdź hasło",
+    "s_confirm_pin": "Potwierdź PIN",
+    "s_copy_log": "Kopiuj logi",
+    "s_counter_based": "Na podstawie licznika",
+    "s_credential_deleted": "Poświadczenie zostało usunięte",
+    "s_credentials": "Poświadczenia",
+    "s_current_password": "Aktualne hasło",
+    "s_current_pin": "Aktualny PIN",
+    "s_custom_icons": "Niestandardowe ikony",
+    "s_dark_mode": "Ciemny",
+    "s_delete": "Usuń",
+    "s_delete_account": "Usuń konto",
+    "s_delete_credential": "Usuń poświadczenie",
+    "s_delete_fingerprint": "Usuń odcisk palca",
+    "s_enable_nfc": "Włącz NFC",
+    "s_enter_manually": "Wprowadź ręcznie",
+    "s_factory_reset": "Ustawienia fabryczne",
+    "s_fido_disabled": "FIDO2 wyłączone",
+    "s_fido_pin_protection": "Ochrona FIDO kodem PIN",
+    "s_fingerprint_added": "Dodano odcisk palca",
+    "s_fingerprint_deleted": "Odcisk palca został usunięty",
+    "s_fingerprint_renamed": "Zmieniono nazwę odcisku palca",
+    "s_fingerprints": "Odciski palców",
+    "s_fw_version": "F/W: {version}",
+    "@s_fw_version": {
+        "placeholders": {
+            "version": {}
+        }
+    },
+    "s_help_and_about": "Pomoc i informacje",
+    "s_help_and_feedback": "Pomoc i opinie",
+    "s_hide_device": "Ukryj urządzenie",
+    "s_hide_window": "Ukryj okno",
+    "s_i_need_help": "Pomoc",
+    "s_invalid_length": "Nieprawidłowa długość",
+    "s_issuer_optional": "Wydawca (opcjonalnie)",
+    "s_label": "Etykieta",
+    "s_language": "Język",
+    "s_learn_more": "Dowiedz się więcej",
+    "s_light_mode": "Jasny",
+    "s_load_icon_pack": "Wczytaj pakiet ikon",
+    "s_log_level": "Poziom logowania: {level}",
+    "@s_log_level": {
+        "placeholders": {
+            "level": {}
+        }
+    },
+    "s_manage": "Zarządzaj",
+    "s_manage_password": "Zarządzaj hasłem",
+    "s_name": "Nazwa",
+    "s_new_password": "Nowe hasło",
+    "s_new_pin": "Nowy PIN",
+    "s_nfc": "NFC",
+    "s_nfc_options": "Opcje NFC",
+    "s_no_accounts": "Brak kont",
+    "s_no_fingerprints": "Brak odcisków palców",
+    "s_no_pinned_accounts": "Brak przypiętych kont",
+    "s_num_digits": "{num} cyfr",
+    "@s_num_digits": {
+        "placeholders": {
+            "num": {}
+        }
+    },
+    "s_num_sec": "{num} sek",
+    "@s_num_sec": {
+        "placeholders": {
+            "num": {}
+        }
+    },
+    "s_open_src_licenses": "Licencje open source",
+    "s_password": "Hasło",
+    "s_password_forgotten": "Hasło zostało zapomniane",
+    "s_password_removed": "Hasło zostało usunięte",
+    "s_password_set": "Hasło zostało ustawione",
+    "s_permission_denied": "Odmowa dostępu",
+    "s_pin": "PIN",
+    "s_pin_account": "Przypnij konto",
+    "s_pin_set": "PIN ustawiony",
+    "s_pinned": "Przypięte",
+    "s_please_wait": "Proszę czekać…",
+    "s_privacy_policy": "Polityka prywatności",
+    "s_qr_scan": "Skanuj kod QR",
+    "s_quit": "Wyjdź",
+    "s_reconfiguring_yk": "Rekonfigurowanie YubiKey…",
+    "s_remember_password": "Zapamiętaj hasło",
+    "s_remove_icon_pack": "Usuń pakiet ikon",
+    "s_remove_password": "Usuń hasło",
+    "s_rename_account": "Zmień nazwę konta",
+    "s_rename_fp": "Zmień nazwę odcisku palca",
+    "s_replace_icon_pack": "Zastąp pakiet ikon",
+    "s_require_touch": "Wymagaj dotknięcia",
+    "s_reset": "Zresetuj",
+    "s_reset_fido": "Zresetuj FIDO",
+    "s_reset_oath": "Zresetuj OATH",
+    "s_review_permissions": "Przegląd uprawnień",
+    "s_run_diagnostics": "Uruchom diagnostykę",
+    "s_save": "Zapisz",
+    "s_search_accounts": "Wyszukaj konta",
+    "s_secret_key": "Tajny klucz",
+    "s_select_to_scan": "Wybierz, aby skanować",
+    "s_select_yk": "Wybierz YubiKey",
+    "s_send_feedback": "Prześlij opinię",
+    "s_set_password": "Ustaw hasło",
+    "s_set_pin": "Ustaw PIN",
+    "s_settings": "Ustawienia",
+    "s_setup": "Konfiguruj",
+    "s_show_hidden_devices": "Pokaż ukryte urządzenia",
+    "s_show_window": "Pokaż okno",
+    "s_silence_nfc_sounds": "Wycisz dźwięki NFC",
+    "s_sn_serial": "S/N: {serial}",
+    "@s_sn_serial": {
+        "placeholders": {
+            "serial": {}
+        }
+    },
+    "s_system_default": "Zgodny z systemem",
+    "s_terms_of_use": "Warunki użytkowania",
+    "s_time_based": "Na podstawie czasu",
+    "s_toggle_applications": "Przełączanie funkcji",
+    "s_touch_required": "Wymagane dotknięcie",
+    "s_troubleshooting": "Rozwiązywanie problemów",
+    "s_unknown_device": "Nierozpoznane urządzenie",
+    "s_unknown_type": "Nieznany typ",
+    "s_unlock": "Odblokuj",
+    "s_unpin_account": "Odepnij konto",
+    "s_unsupported_yk": "Nieobsługiwany klucz YubiKey",
+    "s_usb": "USB",
+    "s_usb_options": "Opcje USB",
+    "s_webauthn": "WebAuthn",
+    "s_wrong_password": "Błędne hasło",
+    "s_yk_inaccessible": "Urządzenie niedostępne",
+    "s_yk_information": "Informacja o YubiKey",
+    "s_yk_not_recognized": "Urządzenie nie rozpoznane"
 }

--- a/reformat_strings.py
+++ b/reformat_strings.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+#  Copyright (C) 2023 Yubico.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+import json
+import sys
+
+
+class ArbKeySort(str):
+    def __lt__(self, other):
+        a = self.lstrip("@")
+        b = other.lstrip("@")
+
+        if a == "locale":
+            return True
+
+        if b == "locale":
+            return False
+
+        if a == "_readme":
+            return True
+
+        if b == "_readme":
+            return False
+
+        if a == "_lint_rules":
+            return True
+
+        if b == "_lint_rules":
+            return False
+
+        if a == "app_name":
+            return True
+
+        if b == "app_name":
+            return False
+
+        return str.__lt__(a, b)
+
+
+if len(sys.argv) != 2:
+    print("USAGE: reformat_strings.py <ARB_FILE>")
+    sys.exit(1)
+
+
+def remove_empty_properties(d):
+    result = {}
+    for a, b in d.items():
+        if not a.startswith("@"):
+            result[a] = b
+        elif b:
+            if isinstance(b, dict):
+                result[a] = remove_empty_properties(b)
+            elif isinstance(b, list):
+                result[a] = list(filter(None, [remove_empty_properties(i) for i in b]))
+            else:
+                result[a] = b
+    return result
+
+
+target = sys.argv[1]
+with open(target, encoding='utf-8') as f:
+    values = json.load(f)
+
+with open(target, 'w', encoding='utf-8') as f:
+    json.dump({ArbKeySort(key): value for key, value in remove_empty_properties(values).items()},
+              f, ensure_ascii=False, indent=4, sort_keys=True)


### PR DESCRIPTION
Added `reformat_strings.py` which will sort an arb file by key name and remove empty property objects.

This is run on all arb files except app_en.arb during github actions builds and can generate diff errors.


Part of this PR is also reformatting of all arb files except app_en.arb.

The app_en.arb contains information which would be lost by reformatting and the file should be edited manually.