### PR TITLE
Pin Cocoapods version 

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -23,6 +23,11 @@ jobs:
       with:
         python-version: ${{ env.PYVER }}
 
+    - name: Set up CocoaPods
+      uses: maxim-lobanov/setup-cocoapods@v1
+      with:
+        podfile-path: macos/Podfile.lock
+
     - name: Cache helper
       id: cache-helper
       uses: actions/cache@v3


### PR DESCRIPTION
For macos GitHub action builds. Installs cocoapods version as we use in Podfile.lock. This prevents failures on runner images which come with different version of cocoapods pre-installed.

Tested and verified on several random runner images with different cocoapods versions.

The action description can be found here: https://github.com/marketplace/actions/setup-cocoapods