### PR TITLE
Wrap Naviagation ListTiles into Material

### DIFF
--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -131,7 +131,9 @@ class AppPage extends StatelessWidget {
                 const SizedBox(width: 48),
               ],
             ),
-            NavigationContent(key: _navExpandedKey, extended: true),
+            Material(
+                type: MaterialType.transparency,
+                child: NavigationContent(key: _navExpandedKey, extended: true)),
           ],
         ),
       ),

--- a/lib/app/views/navigation.dart
+++ b/lib/app/views/navigation.dart
@@ -71,15 +71,18 @@ class NavigationItem extends StatelessWidget {
               ),
       );
     } else {
-      return ListTile(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
-        leading: leading,
-        title: Text(title),
-        minVerticalPadding: 16,
-        onTap: onTap,
-        tileColor: selected ? colorScheme.secondaryContainer : null,
-        textColor: selected ? colorScheme.onSecondaryContainer : null,
-        iconColor: selected ? colorScheme.onSecondaryContainer : null,
+      return Material(
+        type: MaterialType.transparency,
+        child: ListTile(
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
+          leading: leading,
+          title: Text(title),
+          minVerticalPadding: 16,
+          onTap: onTap,
+          tileColor: selected ? colorScheme.secondaryContainer : null,
+          textColor: selected ? colorScheme.onSecondaryContainer : null,
+          iconColor: selected ? colorScheme.onSecondaryContainer : null,
+        ),
       );
     }
   }

--- a/lib/app/views/navigation.dart
+++ b/lib/app/views/navigation.dart
@@ -71,18 +71,15 @@ class NavigationItem extends StatelessWidget {
               ),
       );
     } else {
-      return Material(
-        type: MaterialType.transparency,
-        child: ListTile(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
-          leading: leading,
-          title: Text(title),
-          minVerticalPadding: 16,
-          onTap: onTap,
-          tileColor: selected ? colorScheme.secondaryContainer : null,
-          textColor: selected ? colorScheme.onSecondaryContainer : null,
-          iconColor: selected ? colorScheme.onSecondaryContainer : null,
-        ),
+      return ListTile(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
+        leading: leading,
+        title: Text(title),
+        minVerticalPadding: 16,
+        onTap: onTap,
+        tileColor: selected ? colorScheme.secondaryContainer : null,
+        textColor: selected ? colorScheme.onSecondaryContainer : null,
+        iconColor: selected ? colorScheme.onSecondaryContainer : null,
       );
     }
   }


### PR DESCRIPTION
`tileColor` of `ListTile` is painted by its `Material` ancestor (see [ListTile](https://api.flutter.dev/flutter/material/ListTile-class.html)). 

This PR wraps the `NavigationContent` in the Drawer to `Material` to get a correct ancestor.