### PR TITLE
Check that translation keys exist in app_en.arb in translation linter

### DIFF
--- a/check_strings.py
+++ b/check_strings.py
@@ -15,8 +15,9 @@
 #  limitations under the License.
 
 
-import sys
 import json
+import os
+import sys
 
 errors = []
 
@@ -70,6 +71,14 @@ def check_misc(k, v):
     return errs
 
 
+def check_keys_exist_in_reference(reference_strings, checked_strings):
+    errs = []
+    for key in checked_strings.keys():
+        if key not in reference_strings:
+            errs.append(f"Invalid key: {key}")
+    return errs
+
+
 def lint_strings(strings, rules):
     for k, v in strings.items():
         errs = []
@@ -101,6 +110,11 @@ strings = {k: v for k, v in values.items() if not k.startswith("@")}
 print(target, f"- checking {len(strings)} strings")
 lint_strings(strings, strings.get("@_lint_rules", {}))
 check_duplicate_values(strings)
+
+with open(os.path.join(os.path.dirname(target), 'app_en.arb'), encoding='utf-8') as f:
+    reference_values = json.load(f)
+errors.extend(check_keys_exist_in_reference(reference_values, values))
+
 
 if errors:
     print()


### PR DESCRIPTION
For example, `app_de.arb` has a few keys that do not:

```
../lib/l10n/app_de.arb - checking 261 strings

../lib/l10n/app_de.arb HAS ERRORS:
Invalid key: l_credential
Invalid key: @l_credential
Invalid key: s_credentials
Invalid key: s_delete_credential
Invalid key: s_credential_deleted
Invalid key: p_warning_delete_credential
```