### PR TITLE
Don't use coroutine scope for Camera permissions requests

### DIFF
--- a/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
+++ b/android/flutter_plugins/qrscanner_zxing/android/src/main/kotlin/com/yubico/authenticator/flutter_plugins/qrscanner_zxing/QRScannerView.kt
@@ -107,17 +107,15 @@ internal class QRScannerView(
     }
 
     private fun requestPermissions(activity: Activity) {
-        coroutineScope.launch {
-            methodChannel.invokeMethod(
-                "beforePermissionsRequest", null
-            )
+        methodChannel.invokeMethod(
+            "beforePermissionsRequest", null
+        )
 
-            ActivityCompat.requestPermissions(
-                activity,
-                PERMISSIONS_TO_REQUEST,
-                PERMISSION_REQUEST_CODE
-            )
-        }
+        ActivityCompat.requestPermissions(
+            activity,
+            PERMISSIONS_TO_REQUEST,
+            PERMISSION_REQUEST_CODE
+        )
     }
 
     private val qrScannerView = View.inflate(context, R.layout.qr_scanner_view, null)


### PR DESCRIPTION
### Fixes following issue: 
1. remove Camera permissions from the app
2. run app and QR Scanner, don't allow permissions. 
3. Tap "Review permissions" button

Expected:
- System app settings opens and the user can change the camera permissions

What really happens:
- "nothing" (In real, the app settings is opened but directly closed)

### The bug 
- introduced with PR #1231 when I wrapped the new call to `methodChannel.invokeMethod()` into a coroutine ([the change](https://github.com/Yubico/yubioath-flutter/pull/1231/files?diff=unified&w=0#diff-f04b62f15c4f99ac49ee7df065f528e719609ad1182f63b40f60853ed2ea8f82L107-R120)) - this caused that when tapping the "Review permissions" button, the system app activity was closed directly because of the call to `ActivityCompat.requestPermissions`.

### The fix
Removing the coroutine will make the actions run in correct order, and the app settings activity will not be closed.