### PR TITLE
Use header instead of message in Android main page

### DIFF
--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -86,7 +86,7 @@ class MainPage extends ConsumerWidget {
         return MessagePage(
           centered: true,
           graphic: noKeyImage,
-          message: hasNfcSupport && isNfcEnabled
+          header: hasNfcSupport && isNfcEnabled
               ? l10n.l_insert_or_tap_yk
               : l10n.l_insert_yk,
           actionsBuilder: (context, expanded) => [


### PR DESCRIPTION
Was: 
![image](https://github.com/Yubico/yubioath-flutter/assets/1954891/081ab768-3273-47fe-8e6b-aadf1a2fd64a)

Fix:
![image](https://github.com/Yubico/yubioath-flutter/assets/1954891/18bee438-06b8-4ecd-82e3-581d2aa5b3a4)

and

![image](https://github.com/Yubico/yubioath-flutter/assets/1954891/264c1dd1-49d8-4f07-b326-18713d8134da)
