### PR TITLE
Provide account QR from file

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/ActivityUtil.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/ActivityUtil.kt
@@ -40,6 +40,7 @@ class ActivityUtil(private val activity: Activity) {
             MAIN_ACTIVITY_ALIAS,
             PackageManager.COMPONENT_ENABLED_STATE_ENABLED
         )
+        logger.debug("Enabled USB discovery by setting state of $MAIN_ACTIVITY_ALIAS to ENABLED")
     }
 
     /**
@@ -55,6 +56,7 @@ class ActivityUtil(private val activity: Activity) {
             MAIN_ACTIVITY_ALIAS,
             PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
         )
+        logger.debug("Disabled USB discovery by setting state of $MAIN_ACTIVITY_ALIAS to DEFAULT")
     }
 
     /**
@@ -73,6 +75,7 @@ class ActivityUtil(private val activity: Activity) {
             NDEF_ACTIVITY_ALIAS,
             PackageManager.COMPONENT_ENABLED_STATE_DEFAULT
         )
+        logger.debug("Enabled NFC discovery by setting state of $NDEF_ACTIVITY_ALIAS to DEFAULT")
     }
 
     /**
@@ -88,6 +91,7 @@ class ActivityUtil(private val activity: Activity) {
             NDEF_ACTIVITY_ALIAS,
             PackageManager.COMPONENT_ENABLED_STATE_DISABLED
         )
+        logger.debug("Disabled NFC discovery by setting state of $NDEF_ACTIVITY_ALIAS to DISABLED")
     }
 
     private fun setState(aliasName: String, enabledState: Int) {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -176,7 +176,7 @@ class OathManager(
                         delay(delayMs)
                     }
                     val currentState = lifecycleOwner.lifecycle.currentState
-                    if (currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                    if (currentState.isAtLeast(Lifecycle.State.STARTED)) {
                         requestRefresh()
                     } else {
                         logger.debug(

--- a/android/flutter_plugins/qrscanner_zxing/android/build.gradle
+++ b/android/flutter_plugins/qrscanner_zxing/android/build.gradle
@@ -45,6 +45,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
+        targetSdk 34
     }
 }
 

--- a/android/flutter_plugins/qrscanner_zxing/android/build.gradle
+++ b/android/flutter_plugins/qrscanner_zxing/android/build.gradle
@@ -49,12 +49,11 @@ android {
 }
 
 dependencies {
-    def camerax_version = "1.2.3"
+    def camerax_version = "1.3.0"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"
     implementation "androidx.camera:camera-view:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"
-
-    //noinspection GradleDependency
-    implementation "com.google.zxing:core:3.3.3"
+    
+    implementation "com.google.zxing:core:3.5.2"
     implementation "com.google.zxing:android-core:3.3.0"
 }

--- a/android/flutter_plugins/qrscanner_zxing/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/flutter_plugins/qrscanner_zxing/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jun 23 08:50:38 CEST 2017
+#Mon Oct 16 08:48:17 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/android/flutter_plugins/qrscanner_zxing/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/flutter_plugins/qrscanner_zxing/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Oct 16 08:48:17 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
@@ -389,7 +389,7 @@ internal class QRScannerView(
                     fullSize
                 }
 
-                val result = QrCodeScanner.scan(bitmapToProcess)
+                val result = QrCodeScanner.decodeFromBinaryBitmap(bitmapToProcess)
                 if (analysisPaused) {
                     return
                 }

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
@@ -36,7 +36,9 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.startActivity
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
-import com.google.zxing.*
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.NotFoundException
+import com.google.zxing.RGBLuminanceSource
 import com.google.zxing.common.HybridBinarizer
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
@@ -290,11 +292,6 @@ internal class QRScannerView(
     ) : ImageAnalysis.Analyzer {
 
         var analysisPaused = false
-
-        val multiFormatReader = MultiFormatReader().also {
-            it.setHints(mapOf(DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE)))
-        }
-
         var analyzedImagesCount = 0
 
         private fun ByteBuffer.toByteArray(lastRowPadding: Int): ByteArray {
@@ -392,14 +389,14 @@ internal class QRScannerView(
                     fullSize
                 }
 
-                val result: com.google.zxing.Result = multiFormatReader.decode(bitmapToProcess)
+                val result = QrCodeScanner.scan(bitmapToProcess)
                 if (analysisPaused) {
                     return
                 }
 
                 analysisPaused = true // pause
-                Log.v(TAG, "Analysis result: ${result.text}")
-                listener.invoke(Result.success(result.text))
+                Log.v(TAG, "Analysis result: $result")
+                listener.invoke(Result.success(result))
             } catch (_: NotFoundException) {
                 if (analyzedImagesCount == 0) {
                     Log.v(TAG, "  No QR code found (NotFoundException)")

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerZxingPlugin.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerZxingPlugin.kt
@@ -16,6 +16,12 @@
 
 package com.yubico.authenticator.flutter_plugins.qrscanner_zxing
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Log
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.common.HybridBinarizer
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -24,6 +30,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
+import java.lang.Exception
 
 class PermissionsResultRegistrar {
 
@@ -65,10 +72,48 @@ class QRScannerZxingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
-        if (call.method == "getPlatformVersion") {
-            result.success("Android ${android.os.Build.VERSION.RELEASE}")
-        } else {
-            result.notImplemented()
+        when (call.method) {
+            "getPlatformVersion" -> {
+                result.success("Android ${android.os.Build.VERSION.RELEASE}")
+            }
+            "scanBitmap" -> {
+                val imageFileData = call.argument<ByteArray>("bitmap")
+                var bitmap: Bitmap? = null
+                try {
+                    imageFileData?.let { byteArray ->
+                        Log.i(TAG, "Received ${byteArray.size} bytes")
+                        val options = BitmapFactory.Options()
+                        options.inSampleSize = 4
+                        bitmap = BitmapFactory.decodeByteArray(imageFileData, 0, byteArray.size, options)
+                        bitmap?.let {
+                            val intArray = IntArray(it.allocationByteCount)
+                            it.getPixels(intArray, 0, it.width, 0, 0, it.width, it.height)
+                            val luminanceSource =
+                                RGBLuminanceSource(it.rowBytes, it.height, intArray)
+                            val binaryBitmap = BinaryBitmap(HybridBinarizer(luminanceSource))
+                            val scanResult = QrCodeScanner.scan(binaryBitmap)
+                            Log.i(TAG, "Scan result: $scanResult")
+                            result.success(scanResult)
+                            return
+                        }
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failure decoding data: $e")
+                    result.error("Failed to decode", e.message, e)
+                    return
+                } finally {
+                    bitmap?.let {
+                        it.recycle()
+                        bitmap = null
+                    }
+                }
+
+                Log.e(TAG, "Failure decoding data: Invalid image format ")
+                result.error("Failed to decode", "Invalid image format", null)
+            }
+            else -> {
+                result.notImplemented()
+            }
         }
     }
 
@@ -96,5 +141,9 @@ class QRScannerZxingPlugin : FlutterPlugin, MethodCallHandler, ActivityAware,
         grantResults: IntArray
     ): Boolean {
         return registrar.onResult(requestCode, permissions, grantResults)
+    }
+
+    companion object {
+        const val TAG = "QRScannerZxPlugin"
     }
 }

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
@@ -2,6 +2,10 @@ package com.yubico.authenticator.flutter_plugins.qrscanner_zxing
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.ColorMatrix
+import android.graphics.ColorMatrixColorFilter
+import android.graphics.Paint
 import android.util.Log
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.BinaryBitmap
@@ -14,26 +18,48 @@ import com.google.zxing.common.HybridBinarizer
 object QrCodeScanner {
 
     private val qrCodeScanner = MultiFormatReader().also {
-        it.setHints(mapOf(DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE)))
+        it.setHints(
+            mapOf(
+                DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE),
+                DecodeHintType.ALSO_INVERTED to true,
+                DecodeHintType.TRY_HARDER to true
+            )
+        )
     }
 
     fun decodeFromBinaryBitmap(binaryBitmap: BinaryBitmap): String {
-        val result = qrCodeScanner.decode(binaryBitmap)
+        val result = qrCodeScanner.decodeWithState(binaryBitmap)
         return result.text
     }
 
-    fun decodeFromBytes(byteArray: ByteArray): String? {
+    private fun decodeFromBytes(
+        byteArray: ByteArray,
+        sampleSize: Int,
+        rotation: Int,
+        boostContrast: Boolean
+    ): String? {
         var bitmap: Bitmap? = null
         try {
-            Log.v(TAG, "Received ${byteArray.size} bytes")
-            val options = BitmapFactory.Options()
-            bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size, options)
+            Log.v(
+                TAG,
+                "Decoding with sampleSize $sampleSize, rotation $rotation, boostContrast: $boostContrast"
+            )
+            bitmap = getScaledBitmap(byteArray, sampleSize, boostContrast)
             bitmap?.let {
                 val pixels = IntArray(it.allocationByteCount)
                 it.getPixels(pixels, 0, it.width, 0, 0, it.width, it.height)
+
                 val luminanceSource =
                     RGBLuminanceSource(it.width, it.height, pixels)
-                val binaryBitmap = BinaryBitmap(HybridBinarizer(luminanceSource))
+
+                var binaryBitmap = BinaryBitmap(HybridBinarizer(luminanceSource))
+
+                if (rotation in 1..3 && binaryBitmap.isRotateSupported) {
+                    for (r in 1..rotation) {
+                        binaryBitmap = binaryBitmap.rotateCounterClockwise()
+                    }
+                }
+
                 val scanResult = decodeFromBinaryBitmap(binaryBitmap)
                 Log.v(TAG, "Scan result: $scanResult")
                 return scanResult
@@ -53,6 +79,69 @@ object QrCodeScanner {
             }
         }
     }
+
+    fun decodeFromBytes(byteArray: ByteArray): String? {
+        for (boostContrast in sequenceOf(false, true)) {
+            for (rotation in 0 until 4) {
+                for (sampleSize in sequenceOf(1, 4, 8, 12)) {
+                    val code = decodeFromBytes(byteArray, sampleSize, rotation, boostContrast)
+                    if (code != null) {
+                        return code
+                    }
+                }
+            }
+        }
+        return null
+    }
+
+    private fun getScaledBitmap(
+        byteArray: ByteArray,
+        sampleSize: Int,
+        boostContrast: Boolean
+    ): Bitmap? {
+        var inputBitmap: Bitmap? = null
+        try {
+            val options = BitmapFactory.Options()
+            options.inSampleSize = sampleSize
+            inputBitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size, options)
+            inputBitmap?.let {
+                val drawingBitmap =
+                    Bitmap.createBitmap(it.width, it.height, Bitmap.Config.ARGB_8888)
+
+                val canvas = Canvas(drawingBitmap)
+                val cm = ColorMatrix()
+                if (boostContrast) {
+
+                    val contrast = 0f
+                    val scale = contrast + 1f
+                    val translate = (-.5f * scale + .5f) * 255f
+
+                    cm.setSaturation(0f)
+                    cm.postConcat(
+                        ColorMatrix(
+                            floatArrayOf(
+                                scale, 0f, 0f, 0f, translate,
+                                0f, scale, 0f, 0f, translate,
+                                0f, 0f, scale, 0f, translate,
+                                0f, 0f, 0f, scale, 0f
+                            )
+                        )
+                    )
+                }
+
+                val paint = Paint()
+                paint.setColorFilter(ColorMatrixColorFilter(cm))
+                canvas.drawBitmap(it, 0f, 0f, paint)
+
+                return drawingBitmap
+            }
+        } finally {
+            inputBitmap?.recycle()
+        }
+
+        return null
+    }
+
 
     private const val TAG = "QRScanner"
 }

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
@@ -1,0 +1,18 @@
+package com.yubico.authenticator.flutter_plugins.qrscanner_zxing
+
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.BinaryBitmap
+import com.google.zxing.DecodeHintType
+import com.google.zxing.MultiFormatReader
+
+object QrCodeScanner {
+
+    private val qrCodeScanner = MultiFormatReader().also {
+        it.setHints(mapOf(DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE)))
+    }
+
+    fun scan(binaryBitmap: BinaryBitmap) : String {
+        val result: com.google.zxing.Result = qrCodeScanner.decode(binaryBitmap)
+        return result.text
+    }
+}

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
@@ -2,10 +2,6 @@ package com.yubico.authenticator.flutter_plugins.qrscanner_zxing
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.ColorMatrix
-import android.graphics.ColorMatrixColorFilter
-import android.graphics.Paint
 import android.util.Log
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.BinaryBitmap
@@ -34,17 +30,17 @@ object QrCodeScanner {
 
     private fun decodeFromBytes(
         byteArray: ByteArray,
-        sampleSize: Int,
-        rotation: Int,
-        boostContrast: Boolean
+        sampleSize: Int
     ): String? {
         var bitmap: Bitmap? = null
         try {
             Log.v(
                 TAG,
-                "Decoding with sampleSize $sampleSize, rotation $rotation, boostContrast: $boostContrast"
+                "Decoding with sampleSize $sampleSize"
             )
-            bitmap = getScaledBitmap(byteArray, sampleSize, boostContrast)
+            val options = BitmapFactory.Options()
+            options.inSampleSize = sampleSize
+            bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size, options)
             bitmap?.let {
                 val pixels = IntArray(it.allocationByteCount)
                 it.getPixels(pixels, 0, it.width, 0, 0, it.width, it.height)
@@ -52,14 +48,7 @@ object QrCodeScanner {
                 val luminanceSource =
                     RGBLuminanceSource(it.width, it.height, pixels)
 
-                var binaryBitmap = BinaryBitmap(HybridBinarizer(luminanceSource))
-
-                if (rotation in 1..3 && binaryBitmap.isRotateSupported) {
-                    for (r in 1..rotation) {
-                        binaryBitmap = binaryBitmap.rotateCounterClockwise()
-                    }
-                }
-
+                val binaryBitmap = BinaryBitmap(HybridBinarizer(luminanceSource))
                 val scanResult = decodeFromBinaryBitmap(binaryBitmap)
                 Log.v(TAG, "Scan result: $scanResult")
                 return scanResult
@@ -81,67 +70,11 @@ object QrCodeScanner {
     }
 
     fun decodeFromBytes(byteArray: ByteArray): String? {
-        for (boostContrast in sequenceOf(false, true)) {
-            for (rotation in 0 until 4) {
-                for (sampleSize in sequenceOf(1, 4, 8, 12)) {
-                    val code = decodeFromBytes(byteArray, sampleSize, rotation, boostContrast)
-                    if (code != null) {
-                        return code
-                    }
-                }
-            }
-        }
-        return null
+        return decodeFromBytes(byteArray, 1)
+            ?: decodeFromBytes(byteArray, 4)
+            ?: decodeFromBytes(byteArray, 8)
+            ?: decodeFromBytes(byteArray, 12)
     }
-
-    private fun getScaledBitmap(
-        byteArray: ByteArray,
-        sampleSize: Int,
-        boostContrast: Boolean
-    ): Bitmap? {
-        var inputBitmap: Bitmap? = null
-        try {
-            val options = BitmapFactory.Options()
-            options.inSampleSize = sampleSize
-            inputBitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size, options)
-            inputBitmap?.let {
-                val drawingBitmap =
-                    Bitmap.createBitmap(it.width, it.height, Bitmap.Config.ARGB_8888)
-
-                val canvas = Canvas(drawingBitmap)
-                val cm = ColorMatrix()
-                if (boostContrast) {
-
-                    val contrast = 0f
-                    val scale = contrast + 1f
-                    val translate = (-.5f * scale + .5f) * 255f
-
-                    cm.setSaturation(0f)
-                    cm.postConcat(
-                        ColorMatrix(
-                            floatArrayOf(
-                                scale, 0f, 0f, 0f, translate,
-                                0f, scale, 0f, 0f, translate,
-                                0f, 0f, scale, 0f, translate,
-                                0f, 0f, 0f, scale, 0f
-                            )
-                        )
-                    )
-                }
-
-                val paint = Paint()
-                paint.setColorFilter(ColorMatrixColorFilter(cm))
-                canvas.drawBitmap(it, 0f, 0f, paint)
-
-                return drawingBitmap
-            }
-        } finally {
-            inputBitmap?.recycle()
-        }
-
-        return null
-    }
-
 
     private const val TAG = "QRScanner"
 }

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QrScanner.kt
@@ -1,9 +1,15 @@
 package com.yubico.authenticator.flutter_plugins.qrscanner_zxing
 
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Log
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.BinaryBitmap
 import com.google.zxing.DecodeHintType
 import com.google.zxing.MultiFormatReader
+import com.google.zxing.NotFoundException
+import com.google.zxing.RGBLuminanceSource
+import com.google.zxing.common.HybridBinarizer
 
 object QrCodeScanner {
 
@@ -11,8 +17,42 @@ object QrCodeScanner {
         it.setHints(mapOf(DecodeHintType.POSSIBLE_FORMATS to listOf(BarcodeFormat.QR_CODE)))
     }
 
-    fun scan(binaryBitmap: BinaryBitmap) : String {
-        val result: com.google.zxing.Result = qrCodeScanner.decode(binaryBitmap)
+    fun decodeFromBinaryBitmap(binaryBitmap: BinaryBitmap): String {
+        val result = qrCodeScanner.decode(binaryBitmap)
         return result.text
     }
+
+    fun decodeFromBytes(byteArray: ByteArray): String? {
+        var bitmap: Bitmap? = null
+        try {
+            Log.v(TAG, "Received ${byteArray.size} bytes")
+            val options = BitmapFactory.Options()
+            bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size, options)
+            bitmap?.let {
+                val pixels = IntArray(it.allocationByteCount)
+                it.getPixels(pixels, 0, it.width, 0, 0, it.width, it.height)
+                val luminanceSource =
+                    RGBLuminanceSource(it.width, it.height, pixels)
+                val binaryBitmap = BinaryBitmap(HybridBinarizer(luminanceSource))
+                val scanResult = decodeFromBinaryBitmap(binaryBitmap)
+                Log.v(TAG, "Scan result: $scanResult")
+                return scanResult
+            }
+            Log.e(TAG, "Could not decode image data.")
+            return null
+        } catch (_: NotFoundException) {
+            Log.e(TAG, "No QR code found/decoded.")
+            return null
+        } catch (e: Throwable) {
+            Log.e(TAG, "Exception while decoding data: ", e)
+            return null
+        } finally {
+            bitmap?.let {
+                it.recycle()
+                bitmap = null
+            }
+        }
+    }
+
+    private const val TAG = "QRScanner"
 }

--- a/android/flutter_plugins/qrscanner_zxing/example/android/app/build.gradle
+++ b/android/flutter_plugins/qrscanner_zxing/example/android/app/build.gradle
@@ -26,8 +26,10 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
     ndkVersion flutter.ndkVersion
+
+    namespace 'com.yubico.authenticator.flutter_plugins.qrscanner_zxing_example'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -48,7 +50,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }
@@ -59,6 +61,10 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 }
 

--- a/android/flutter_plugins/qrscanner_zxing/example/android/build.gradle
+++ b/android/flutter_plugins/qrscanner_zxing/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:8.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }

--- a/android/flutter_plugins/qrscanner_zxing/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/flutter_plugins/qrscanner_zxing/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/android/flutter_plugins/qrscanner_zxing/example/lib/main.dart
+++ b/android/flutter_plugins/qrscanner_zxing/example/lib/main.dart
@@ -68,8 +68,10 @@ class AppHomePage extends StatelessWidget {
                 child: const Text("Open QR Scanner")),
             ElevatedButton(
                 onPressed: () async {
+                  var channel = MethodChannelQRScannerZxing();
+                  final scaffoldMessenger = ScaffoldMessenger.of(context);
                   final result = await FilePicker.platform.pickFiles(
-                      allowedExtensions: ['png', 'jpg'],
+                      allowedExtensions: ['png', 'jpg', 'gif', 'webp'],
                       type: FileType.custom,
                       allowMultiple: false,
                       lockParentWindow: true,
@@ -82,11 +84,13 @@ class AppHomePage extends StatelessWidget {
                   }
 
                   final bytes = result.files.first.bytes;
-
                   if (bytes != null) {
-                    var channel = MethodChannelQRScannerZxing();
                     var value = await channel.scanBitmap(bytes);
-                    debugPrint(value);
+                    final snackBar = SnackBar(
+                        content: Text(value == null
+                            ? 'No QR code detected'
+                            : 'QR: $value'));
+                    scaffoldMessenger.showSnackBar(snackBar);
                   } else {
                     // no files selected
                   }

--- a/android/flutter_plugins/qrscanner_zxing/example/lib/main.dart
+++ b/android/flutter_plugins/qrscanner_zxing/example/lib/main.dart
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:qrscanner_zxing/qrscanner_zxing_method_channel.dart';
 import 'package:qrscanner_zxing/qrscanner_zxing_view.dart';
 
 import 'cutout_overlay.dart';
@@ -64,6 +66,32 @@ class AppHomePage extends StatelessWidget {
                       ));
                 },
                 child: const Text("Open QR Scanner")),
+            ElevatedButton(
+                onPressed: () async {
+                  final result = await FilePicker.platform.pickFiles(
+                      allowedExtensions: ['png', 'jpg'],
+                      type: FileType.custom,
+                      allowMultiple: false,
+                      lockParentWindow: true,
+                      withData: true,
+                      dialogTitle: 'Select file with QR code');
+
+                  if (result == null || !result.isSinglePick) {
+                    // no result
+                    return;
+                  }
+
+                  final bytes = result.files.first.bytes;
+
+                  if (bytes != null) {
+                    var channel = MethodChannelQRScannerZxing();
+                    var value = await channel.scanBitmap(bytes);
+                    debugPrint(value);
+                  } else {
+                    // no files selected
+                  }
+                },
+                child: const Text("Scan from file")),
           ],
         ),
       ),

--- a/android/flutter_plugins/qrscanner_zxing/example/pubspec.lock
+++ b/android/flutter_plugins/qrscanner_zxing/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: be325344c1f3070354a1d84a231a1ba75ea85d413774ec4bdf444c023342e030
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.5.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -70,19 +86,24 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: f185ac890306b5779ecbd611f52502d8d4d63d27703ef73161ca0407e815f02c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.16"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
+  flutter_web_plugins:
     dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   lints:
     dependency: transitive
     description:
@@ -95,18 +116,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -127,10 +148,10 @@ packages:
     dependency: transitive
     description:
       name: plugin_platform_interface
-      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
+      sha256: da3fdfeccc4d4ff2da8f8c556704c08f912542c5fb3cf2233ed75372384a034d
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.6"
   qrscanner_zxing:
     dependency: "direct main"
     description:
@@ -147,10 +168,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -187,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -199,6 +220,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.9"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
+  flutter: ">=3.7.0"

--- a/android/flutter_plugins/qrscanner_zxing/example/pubspec.yaml
+++ b/android/flutter_plugins/qrscanner_zxing/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the qrscanner_zxing plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.17.0-266.1.beta <3.0.0"
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -14,6 +14,7 @@ dependencies:
     path: ../
 
   cupertino_icons: ^1.0.2
+  file_picker: ^5.3.2
 
 dev_dependencies:
   flutter_test:

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing.dart
@@ -14,10 +14,16 @@
  * limitations under the License.
  */
 
