### PR TITLE
Make punctuation customizable per language in translation linter

### DIFF
--- a/check_strings.py
+++ b/check_strings.py
@@ -40,7 +40,7 @@ def check_duplicate_values(strings):
                 seen[v] = k
 
 
-def check_prefixes(k, v, s_max_words, s_max_len):
+def check_prefixes(k, v, s_max_words, s_max_len, punctuation, q_endings):
     errs = []
     if k.startswith("s_"):
         if len(v) > s_max_len:
@@ -53,11 +53,11 @@ def check_prefixes(k, v, s_max_words, s_max_len):
         if ". " in v:
             errs.append("Spans multiple sentences")
     elif k.startswith("p_"):
-        if v[-1] not in ".!":
+        if punctuation and not any(v.endswith(p) for p in punctuation):
             errs.append("Doesn't end in punctuation")
     elif k.startswith("q_"):
-        if not v.endswith("?"):
-            errs.append("Doesn't end in '?'")
+        if q_endings and not any(v.endswith(q) for q in q_endings):
+            errs.append("Doesn't end in question mark.")
     return errs
 
 
@@ -79,6 +79,8 @@ def lint_strings(strings, rules):
                 v,
                 rules.get("s_max_words", 4),
                 rules.get("s_max_len", 32),
+                rules.get("punctuation", [".", "!"]),
+                rules.get("q_endings", ["?"]),
             )
         )
         errs.extend(check_misc(k, v))

--- a/check_strings.py
+++ b/check_strings.py
@@ -99,7 +99,7 @@ with open(target, encoding='utf-8') as f:
 strings = {k: v for k, v in values.items() if not k.startswith("@")}
 
 print(target, f"- checking {len(strings)} strings")
-lint_strings(strings, strings.get("@_lint_rules", {}))
+lint_strings(strings, values.get("@_lint_rules", {}))
 check_duplicate_values(strings)
 
 if errors:

--- a/check_strings.py
+++ b/check_strings.py
@@ -40,7 +40,7 @@ def check_duplicate_values(strings):
                 seen[v] = k
 
 
-def check_prefixes(k, v, s_max_words, s_max_len, punctuation, q_endings):
+def check_prefixes(k, v, s_max_words, s_max_len, p_endings, q_endings):
     errs = []
     if k.startswith("s_"):
         if len(v) > s_max_len:
@@ -53,7 +53,7 @@ def check_prefixes(k, v, s_max_words, s_max_len, punctuation, q_endings):
         if ". " in v:
             errs.append("Spans multiple sentences")
     elif k.startswith("p_"):
-        if punctuation and not any(v.endswith(p) for p in punctuation):
+        if p_endings and not any(v.endswith(p) for p in p_endings):
             errs.append("Doesn't end in punctuation")
     elif k.startswith("q_"):
         if q_endings and not any(v.endswith(q) for q in q_endings):
@@ -79,7 +79,7 @@ def lint_strings(strings, rules):
                 v,
                 rules.get("s_max_words", 4),
                 rules.get("s_max_len", 32),
-                rules.get("punctuation", [".", "!"]),
+                rules.get("p_endings", [".", "!"]),
                 rules.get("q_endings", ["?"]),
             )
         )

--- a/check_strings.py
+++ b/check_strings.py
@@ -40,7 +40,7 @@ def check_duplicate_values(strings):
                 seen[v] = k
 
 
-def check_prefixes(k, v, s_max_words, s_max_len, p_endings, q_endings):
+def check_prefixes(k, v, s_max_words, s_max_len, p_ending_chars, q_ending_chars):
     errs = []
     if k.startswith("s_"):
         if len(v) > s_max_len:
@@ -53,10 +53,10 @@ def check_prefixes(k, v, s_max_words, s_max_len, p_endings, q_endings):
         if ". " in v:
             errs.append("Spans multiple sentences")
     elif k.startswith("p_"):
-        if p_endings and not any(v.endswith(p) for p in p_endings):
+        if p_ending_chars and not any(v.endswith(p) for p in p_ending_chars):
             errs.append("Doesn't end in punctuation")
     elif k.startswith("q_"):
-        if q_endings and not any(v.endswith(q) for q in q_endings):
+        if q_ending_chars and not any(v.endswith(q) for q in q_ending_chars):
             errs.append("Doesn't end in question mark.")
     return errs
 
@@ -79,8 +79,8 @@ def lint_strings(strings, rules):
                 v,
                 rules.get("s_max_words", 4),
                 rules.get("s_max_len", 32),
-                rules.get("p_endings", [".", "!"]),
-                rules.get("q_endings", ["?"]),
+                rules.get("p_ending_chars", ".!"),
+                rules.get("q_ending_chars", "?"),
             )
         )
         errs.extend(check_misc(k, v))

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -16,6 +16,8 @@
     },
 
     "@_lint_rules": {
+        "p_endings": [".", "!"],
+        "q_endings": ["?"],
         "s_max_words": 4,
         "s_max_length": 32
     },

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -16,8 +16,8 @@
     },
 
     "@_lint_rules": {
-        "p_endings": [".", "!"],
-        "q_endings": ["?"],
+        "p_ending_chars": ".!",
+        "q_ending_chars": "?",
         "s_max_words": 4,
         "s_max_length": 32
     },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -16,8 +16,8 @@
     },
 
     "@_lint_rules": {
-        "p_endings": ["。", "！"],
-        "q_endings": ["?", "？"],
+        "p_ending_chars": "。！",
+        "q_ending_chars": "?",
         "s_max_words": 4,
         "s_max_length": 32
     },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -17,7 +17,7 @@
 
     "@_lint_rules": {
         "p_ending_chars": "。！",
-        "q_ending_chars": "?",
+        "q_ending_chars": "?？",
         "s_max_words": 4,
         "s_max_length": 32
     },

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -16,7 +16,7 @@
     },
 
     "@_lint_rules": {
-        "punctuation": ["。", "！"],
+        "p_endings": ["。", "！"],
         "q_endings": ["?", "？"],
         "s_max_words": 4,
         "s_max_length": 32

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -16,6 +16,8 @@
     },
 
     "@_lint_rules": {
+        "punctuation": ["。", "！"],
+        "q_endings": ["?", "？"],
         "s_max_words": 4,
         "s_max_length": 32
     },


### PR DESCRIPTION
Japanese, for example, uses different punctuation than ASCII `.!?`.