### PR TITLE
Run `onCancel` when dialog is dismissed

### DIFF
--- a/helper/helper/fido.py
+++ b/helper/helper/fido.py
@@ -362,6 +362,7 @@ class FingerprintsNode(RpcNode):
             except CtapError as e:
                 if e.code == CtapError.ERR.USER_ACTION_TIMEOUT:
                     raise InactivityException()
+                raise
         if name:
             self.bio.set_name(template_id, name)
         self._templates[template_id] = name

--- a/lib/widgets/responsive_dialog.dart
+++ b/lib/widgets/responsive_dialog.dart
@@ -75,26 +75,32 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
     final cancelText = widget.onCancel == null && widget.actions.isEmpty
         ? l10n.s_close
         : l10n.s_cancel;
-    return AlertDialog(
-      title: widget.title,
-      titlePadding: const EdgeInsets.only(top: 24, left: 18, right: 18),
-      scrollable: true,
-      backgroundColor: Theme.of(context).colorScheme.surface.withOpacity(0.9),
-      contentPadding: const EdgeInsets.symmetric(vertical: 8),
-      content: SizedBox(
-        width: 600,
-        child: Container(key: _childKey, child: widget.child),
-      ),
-      actions: [
-        TextButton(
-          child: Text(cancelText),
-          onPressed: () {
-            widget.onCancel?.call();
-            Navigator.of(context).pop();
-          },
+    return PopScope(
+      child: AlertDialog(
+        title: widget.title,
+        titlePadding: const EdgeInsets.only(top: 24, left: 18, right: 18),
+        scrollable: true,
+        backgroundColor: Theme.of(context).colorScheme.surface.withOpacity(0.9),
+        contentPadding: const EdgeInsets.symmetric(vertical: 8),
+        content: SizedBox(
+          width: 600,
+          child: Container(key: _childKey, child: widget.child),
         ),
-        ...widget.actions
-      ],
+        actions: [
+          TextButton(
+            child: Text(cancelText),
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+          ),
+          ...widget.actions
+        ],
+      ),
+      onPopInvoked: (didPop) {
+        if (didPop) {
+          widget.onCancel?.call();
+        }
+      },
     );
   }
 


### PR DESCRIPTION
This PR ensures that the `onCancel` callback is triggered when the dialog is dismissed by tapping outside the dialog barrier. Additionally, it resolves an issue related to FIDO bio enrollment. 