### PR TITLE
[Android] Use only strings from ARB files 

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/CompatUtil.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/CompatUtil.kt
@@ -86,6 +86,14 @@ class CompatUtil(private val sdkVersion: Int) {
         `when`({ sdkVersion < version }, block)
 
     /**
+     * Execute [block] only on devices running lower sdk version than [version]
+     *
+     * @return wrapped value
+     */
+    suspend fun <T> until(version: Int, block: suspend () -> T): CompatValue<T> =
+        `when`({ sdkVersion < version }, block)
+
+    /**
      * Execute [block] only on devices running higher or equal sdk version than [version]
      *
      * @return wrapped value
@@ -102,6 +110,12 @@ class CompatUtil(private val sdkVersion: Int) {
         p() -> CompatValue.of(block())
         else -> CompatValue.empty()
     }
+
+    private suspend fun <T> `when`(p: () -> Boolean, block: suspend () -> T): CompatValue<T> =
+        when {
+            p() -> CompatValue.of(block())
+            else -> CompatValue.empty()
+        }
 }
 
 val compatUtil = CompatUtil(Build.VERSION.SDK_INT)

--- a/android/app/src/main/kotlin/com/yubico/authenticator/NdefActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/NdefActivity.kt
@@ -76,8 +76,8 @@ class NdefActivity : FlutterFragmentActivity() {
                         showToast(
                             this,
                             when (otpSlotContent.type) {
-                                OtpType.Otp -> "s_ndef_set_otp"
-                                OtpType.Password -> "s_ndef_set_password"
+                                OtpType.Otp -> "p_ndef_set_otp"
+                                OtpType.Password -> "p_ndef_set_password"
                             }, Toast.LENGTH_SHORT
                         )
                     }
@@ -88,9 +88,9 @@ class NdefActivity : FlutterFragmentActivity() {
                         illegalArgumentException.message ?: "Failure when handling YubiKey OTP",
                         illegalArgumentException
                     )
-                    showToast(this, "s_ndef_parse_failure", Toast.LENGTH_LONG)
+                    showToast(this, "p_ndef_parse_failure", Toast.LENGTH_LONG)
                 } catch (_: UnsupportedOperationException) {
-                    showToast(this, "s_ndef_set_clip_failure", Toast.LENGTH_LONG)
+                    showToast(this, "p_ndef_set_clip_failure", Toast.LENGTH_LONG)
                 }
             }
 

--- a/android/app/src/main/kotlin/com/yubico/authenticator/app/AppMethodChannel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/app/AppMethodChannel.kt
@@ -1,0 +1,119 @@
+package com.yubico.authenticator.app
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.nfc.NfcAdapter
+import android.os.Build
+import android.provider.Settings
+import com.yubico.authenticator.ClipboardUtil
+import com.yubico.authenticator.MainActivity
+import com.yubico.authenticator.invoke
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+
+class AppMethodChannel(activity: Activity, messenger: BinaryMessenger) {
+
+    private val methodChannel = MethodChannel(messenger, "app.methods")
+    private val logger = LoggerFactory.getLogger(AppMethodChannel::class.java)
+
+    init {
+        methodChannel.setMethodCallHandler { methodCall, result ->
+            when (methodCall.method) {
+                "allowScreenshots" -> result.success(
+                    activity.allowScreenshots(
+                        methodCall.arguments as Boolean
+                    )
+                )
+
+                "getAndroidSdkVersion" -> result.success(
+                    Build.VERSION.SDK_INT
+                )
+
+                "preserveConnectionOnPause" -> {
+                    if (activity is MainActivity) {
+                        activity.preserveConnectionOnPause = true
+                        result.success(
+                            true
+                        )
+                    }
+                }
+
+                "setPrimaryClip" -> {
+                    val toClipboard = methodCall.argument<String>("toClipboard")
+                    val isSensitive = methodCall.argument<Boolean>("isSensitive")
+                    if (toClipboard != null && isSensitive != null) {
+                        ClipboardUtil.setPrimaryClip(
+                            activity,
+                            toClipboard,
+                            isSensitive
+                        )
+                    }
+                    result.success(true)
+                }
+
+                "hasCamera" -> {
+                    val cameraService =
+                        activity.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+                    result.success(
+                        cameraService.cameraIdList.any {
+                            cameraService.getCameraCharacteristics(it)
+                                .get(CameraCharacteristics.LENS_FACING) == CameraCharacteristics.LENS_FACING_BACK
+                        }
+                    )
+                }
+
+                "hasNfc" -> result.success(
+                    activity.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC)
+                )
+
+                "isNfcEnabled" -> {
+                    val nfcAdapter = NfcAdapter.getDefaultAdapter(activity)
+
+                    result.success(
+                        nfcAdapter != null && nfcAdapter.isEnabled
+                    )
+                }
+
+                "openNfcSettings" -> {
+                    activity.startActivity(Intent(Settings.ACTION_NFC_SETTINGS))
+                    result.success(true)
+                }
+
+                else -> logger.warn("Unknown app method: {}", methodCall.method)
+            }
+        }
+    }
+
+    fun nfcAdapterStateChanged(value: Boolean) {
+        methodChannel.invokeMethod(
+            "nfcAdapterStateChanged",
+            JSONObject(mapOf("nfcEnabled" to value)).toString()
+        )
+    }
+
+    suspend fun getString(arbKey: String) =
+        methodChannel.invoke(
+            "getString",
+            JSONObject(mapOf("arbKey" to arbKey)).toString()
+        ) as String
+}
+
+fun Activity.allowScreenshots(value: Boolean): Boolean {
+    // Note that FLAG_SECURE is the inverse of allowScreenshots
+    val logger = LoggerFactory.getLogger("Activity.allowScreenshots")
+    if (value) {
+        logger.debug("Clearing FLAG_SECURE (allow screenshots)")
+        window.clearFlags(MainActivity.FLAG_SECURE)
+    } else {
+        logger.debug("Setting FLAG_SECURE (disallow screenshots)")
+        window.setFlags(MainActivity.FLAG_SECURE, MainActivity.FLAG_SECURE)
+    }
+
+    return MainActivity.FLAG_SECURE != (window.attributes.flags and MainActivity.FLAG_SECURE)
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_label">Yubico Authenticator</string>
-    <string name="otp_success_set_otp_to_clipboard">Successfully copied OTP code from YubiKey to clipboard.</string>
-    <string name="otp_success_set_password_to_clipboard">Successfully copied password from YubiKey to clipboard.</string>
-    <string name="otp_parse_failure">Failed to parse OTP code from YubiKey.</string>
-    <string name="otp_set_clip_failure">Failed to access clipboard when trying to copy OTP code from YubiKey.</string>
 </resources>

--- a/lib/android/app_methods.dart
+++ b/lib/android/app_methods.dart
@@ -75,10 +75,10 @@ void setupAppMethodsChannel(WidgetRef ref) {
 
           var l10n = ref.read(l10nProvider);
           return switch (arbKey) {
-            's_ndef_set_otp' => l10n.s_ndef_set_otp,
-            's_ndef_set_password' => l10n.s_ndef_set_password,
-            's_ndef_parse_failure' => l10n.s_ndef_parse_failure,
-            's_ndef_set_clip_failure' => l10n.s_ndef_set_clip_failure,
+            'p_ndef_set_otp' => l10n.p_ndef_set_otp,
+            'p_ndef_set_password' => l10n.p_ndef_set_password,
+            'p_ndef_parse_failure' => l10n.p_ndef_parse_failure,
+            'p_ndef_set_clip_failure' => l10n.p_ndef_set_clip_failure,
             _ => arbKey
           };
         }

--- a/lib/android/app_methods.dart
+++ b/lib/android/app_methods.dart
@@ -18,6 +18,8 @@ import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../app/state.dart';
 import 'state.dart';
 
 const appMethodsChannel = MethodChannel('app.methods');
@@ -66,6 +68,19 @@ void setupAppMethodsChannel(WidgetRef ref) {
           var nfcEnabled = args['nfcEnabled'];
           ref.read(androidNfcStateProvider.notifier).setNfcEnabled(nfcEnabled);
           break;
+        }
+      case 'getString':
+        {
+          var arbKey = args['arbKey'] as String;
+
+          var l10n = ref.read(l10nProvider);
+          return switch (arbKey) {
+            's_ndef_set_otp' => l10n.s_ndef_set_otp,
+            's_ndef_set_password' => l10n.s_ndef_set_password,
+            's_ndef_parse_failure' => l10n.s_ndef_parse_failure,
+            's_ndef_set_clip_failure' => l10n.s_ndef_set_clip_failure,
+            _ => arbKey
+          };
         }
       default:
         throw PlatformException(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -627,10 +627,10 @@
     "s_nfc_dialog_oath_add_multiple_accounts": "Action: add multiple accounts",
 
     "@_ndef": {},
-    "s_ndef_set_otp": "Successfully copied OTP code from YubiKey to clipboard.",
-    "s_ndef_set_password": "Successfully copied password from YubiKey to clipboard.",
-    "s_ndef_parse_failure": "Failed to parse OTP code from YubiKey.",
-    "s_ndef_set_clip_failure": "Failed to access clipboard when trying to copy OTP code from YubiKey.",
+    "p_ndef_set_otp": "Successfully copied OTP code from YubiKey to clipboard.",
+    "p_ndef_set_password": "Successfully copied password from YubiKey to clipboard.",
+    "p_ndef_parse_failure": "Failed to parse OTP code from YubiKey.",
+    "p_ndef_set_clip_failure": "Failed to access clipboard when trying to copy OTP code from YubiKey.",
 
     "@_eof": {}
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -626,5 +626,11 @@
     "s_nfc_dialog_oath_failure": "OATH operation failed",
     "s_nfc_dialog_oath_add_multiple_accounts": "Action: add multiple accounts",
 
+    "@_ndef": {},
+    "s_ndef_set_otp": "Successfully copied OTP code from YubiKey to clipboard.",
+    "s_ndef_set_password": "Successfully copied password from YubiKey to clipboard.",
+    "s_ndef_parse_failure": "Failed to parse OTP code from YubiKey.",
+    "s_ndef_set_clip_failure": "Failed to access clipboard when trying to copy OTP code from YubiKey.",
+
     "@_eof": {}
 }


### PR DESCRIPTION
For unified localizations, this PR moves the strings defined in `strings.xml` to ARB and uses dart's l10n support to do the translations.

There are several other disadvantages:
- to get the strings we have to start flutter process, which is not needed when doing "just" ndef activity.
- the way how flutter localizations work makes us to call a specific method for each of the needed string

Advantages: 1 file with all localizable strings.