### PR TITLE
OATH: Replace empty issuer with null.

### DIFF
--- a/lib/oath/models.dart
+++ b/lib/oath/models.dart
@@ -71,8 +71,14 @@ class OathCredential with _$OathCredential {
       int period,
       bool touchRequired) = _OathCredential;
 
-  factory OathCredential.fromJson(Map<String, dynamic> json) =>
-      _$OathCredentialFromJson(json);
+  factory OathCredential.fromJson(Map<String, dynamic> json) {
+    final value = _$OathCredentialFromJson(json);
+    // Replace empty issuer string with null
+    return switch (value.issuer) {
+      (String issuer) when issuer.isEmpty => value.copyWith(issuer: null),
+      _ => value,
+    };
+  }
 }
 
 @freezed


### PR DESCRIPTION
This occurs when you have a HOTP credential with a name of `:name` with no issuer. Since the issuer is empty (but not null) the credential list fails to display it correctly.