### PR TITLE
Updated Android and ChromeOS dependencies

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,6 +31,8 @@ linter:
 # https://dart.dev/guides/language/analysis-options
 
 analyzer:
+  optional-checks:
+    chrome-os-manifest-checks
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.1'
     implementation 'androidx.preference:preference-ktx:1.2.1'
 
-    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'com.google.android.material:material:1.10.0'
 
     implementation 'com.github.tony19:logback-android:3.0.0'
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,7 +53,7 @@ android {
     defaultConfig {
         applicationId "com.yubico.yubioath"
         minSdkVersion project.minSdkVersion
-        targetSdkVersion project.targetSdkVersion
+        targetSdk project.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -5,6 +5,10 @@
     -->
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
     <!-- support ACTION_RUN for debug builds -->
     <application
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
         android:required="false" />
 
     <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
+    <uses-feature
         android:name="android.hardware.screen.portrait"
         android:required="false" />
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -3,4 +3,9 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+
+    <uses-feature
+        android:name="android.hardware.touchscreen"
+        android:required="false" />
+
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ allprojects {
 
     project.ext {
         minSdkVersion = 21
-        targetSdkVersion = 33
+        targetSdkVersion = 34
         compileSdkVersion = 34
 
         yubiKitVersion = "2.4.0-beta01"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ allprojects {
 
         yubiKitVersion = "2.4.0-beta01"
         junitVersion = "4.13.2"
-        mockitoVersion = "5.5.0"
+        mockitoVersion = "5.6.0"
     }
 }
 

--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/AndroidManifest.xml
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/AndroidManifest.xml
@@ -8,6 +8,10 @@
         android:name="android.hardware.camera.any"
         android:required="false" />
 
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.CAMERA" />
 
 </manifest>


### PR DESCRIPTION
- bumps `targetSdk` to 34
- adds ChromeOS optional analysis and fixes discovered issues (see [official flutter documentation](https://docs.flutter.dev/platform-integration/android/chromeos) for details)
- bumps android libraries