### PR TITLE
ChromeOS fix for adding account

### DIFF
--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -109,6 +109,10 @@ class MainPage extends ConsumerWidget {
                   // ignored - user cancelled
                   return;
                 }
+              } else {
+                // no QR scanner - enter data manually
+                await AndroidQrScanner.showAccountManualEntryDialog(
+                    withContext, l10n);
               }
             },
           ),

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -68,6 +68,10 @@ Widget oathBuildActions(
                           final qrData = await qrScanner.scanQr();
                           await AndroidQrScanner.handleScannedData(
                               qrData, withContext, qrScanner, l10n);
+                        } else {
+                          // no QR scanner - enter data manually
+                          await AndroidQrScanner.showAccountManualEntryDialog(
+                              withContext, l10n);
                         }
                       } else {
                         await showBlurDialog(


### PR DESCRIPTION
Fixes issue where tapping "Add account" did not do anything on Chrome OS. The reason was missing action for the situation when there is no QR Scanner.

The fix launches manual entry dialog in such situations.