+import 'dart:typed_data';
+
 import 'qrscanner_zxing_platform_interface.dart';
 
 class QRScannerZxing {
   Future<String?> getPlatformVersion() {
     return QRScannerZxingPlatform.instance.getPlatformVersion();
+  }
+
+  Future<String?> scanBitmap(Uint8List bitmap) {
+    return QRScannerZxingPlatform.instance.scanBitmap(bitmap);
   }
 }

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_method_channel.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_method_channel.dart
@@ -31,4 +31,11 @@ class MethodChannelQRScannerZxing extends QRScannerZxingPlatform {
         await methodChannel.invokeMethod<String>('getPlatformVersion');
     return version;
   }
+
+  @override
+  Future<String?> scanBitmap(Uint8List bitmap) async {
+    final version = await methodChannel
+        .invokeMethod<String>('scanBitmap', {'bitmap': bitmap});
+    return version;
+  }
 }

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_method_channel.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_method_channel.dart
@@ -28,14 +28,14 @@ class MethodChannelQRScannerZxing extends QRScannerZxingPlatform {
   @override
   Future<String?> getPlatformVersion() async {
     final version =
-        await methodChannel.invokeMethod<String>('getPlatformVersion');
+    await methodChannel.invokeMethod<String>('getPlatformVersion');
     return version;
   }
 
   @override
-  Future<String?> scanBitmap(Uint8List bitmap) async {
+  Future<String?> scanBitmap(Uint8List bytes) async {
     final version = await methodChannel
-        .invokeMethod<String>('scanBitmap', {'bitmap': bitmap});
+        .invokeMethod<String>('scanBitmap', {'bytes': bytes});
     return version;
   }
 }

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_method_channel.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_method_channel.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,14 +28,14 @@ class MethodChannelQRScannerZxing extends QRScannerZxingPlatform {
   @override
   Future<String?> getPlatformVersion() async {
     final version =
-    await methodChannel.invokeMethod<String>('getPlatformVersion');
+        await methodChannel.invokeMethod<String>('getPlatformVersion');
     return version;
   }
 
   @override
   Future<String?> scanBitmap(Uint8List bytes) async {
-    final version = await methodChannel
+    final result = await methodChannel
         .invokeMethod<String>('scanBitmap', {'bytes': bytes});
-    return version;
+    return result;
   }
 }

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_platform_interface.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_platform_interface.dart
@@ -45,7 +45,7 @@ abstract class QRScannerZxingPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Future<String?> scanBitmap(Uint8List bitmap) {
-    throw UnimplementedError('platformVersion() has not been implemented.');
+  Future<String?> scanBitmap(Uint8List bytes) {
+    throw UnimplementedError('scanBitmap(Uint8List) has not been implemented.');
   }
 }

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_platform_interface.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_platform_interface.dart
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import 'dart:typed_data';
+
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'qrscanner_zxing_method_channel.dart';
@@ -40,6 +42,10 @@ abstract class QRScannerZxingPlatform extends PlatformInterface {
   }
 
   Future<String?> getPlatformVersion() {
+    throw UnimplementedError('platformVersion() has not been implemented.');
+  }
+
+  Future<String?> scanBitmap(Uint8List bitmap) {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 }

--- a/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_view.dart
+++ b/android/flutter_plugins/qrscanner_zxing/lib/qrscanner_zxing_view.dart
@@ -24,13 +24,21 @@ import 'package:flutter/services.dart';
 
 class QRScannerZxingView extends StatefulWidget {
   final int marginPct;
+  /// Called when a code has been detected.
   final Function(String rawData) onDetect;
+  /// Called before the system UI with runtime permissions request is
+  /// displayed.
+  final Function()? beforePermissionsRequest;
+  /// Called after the view is completely initialized.
+  ///
+  /// permissionsGranted is true if the user granted camera permissions.
   final Function(bool permissionsGranted) onViewInitialized;
 
   const QRScannerZxingView(
       {Key? key,
       required this.marginPct,
       required this.onDetect,
+      this.beforePermissionsRequest,
       required this.onViewInitialized})
       : super(key: key);
 
@@ -50,6 +58,9 @@ class QRScannerZxingViewState extends State<QRScannerZxingView> {
             var arguments = jsonDecode(call.arguments);
             var rawValue = arguments["value"];
             widget.onDetect(rawValue);
+            return;
+          case "beforePermissionsRequest":
+            widget.beforePermissionsRequest?.call();
             return;
           case "viewInitialized":
             var arguments = jsonDecode(call.arguments);

--- a/android/flutter_plugins/qrscanner_zxing/test/qrscanner_zxing_test.dart
+++ b/android/flutter_plugins/qrscanner_zxing/test/qrscanner_zxing_test.dart
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:qrscanner_zxing/qrscanner_zxing.dart';
@@ -25,6 +27,10 @@ class MockQRScannerZxingPlatform
     implements QRScannerZxingPlatform {
   @override
   Future<String?> getPlatformVersion() => Future.value('42');
+
+  @override
+  Future<String?> scanBitmap(Uint8List bitmap) =>
+      Future.value(bitmap.length.toString());
 }
 
 void main() {
@@ -41,5 +47,13 @@ void main() {
     QRScannerZxingPlatform.instance = fakePlatform;
 
     expect(await qrscannerZxingPlugin.getPlatformVersion(), '42');
+  });
+
+  test('scanBitmap', () async {
+    QRScannerZxing qrscannerZxingPlugin = QRScannerZxing();
+    MockQRScannerZxingPlatform fakePlatform = MockQRScannerZxingPlatform();
+    QRScannerZxingPlatform.instance = fakePlatform;
+
+    expect(await qrscannerZxingPlugin.scanBitmap(Uint8List(10)), '10');
   });
 }

--- a/android/flutter_plugins/qrscanner_zxing/test/qrscanner_zxing_test.dart
+++ b/android/flutter_plugins/qrscanner_zxing/test/qrscanner_zxing_test.dart
@@ -29,8 +29,8 @@ class MockQRScannerZxingPlatform
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
-  Future<String?> scanBitmap(Uint8List bitmap) =>
-      Future.value(bitmap.length.toString());
+  Future<String?> scanBitmap(Uint8List bytes) =>
+      Future.value(bytes.length.toString());
 }
 
 void main() {

--- a/lib/android/app_methods.dart
+++ b/lib/android/app_methods.dart
@@ -34,6 +34,16 @@ Future<bool> isNfcEnabled() async {
   return await appMethodsChannel.invokeMethod('isNfcEnabled');
 }
 
+/// The next onPause/onResume lifecycle event will not stop and start
+/// USB/NFC discovery which will preserve the current YubiKey connection.
+///
+/// This function should be called before showing system dialogs, such as
+/// native file picker or permission request dialogs.
+/// The state automatically resets during onResume call.
+Future<void> preserveConnectedDeviceWhenPaused() async {
+  await appMethodsChannel.invokeMethod('preserveConnectionOnPause');
+}
+
 Future<void> openNfcSettings() async {
   await appMethodsChannel.invokeMethod('openNfcSettings');
 }

--- a/lib/android/keys.dart
+++ b/lib/android/keys.dart
@@ -22,6 +22,7 @@ const _prefix = 'android.keys';
 
 const okButton = Key('$_prefix.ok');
 const manualEntryButton = Key('$_prefix.manual_entry');
+const readFromImage = Key('$_prefix.read_image_file');
 
 const nfcBypassTouchSetting = Key('$_prefix.nfc_bypass_touch');
 const nfcSilenceSoundsSettings = Key('$_prefix.nfc_silence_sounds');

--- a/lib/android/qr_scanner/qr_scanner_permissions_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_permissions_view.dart
@@ -16,6 +16,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:yubico_authenticator/android/qr_scanner/qr_scanner_provider.dart';
 
 import 'qr_scanner_scan_status.dart';
 
@@ -47,45 +48,69 @@ class QRScannerPermissionsUI extends StatelessWidget {
               style: const TextStyle(color: Colors.white),
               textAlign: TextAlign.center,
             ),
-            Row(
-                mainAxisSize: MainAxisSize.min,
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  Column(
+            Column(
+              children: [
+                Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
-                      Text(
-                        l10n.q_have_account_info,
-                        textScaleFactor: 0.7,
-                        style: const TextStyle(color: Colors.white),
-                      ),
+                      Column(
+                        children: [
+                          Text(
+                            l10n.q_want_to_scan,
+                            textScaleFactor: 0.7,
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          OutlinedButton(
+                              onPressed: () {
+                                onPermissionRequest();
+                              },
+                              child: Text(
+                                l10n.s_review_permissions,
+                                style: const TextStyle(color: Colors.white),
+                              )),
+                        ],
+                      )
+                    ]),
+                const SizedBox(height: 16),
+                Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
+                      Column(children: [
+                        Text(
+                          l10n.q_have_account_info,
+                          textScaleFactor: 0.7,
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ])
+                    ]),
+                Row(
+                    mainAxisSize: MainAxisSize.min,
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: [
                       OutlinedButton(
                           onPressed: () {
-                            Navigator.of(context).pop('');
+                            Navigator.of(context).pop(
+                                AndroidQrScanner.kQrScannerRequestManualEntry);
                           },
                           child: Text(
                             l10n.s_enter_manually,
                             style: const TextStyle(color: Colors.white),
                           )),
-                    ],
-                  ),
-                  Column(
-                    children: [
-                      Text(
-                        l10n.q_want_to_scan,
-                        textScaleFactor: 0.7,
-                        style: const TextStyle(color: Colors.white),
-                      ),
+                      const SizedBox(width: 16),
                       OutlinedButton(
                           onPressed: () {
-                            onPermissionRequest();
+                            Navigator.of(context).pop(
+                                AndroidQrScanner.kQrScannerRequestReadFromFile);
                           },
                           child: Text(
-                            l10n.s_review_permissions,
+                            l10n.s_read_from_file,
                             style: const TextStyle(color: Colors.white),
-                          )),
-                    ],
-                  )
-                ])
+                          ))
+                    ]),
+              ],
+            )
           ],
         ),
       ),

