### PR TITLE
[Android] update logging

### DIFF
--- a/android/app/src/main/assets/logback.xml
+++ b/android/app/src/main/assets/logback.xml
@@ -24,8 +24,14 @@
         </encoder>
     </appender>
 
-    <!-- Write TRACE (and higher-level) messages to logcat -->
+    <appender name="buffer" class="com.yubico.authenticator.logging.BufferAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss:SSS} [%thread] %-5level %logger{36} - %X{app} %msg</pattern>
+        </encoder>
+    </appender>
+
     <root level="TRACE">
         <appender-ref ref="logcat" />
+        <appender-ref ref="buffer" />
     </root>
 </configuration>

--- a/android/app/src/main/kotlin/com/yubico/authenticator/logging/BufferAppender.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/logging/BufferAppender.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator.logging
+
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.UnsynchronizedAppenderBase
+
+class BufferAppender : UnsynchronizedAppenderBase<ILoggingEvent>() {
+
+    private var encoder: PatternLayoutEncoder? = null
+
+    private val buffer = arrayListOf<String>()
+
+    public override fun append(event: ILoggingEvent) {
+        if (!isStarted) {
+            return
+        }
+
+        if (buffer.size > MAX_BUFFER_SIZE) {
+            buffer.removeAt(0)
+        }
+
+        buffer.add(encoder!!.layout.doLayout(event))
+    }
+
+    fun getEncoder(): PatternLayoutEncoder? = encoder
+
+    fun setEncoder(encoder: PatternLayoutEncoder?) {
+        this.encoder = encoder
+    }
+
+    fun getLogBuffer(): ArrayList<String> {
+        return buffer
+    }
+
+    companion object {
+        private const val MAX_BUFFER_SIZE = 1000
+    }
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/logging/FlutterLog.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/logging/FlutterLog.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,18 @@ package com.yubico.authenticator.logging
 
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class FlutterLog(messenger: BinaryMessenger) {
     private var channel = MethodChannel(messenger, "android.log.redirect")
 
+    private val bufferAppender =
+        (LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as ch.qos.logback.classic.Logger)
+            .getAppender("buffer") as BufferAppender
+
     init {
+
         channel.setMethodCallHandler { call, result ->
 
             when (call.method) {
@@ -53,7 +60,7 @@ class FlutterLog(messenger: BinaryMessenger) {
                     result.success(null)
                 }
                 "getLogs" -> {
-                    result.success(Log.getBuffer())
+                    result.success(bufferAppender.getLogBuffer())
                 }
                 else -> {
                     result.notImplemented()

--- a/android/app/src/main/kotlin/com/yubico/authenticator/logging/Log.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/logging/Log.kt
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory
 
 object Log {
 
-    private val logger = LoggerFactory.getLogger("com.yubico.authenticator")
+    private val logger = LoggerFactory.getLogger("com.yubico.authenticator.Log")
 
     enum class LogLevel {
         TRAFFIC,
@@ -32,13 +32,6 @@ object Log {
         INFO,
         WARNING,
         ERROR
-    }
-
-    private const val MAX_BUFFER_SIZE = 1000
-    private val buffer = arrayListOf<String>()
-
-    fun getBuffer() : List<String> {
-        return buffer
     }
 
     private var level = if (BuildConfig.DEBUG) {
@@ -56,17 +49,10 @@ object Log {
             return
         }
 
-        if (buffer.size > MAX_BUFFER_SIZE) {
-            buffer.removeAt(0)
-        }
-
         val logMessage = (if (error == null)
-            "[$loggerName] ${level.name}: $message"
+            "$message [$loggerName]"
         else
-            "[$loggerName] ${level.name}: $message (err: $error)"
-                ).also {
-                buffer.add(it)
-            }
+            "$message [$loggerName] (err: $error)")
 
         when (level) {
             LogLevel.TRAFFIC -> logger.trace(logMessage)


### PR DESCRIPTION
This PR fixes issue where native logs (coming from slf4j logger.xxx calls) were not exposed through the "Copy log" feature. The reason was that such logs were never added to the buffer in the `Log` class.

The issue is solved by the `BufferAppender` class which is wired into our logback structure. Its only purpose is to collect any incoming logging message (originally this was in the `Log` class, now this is removed). The buffer from buffer appender is returned to the application when "Copy log" button is clicked.

The addition of `BufferAppender` does not change anything with `logcat` appender and it is still possible to inspect the logs in with `adb logcat`.

The format of the log message has been updated in the following way:
1. any logs produced in Flutter are tagged with `com.yubico.authenticator.Log` and ahve the logger name at the end of the message in brackets:
    ```
    19:04:37.884 13110-13110 com....Log  D  appLifecycleStateChange triggered with: inactive [android.window_state_provider]
    ```
2. android `slf4j` log messages have its correct tag coming from the logger name
3. The messages don't repeat the log level anymore
