### PR TITLE
[Android] Catch exceptions during refresh

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -62,6 +62,7 @@ import io.flutter.plugin.common.MethodChannel
 import kotlinx.coroutines.*
 import kotlinx.serialization.encodeToString
 import org.slf4j.LoggerFactory
+import java.io.IOException
 import java.net.URI
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicBoolean
@@ -554,29 +555,50 @@ class OathManager(
             NULL
         }
 
-    private suspend fun requestRefresh() =
+    private suspend fun requestRefresh() {
+
+        val clearCodes = {
+            val currentCredentials = oathViewModel.credentials.value
+            oathViewModel.updateCredentials(currentCredentials?.associate {
+                it.credential to null
+            } ?: emptyMap())
+        }
+
         appViewModel.connectedYubiKey.value?.let { usbYubiKeyDevice ->
-            useOathSessionUsb(usbYubiKeyDevice) { session ->
-                try {
-                    oathViewModel.updateCredentials(calculateOathCodes(session))
-                } catch (apduException: ApduException) {
-                    if (apduException.sw == SW.SECURITY_CONDITION_NOT_SATISFIED) {
-                        logger.debug("Handled oath credential refresh on locked session.")
-                        oathViewModel.setSessionState(
-                            Session(
-                                session,
-                                keyManager.isRemembered(session.deviceId)
+            try {
+                useOathSessionUsb(usbYubiKeyDevice) { session ->
+                    try {
+                        oathViewModel.updateCredentials(calculateOathCodes(session))
+                    } catch (ioException: IOException) {
+                        logger.error("Exception while calculating codes: ", ioException)
+                        clearCodes()
+                    } catch (apduException: ApduException) {
+                        if (apduException.sw == SW.SECURITY_CONDITION_NOT_SATISFIED) {
+                            logger.debug("Handled oath credential refresh on locked session.")
+                            oathViewModel.setSessionState(
+                                Session(
+                                    session,
+                                    keyManager.isRemembered(session.deviceId)
+                                )
                             )
-                        )
-                    } else {
-                        logger.error(
-                            "Unexpected sw when refreshing oath credentials",
-                            apduException
-                        )
+                        } else {
+                            logger.error(
+                                "Unexpected sw when refreshing oath credentials",
+                                apduException
+                            )
+                        }
                     }
                 }
+            } catch (ioException: IOException) {
+                logger.error("IOException when accessing USB device: ", ioException)
+                clearCodes()
+            } catch (illegalStateException: IllegalStateException) {
+                logger.error("IllegalStateException when accessing USB device: ", illegalStateException)
+                clearCodes()
             }
         }
+    }
+
 
     private suspend fun calculate(credentialId: String): String =
         useOathSession(OathActionDescription.CalculateCode) { session ->

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -569,9 +569,6 @@ class OathManager(
                 useOathSessionUsb(usbYubiKeyDevice) { session ->
                     try {
                         oathViewModel.updateCredentials(calculateOathCodes(session))
-                    } catch (ioException: IOException) {
-                        logger.error("Exception while calculating codes: ", ioException)
-                        clearCodes()
                     } catch (apduException: ApduException) {
                         if (apduException.sw == SW.SECURITY_CONDITION_NOT_SATISFIED) {
                             logger.debug("Handled oath credential refresh on locked session.")


### PR DESCRIPTION
When using USB YubiKey, the application periodically calls refresh. 

Following situations currently crash the app. This PR adds a catch block for each of them.

### General repro steps:
- create many (>15) credentials on a YubiKey, so that code calculating takes longer time
- create 1 short-lived credential (1s) - this will cause refresh being called often

Do following:
1. Start the app.
2. Connect the YubiKey.
3. Disconnect the YubiKey when the short-lived credential times out.

What happens: depending on the timing, one of the three situations will crash the app.

### Situation 1:
The USB device is disconnected while codes are being calculated.

IOException is thrown.

### Situation 2:
- The application executes requestRefresh and `connectedYubiKey.value` is not null.  
- The physical YubiKey is disconnected
- The application calls `useOathSessionUsb` 

Because the USB device is not valid anymore, `usbManager.hasPermission(usbDevice)` will be false and `IllegalStateException("Device access not permitted")` is thrown from yubikit-android. 

### Situation 3.
- The application executes requestRefresh and `connectedYubiKey.value` is not null.
- The application calls `useOathSessionUsb` (Usb device is still OK)
- The USB device is disconnected during the creation of OathSession instance

This situation will cause an IOException.