### PR TITLE
Fixes dialog display on Android

### DIFF
--- a/lib/widgets/responsive_dialog.dart
+++ b/lib/widgets/responsive_dialog.dart
@@ -16,6 +16,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:yubico_authenticator/core/state.dart';
 
 class ResponsiveDialog extends StatefulWidget {
   final Widget? title;
@@ -97,6 +98,7 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
   @override
   Widget build(BuildContext context) =>
       LayoutBuilder(builder: ((context, constraints) {
+        var maxWidth = isDesktop ? 400 : 600;
         // This keeps the focus in the dialog, even if the underlying page changes.
         return FocusScope(
           node: _focus,
@@ -107,7 +109,7 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
               _hasLostFocus = true;
             }
           },
-          child: constraints.maxWidth < 400
+          child: constraints.maxWidth < maxWidth
               ? _buildFullscreen(context)
               : _buildDialog(context),
         );


### PR DESCRIPTION
This PR makes sure that responsive dialogs are rendered fullscreen (not floating) on devices with shortest width 600 dpi (phones and not tablets)