--- a/lib/android/qr_scanner/qr_scanner_provider.dart
+++ b/lib/android/qr_scanner/qr_scanner_provider.dart
@@ -93,7 +93,7 @@ class AndroidQrScanner implements QrScanner {
             allowMultiple: false,
             lockParentWindow: true,
             withData: true,
-            dialogTitle: 'Select file with QR code');
+            dialogTitle: l10n.l_qr_select_file);
 
         if (result == null || !result.isSinglePick) {
           // no result

--- a/lib/android/qr_scanner/qr_scanner_provider.dart
+++ b/lib/android/qr_scanner/qr_scanner_provider.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2023 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,25 @@
 
 import 'dart:convert';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:qrscanner_zxing/qrscanner_zxing_method_channel.dart';
 import 'package:yubico_authenticator/app/state.dart';
 import 'package:yubico_authenticator/exception/cancellation_exception.dart';
 import 'package:yubico_authenticator/theme.dart';
 
-import 'package:qrscanner_zxing/qrscanner_zxing_method_channel.dart';
-
+import '../../app/message.dart';
+import '../../oath/views/add_account_page.dart';
+import '../../oath/views/utils.dart';
 import 'qr_scanner_view.dart';
 
 class AndroidQrScanner implements QrScanner {
+  static const String kQrScannerRequestManualEntry =
+      '__QR_SCANNER_ENTER_MANUALLY__';
+  static const String kQrScannerRequestReadFromFile =
+      '__QR_SCANNER_SCAN_FROM_FILE__';
   final WithContext _withContext;
 
   AndroidQrScanner(this._withContext);
@@ -33,8 +42,7 @@ class AndroidQrScanner implements QrScanner {
   @override
   Future<String?> scanQr([String? imageData]) async {
     if (imageData == null) {
-      var scannedCode = await _withContext(
-              (context) async =>
+      var scannedCode = await _withContext((context) async =>
           await Navigator.of(context).push(PageRouteBuilder(
             pageBuilder: (_, __, ___) =>
                 Theme(data: AppTheme.darkTheme, child: const QrScannerView()),
@@ -55,9 +63,62 @@ class AndroidQrScanner implements QrScanner {
       return await zxingChannel.scanBitmap(base64Decode(imageData));
     }
   }
+
+  static Future<void> handleScannedData(
+      String? qrData, WidgetRef ref, AppLocalizations l10n) async {
+    final withContext = ref.read(withContextProvider);
+    switch (qrData) {
+      case null:
+        break;
+      case kQrScannerRequestManualEntry:
+        await withContext((context) => showBlurDialog(
+              context: context,
+              routeSettings: const RouteSettings(name: 'oath_add_account'),
+              builder: (context) {
+                return const OathAddAccountPage(
+                  null,
+                  null,
+                  credentials: null,
+                );
+              },
+            ));
+      case kQrScannerRequestReadFromFile:
+        final result = await FilePicker.platform.pickFiles(
+            allowedExtensions: ['png', 'jpg', 'gif', 'webp'],
+            type: FileType.custom,
+            allowMultiple: false,
+            lockParentWindow: true,
+            withData: true,
+            dialogTitle: 'Select file with QR code');
+
+        if (result == null || !result.isSinglePick) {
+          // no result
+          return;
+        }
+
+        final bytes = result.files.first.bytes;
+        final scanner = ref.read(qrScannerProvider);
+        if (bytes != null && scanner != null) {
+          final b64bytes = base64Encode(bytes);
+          final qrData = await scanner.scanQr(b64bytes);
+          if (qrData != null) {
+            await withContext((context) =>
+                handleUri(context, null, qrData, null, null, l10n));
+            return;
+          }
+        }
+        // no QR code found
+        await withContext(
+            (context) async => showMessage(context, l10n.l_qr_not_found));
+
+      default:
+        await withContext(
+            (context) => handleUri(context, null, qrData, null, null, l10n));
+    }
+  }
 }
 
 QrScanner? Function(dynamic) androidQrScannerProvider(hasCamera) {
   return (ref) =>
-  hasCamera ? AndroidQrScanner(ref.watch(withContextProvider)) : null;
+      hasCamera ? AndroidQrScanner(ref.watch(withContextProvider)) : null;
 }

--- a/lib/android/qr_scanner/qr_scanner_ui_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_ui_view.dart
@@ -16,13 +16,12 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yubico_authenticator/android/qr_scanner/qr_scanner_provider.dart';
 
 import '../keys.dart' as keys;
 import 'qr_scanner_scan_status.dart';
 
-class QRScannerUI extends ConsumerWidget {
+class QRScannerUI extends StatelessWidget {
   final ScanStatus status;
   final Size screenSize;
   final GlobalKey overlayWidgetKey;
@@ -34,7 +33,7 @@ class QRScannerUI extends ConsumerWidget {
       required this.overlayWidgetKey});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
 
     return Stack(
@@ -75,32 +74,29 @@ class QRScannerUI extends ConsumerWidget {
                     textScaleFactor: 0.7,
                     style: const TextStyle(color: Colors.white),
                   ),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      OutlinedButton(
-                          onPressed: () {
-                            Navigator.of(context).pop(
-                                AndroidQrScanner.kQrScannerRequestManualEntry);
-                          },
-                          key: keys.manualEntryButton,
-                          child: Text(
-                            l10n.s_enter_manually,
-                            style: const TextStyle(color: Colors.white),
-                          )),
-                      const SizedBox(width: 16),
-                      OutlinedButton(
-                          onPressed: () {
-                            Navigator.of(context).pop(
-                                AndroidQrScanner.kQrScannerRequestReadFromFile);
-                          },
-                          key: keys.readFromImage,
-                          child: Text(
-                            l10n.s_read_from_file,
-                            style: const TextStyle(color: Colors.white),
-                          ))
-                    ],
-                  ),
+                  Row(mainAxisAlignment: MainAxisAlignment.center, children: [
+                    OutlinedButton(
+                        onPressed: () {
+                          Navigator.of(context).pop(
+                              AndroidQrScanner.kQrScannerRequestManualEntry);
+                        },
+                        key: keys.manualEntryButton,
+                        child: Text(
+                          l10n.s_enter_manually,
+                          style: const TextStyle(color: Colors.white),
+                        )),
+                    const SizedBox(width: 16),
+                    OutlinedButton(
+                        onPressed: () {
+                          Navigator.of(context).pop(
+                              AndroidQrScanner.kQrScannerRequestReadFromFile);
+                        },
+                        key: keys.readFromImage,
+                        child: Text(
+                          l10n.s_read_from_file,
+                          style: const TextStyle(color: Colors.white),
+                        ))
+                  ])
                 ],
               ),
               const SizedBox(height: 16)

--- a/lib/android/qr_scanner/qr_scanner_ui_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_ui_view.dart
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-import 'dart:convert';
-
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:yubico_authenticator/app/state.dart';
+import 'package:yubico_authenticator/android/qr_scanner/qr_scanner_provider.dart';
 
 import '../keys.dart' as keys;
 import 'qr_scanner_scan_status.dart';
@@ -79,53 +76,34 @@ class QRScannerUI extends ConsumerWidget {
                     style: const TextStyle(color: Colors.white),
                   ),
                   Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       OutlinedButton(
                           onPressed: () {
-                            Navigator.of(context).pop('');
+                            Navigator.of(context).pop(
+                                AndroidQrScanner.kQrScannerRequestManualEntry);
                           },
                           key: keys.manualEntryButton,
                           child: Text(
                             l10n.s_enter_manually,
                             style: const TextStyle(color: Colors.white),
                           )),
+                      const SizedBox(width: 16),
                       OutlinedButton(
-                          onPressed: () async {
-                            Navigator.of(context).pop('');
-                            final result = await FilePicker.platform.pickFiles(
-                                allowedExtensions: ['png', 'jpg'],
-                                type: FileType.custom,
-                                allowMultiple: false,
-                                lockParentWindow: true,
-                                dialogTitle: 'Select file with QR code');
-                            if (result != null && result.files.isNotEmpty) {
-                              final fileWithCode = result.files.first;
-                              final bytes = fileWithCode.bytes;
-                              if (bytes == null || bytes.isEmpty) {
-                                //err return
-                                return;
-                              }
-                              if (bytes.length > 3 * 1024 * 1024) {
-                                // too big file
-                                return;
-                              }
-                              final scanner = ref.read(qrScannerProvider);
-                              if (scanner != null) {
-                                await scanner.scanQr(base64UrlEncode(bytes));
-                              }
-                            }
+                          onPressed: () {
+                            Navigator.of(context).pop(
+                                AndroidQrScanner.kQrScannerRequestReadFromFile);
                           },
                           key: keys.readFromImage,
                           child: Text(
-                            l10n.s_read_from_image,
+                            l10n.s_read_from_file,
                             style: const TextStyle(color: Colors.white),
-                          )),
+                          ))
                     ],
                   ),
                 ],
               ),
