### PR TITLE
Add semanticsLabel to code widget

### DIFF
--- a/lib/oath/views/account_helper.dart
+++ b/lib/oath/views/account_helper.dart
@@ -171,6 +171,7 @@ class _CodeLabel extends StatelessWidget {
             // This helps with vertical centering on desktop
             applyHeightToFirstAscent: !isDesktop,
           ),
+          semanticsLabel: code?.value.characters.map((c) => '$c ' ).toString(),
         ),
       );
 }


### PR DESCRIPTION
The codes are now read digit by digit instead of as a number.