### PR TITLE
Android fixes for 6.3.0 

### DIFF
--- a/lib/android/qr_scanner/qr_scanner_ui_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_ui_view.dart
@@ -44,12 +44,15 @@ class QRScannerUI extends StatelessWidget {
                 screenSize.height + scannerAreaWidth / 2.0 + 8.0),
             width: screenSize.width,
             height: screenSize.height),
-        child: Text(
-          status != ScanStatus.error
-              ? l10n.l_point_camera_scan
-              : l10n.l_invalid_qr,
-          style: const TextStyle(color: Colors.white),
-          textAlign: TextAlign.center,
+        child: Padding(
+          padding: const EdgeInsets.all(4.0),
+          child: Text(
+            status != ScanStatus.error
+                ? l10n.l_point_camera_scan
+                : l10n.l_invalid_qr,
+            style: const TextStyle(color: Colors.white),
+            textAlign: TextAlign.center,
+          ),
         ),
       ),
 


### PR DESCRIPTION
Fixes following:
- adds margin around a text widget in QR Scanner view which could go offscreen in specific localization
- fix icon pack import on Android - now it is not possible to select invalid files, which are not zip files
- adds a widget to drawer when no key is connected