### PR TITLE
Add arb_reformatter.py

### DIFF
--- a/arb_reformatter.py
+++ b/arb_reformatter.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import os
+
+# Function to load the contents of a file into a line list
+def read_file_lines(file_path):
+    with open(file_path, 'r', encoding='utf-8') as file:
+        return file.readlines()
+
+# Function to save a list of lines to a file
+def write_lines_to_file(file_path, lines):
+    with open(file_path, 'w', encoding='utf-8') as file:
+        file.writelines(lines)
+
+# Function to update the ARB files
+def update_arb_file(source_path, target_path, language_code):
+    # Load the contents of the source file 'app_en.arb'
+    source_lines = read_file_lines(source_path)
+
+    # Load the contents of the target file 'app_**.arb'
+    target_lines = read_file_lines(target_path)
+
+    # Create a translation dictionary based on the contents of the target file
+    translation_dict = {}
+    in_placeholders = False
+    in_readme = False
+    in_lint_rules = False
+
+    for line in target_lines:
+        if line.strip() == '"placeholders": {':
+            in_placeholders = True
+            continue
+        elif line.strip() == '"@_readme": {':
+            in_readme = True
+            continue
+        elif line.strip() == '"@_lint_rules": {':
+            in_lint_rules = True
+            continue
+
+        if in_placeholders:
+            if line.strip() == '},':
+                in_placeholders = False
+            continue
+        elif in_readme:
+            if line.strip() == '},':
+                in_readme = False
+            continue
+        elif in_lint_rules:
+            if line.strip() == '},':
+                in_lint_rules = False
+            continue
+
+        if ':' in line:
+            key, value = line.split(':', 1)
+            key = key.strip().strip('"')
+            translation_dict[key] = value.strip()
+
+    # Update the target file based on the source file
+    updated_target_lines = []
+
+    for line in source_lines:
+        if '"@@locale": "en"' in line:
+            line = line.replace('"@@locale": "en"', f'"@@locale": "{language_code}"')
+
+        if ':' in line:
+            key, value = line.split(':', 1)
+            key = key.strip().strip('"')
+            if key in translation_dict:
+                updated_line = f'    "{key}": {translation_dict[key]}\n'
+                updated_target_lines.append(updated_line)
+            else:
+                updated_target_lines.append(line)
+        else:
+            updated_target_lines.append(line)
+
+    # Save the updated target file
+    write_lines_to_file(target_path, updated_target_lines)
+
+if __name__ == "__main__":
+    source_file_path = 'lib/l10n/app_en.arb'
+    target_directory = 'lib/l10n'
+    language_code = os.path.basename(source_file_path).split('_')[1].split('.')[0]
+
+    for file_name in os.listdir(target_directory):
+        if file_name.startswith('app_') and file_name.endswith('.arb') and file_name != os.path.basename(source_file_path):
+            target_file_path = os.path.join(target_directory, file_name)
+            update_arb_file(source_file_path, target_file_path, language_code)
+            print(f'File updated: {file_name}')

--- a/arb_reformatter.py
+++ b/arb_reformatter.py
@@ -106,10 +106,10 @@ def update_arb_file(source_path, target_path, language_code):
 if __name__ == "__main__":
     source_file_path = 'lib/l10n/app_en.arb'
     target_directory = 'lib/l10n'
-    language_code = os.path.basename(source_file_path).split('_')[1].split('.')[0]
 
     for file_name in os.listdir(target_directory):
         if file_name.startswith('app_') and file_name.endswith('.arb') and file_name != os.path.basename(source_file_path):
             target_file_path = os.path.join(target_directory, file_name)
+            language_code = file_name.split('_')[1].split('.')[0]
             update_arb_file(source_file_path, target_file_path, language_code)
             print(f'File updated: {file_name}')


### PR DESCRIPTION
Formats ARB files translated in various tools into ones that match the source file.

File translated in Weblate looks like:
<img src=https://github.com/Yubico/yubioath-flutter/assets/11527277/7868adcf-b77a-4233-999f-c88e763d74b2 width=20%><img src=https://github.com/Yubico/yubioath-flutter/assets/11527277/e7f574b8-b34f-4649-9881-ba721e23a334 width=20%>

After using the script:
<img src=https://github.com/Yubico/yubioath-flutter/assets/11527277/06c8ab1d-5fa6-4a41-845e-a38ba7a47b19 width=20%><img src=https://github.com/Yubico/yubioath-flutter/assets/11527277/831d4bf5-ddf9-4fc0-a3f1-3df66274cb8e width=20%>

Warning:
- Readme and Lint rules sections are copied from the source file
- Missing translations are filled from the source file.
- Code may look strange, but it works.

For my purposes it is already very good :)