-              const SizedBox(height: 8)
+              const SizedBox(height: 16)
             ],
           ),
         )

--- a/lib/android/qr_scanner/qr_scanner_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_view.dart
@@ -17,6 +17,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:qrscanner_zxing/qrscanner_zxing_view.dart';
+import 'package:yubico_authenticator/android/app_methods.dart';
 
 import '../../oath/models.dart';
 import 'qr_scanner_overlay_view.dart';
@@ -138,17 +139,21 @@ class _QrScannerViewState extends State<QrScannerView> {
               maintainSize: true,
               visible: _permissionsGranted,
               child: QRScannerZxingView(
-                  key: _zxingViewKey,
-                  marginPct: 10,
-                  onDetect: (scannedData) => handleResult(scannedData),
-                  onViewInitialized: (bool permissionsGranted) {
-                    Future.delayed(const Duration(milliseconds: 50), () {
-                      setState(() {
-                        _previewInitialized = true;
-                        _permissionsGranted = permissionsGranted;
-                      });
+                key: _zxingViewKey,
+                marginPct: 10,
+                onDetect: (scannedData) => handleResult(scannedData),
+                onViewInitialized: (bool permissionsGranted) {
+                  Future.delayed(const Duration(milliseconds: 50), () {
+                    setState(() {
+                      _previewInitialized = true;
+                      _permissionsGranted = permissionsGranted;
                     });
-                  })),
+                  });
+                },
+                beforePermissionsRequest: () async {
+                  await preserveConnectedDeviceWhenPaused();
+                },
+              )),
           Visibility(
               visible: _permissionsGranted,
               child: QRScannerOverlay(

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -15,19 +15,18 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 import '../../android/app_methods.dart';
+import '../../android/qr_scanner/qr_scanner_provider.dart';
 import '../../android/state.dart';
-import '../../exception/cancellation_exception.dart';
 import '../../core/state.dart';
+import '../../exception/cancellation_exception.dart';
 import '../../fido/views/fido_screen.dart';
-import '../../oath/views/add_account_page.dart';
 import '../../oath/views/oath_screen.dart';
-import '../../oath/views/utils.dart';
 import '../../piv/views/piv_screen.dart';
 import '../../widgets/custom_icons.dart';
-import '../message.dart';
 import '../models.dart';
 import '../state.dart';
 import 'device_error_screen.dart';
@@ -99,33 +98,16 @@ class MainPage extends ConsumerWidget {
             icon: const Icon(Icons.person_add_alt_1),
             tooltip: l10n.s_add_account,
             onPressed: () async {
-              final withContext = ref.read(withContextProvider);
               final scanner = ref.read(qrScannerProvider);
               if (scanner != null) {
                 try {
                   final qrData = await scanner.scanQr();
-                  if (qrData != null) {
-                    await withContext((context) =>
-                        handleUri(context, null, qrData, null, null, l10n));
-                    return;
-                  }
+                  await AndroidQrScanner.handleScannedData(qrData, ref, l10n);
                 } on CancellationException catch (_) {
                   // ignored - user cancelled
                   return;
                 }
               }
-              await withContext((context) => showBlurDialog(
-                    context: context,
-                    routeSettings:
-                        const RouteSettings(name: 'oath_add_account'),
-                    builder: (context) {
-                      return const OathAddAccountPage(
-                        null,
-                        null,
-                        credentials: null,
-                      );
-                    },
-                  ));
             },
           ),
         );

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -98,11 +98,13 @@ class MainPage extends ConsumerWidget {
             icon: const Icon(Icons.person_add_alt_1),
             tooltip: l10n.s_add_account,
             onPressed: () async {
-              final scanner = ref.read(qrScannerProvider);
-              if (scanner != null) {
+              final withContext = ref.read(withContextProvider);
+              final qrScanner = ref.read(qrScannerProvider);
+              if (qrScanner != null) {
                 try {
-                  final qrData = await scanner.scanQr();
-                  await AndroidQrScanner.handleScannedData(qrData, ref, l10n);
+                  final qrData = await qrScanner.scanQr();
+                  await AndroidQrScanner.handleScannedData(
+                      qrData, withContext, qrScanner, l10n);
                 } on CancellationException catch (_) {
                   // ignored - user cancelled
                   return;

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -506,6 +506,7 @@
     "l_qr_scanned": "Scanned QR code",
     "l_invalid_qr": "Invalid QR code",
     "l_qr_not_found": "No QR code found",
+    "l_qr_select_file": "Select file with QR code",
     "l_qr_not_read": "Failed reading QR code: {message}",
     "@l_qr_not_read" : {
         "placeholders": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -516,6 +516,7 @@
     "q_want_to_scan": "Would like to scan?",
     "q_no_qr": "No QR code?",
     "s_enter_manually": "Enter manually",
+    "s_read_from_image": "Provide image file",
 
     "@_factory_reset": {},
     "s_reset": "Reset",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -516,7 +516,7 @@
     "q_want_to_scan": "Would like to scan?",
     "q_no_qr": "No QR code?",
     "s_enter_manually": "Enter manually",
-    "s_read_from_image": "Provide image file",
+    "s_read_from_file": "Read from file",
 
     "@_factory_reset": {},
     "s_reset": "Reset",

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -30,10 +30,10 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/user_interaction.dart';
-import '../../exception/apdu_exception.dart';
-import '../../exception/cancellation_exception.dart';
 import '../../core/state.dart';
 import '../../desktop/models.dart';
+import '../../exception/apdu_exception.dart';
+import '../../exception/cancellation_exception.dart';
 import '../../management/models.dart';
 import '../../widgets/choice_filter_chip.dart';
 import '../../widgets/file_drop_target.dart';
@@ -56,6 +56,7 @@ class OathAddAccountPage extends ConsumerStatefulWidget {
   final OathState? state;
   final List<OathCredential>? credentials;
   final CredentialData? credentialData;
+
   const OathAddAccountPage(
     this.devicePath,
     this.state, {

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -30,10 +30,10 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/user_interaction.dart';
-import '../../core/state.dart';
-import '../../desktop/models.dart';
 import '../../exception/apdu_exception.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../core/state.dart';
+import '../../desktop/models.dart';
 import '../../management/models.dart';
 import '../../widgets/choice_filter_chip.dart';
 import '../../widgets/file_drop_target.dart';
@@ -56,7 +56,6 @@ class OathAddAccountPage extends ConsumerStatefulWidget {
   final OathState? state;
   final List<OathCredential>? credentials;
   final CredentialData? credentialData;
-
   const OathAddAccountPage(
     this.devicePath,
     this.state, {

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -20,6 +20,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:yubico_authenticator/oath/icon_provider/icon_pack_dialog.dart';
 import 'package:yubico_authenticator/oath/views/add_account_dialog.dart';
 
+import '../../android/qr_scanner/qr_scanner_provider.dart';
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
@@ -28,11 +29,8 @@ import '../../app/views/action_list.dart';
 import '../../core/state.dart';
 import '../models.dart';
 import '../keys.dart' as keys;
-import '../state.dart';
-import 'add_account_page.dart';
 import 'manage_password_dialog.dart';
 import 'reset_dialog.dart';
-import 'utils.dart';
 
 Widget oathBuildActions(
   BuildContext context,
@@ -59,38 +57,14 @@ Widget oathBuildActions(
               icon: const Icon(Icons.person_add_alt_1_outlined),
               onTap: used != null && (capacity == null || capacity > used)
                   ? (context) async {
-                      final credentials = ref.read(credentialsProvider);
-                      final withContext = ref.read(withContextProvider);
                       Navigator.of(context).pop();
                       if (isAndroid) {
                         final qrScanner = ref.read(qrScannerProvider);
                         if (qrScanner != null) {
                           final qrData = await qrScanner.scanQr();
-                          if (qrData != null) {
-                            await withContext((context) => handleUri(
-                                  context,
-                                  credentials,
-                                  qrData,
-                                  devicePath,
-                                  oathState,
-                                  l10n,
-                                ));
-                            return;
-                          }
+                          await AndroidQrScanner.handleScannedData(
+                              qrData, ref, l10n);
                         }
-                        await withContext((context) => showBlurDialog(
-                              context: context,
-                              routeSettings:
-                                  const RouteSettings(name: 'oath_add_account'),
-                              builder: (context) {
-                                return OathAddAccountPage(
-                                  devicePath,
-                                  oathState,
-                                  credentials: credentials,
-                                  credentialData: null,
-                                );
-                              },
-                            ));
                       } else {
                         await showBlurDialog(
                           context: context,

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -57,13 +57,15 @@ Widget oathBuildActions(
               icon: const Icon(Icons.person_add_alt_1_outlined),
               onTap: used != null && (capacity == null || capacity > used)
                   ? (context) async {
+
                       Navigator.of(context).pop();
                       if (isAndroid) {
+                        final withContext = ref.read(withContextProvider);
                         final qrScanner = ref.read(qrScannerProvider);
                         if (qrScanner != null) {
                           final qrData = await qrScanner.scanQr();
                           await AndroidQrScanner.handleScannedData(
-                              qrData, ref, l10n);
+                              qrData, withContext, qrScanner, l10n);
                         }
                       } else {
                         await showBlurDialog(

--- a/lib/widgets/file_drop_target.dart
+++ b/lib/widgets/file_drop_target.dart
@@ -17,6 +17,8 @@
 import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 
+import '../core/state.dart';
+
 class FileDropTarget extends StatefulWidget {
   final Widget child;
   final Function(List<int> filedata) onFileDropped;
@@ -64,6 +66,7 @@ class _FileDropTargetState extends State<FileDropTarget> {
             widget.onFileDropped(await file.readAsBytes());
           }
         },
+        enable: !isAndroid,
         child: Stack(
           alignment: Alignment.center,
           children: [


### PR DESCRIPTION
Adds support to read files and let the app scan them for account QR codes.

To access the feature:
- tap "Read from file" in the QR scanner
- the system will provide UI for selecting the file, select the image
- if a QR code was identified in the image, the Add account UI will be shown

![Screenshot_20231019-083833](https://github.com/Yubico/yubioath-flutter/assets/1954891/553a5165-f346-4a42-90a5-38dab1ff0b0b) ![sysui](https://github.com/Yubico/yubioath-flutter/assets/1954891/55e9ed9d-6841-4904-94e0-499623ae79a1)
