### PR TITLE
Add support for FIDO applet on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -99,7 +99,6 @@ dependencies {
     api "com.yubico.yubikit:fido:$project.yubiKitVersion"
     api "com.yubico.yubikit:support:$project.yubiKitVersion"
 
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-core:1.6.2'
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2'
 
     // Lifecycle
@@ -109,7 +108,7 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.2'
     implementation 'androidx.preference:preference-ktx:1.2.1'
 
-    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'com.google.android.material:material:1.11.0'
 
     implementation 'com.github.tony19:logback-android:3.0.0'
 

--- a/android/app/src/main/kotlin/com/yubico/authenticator/AppContext.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/AppContext.kt
@@ -37,7 +37,7 @@ class AppContext(messenger: BinaryMessenger, coroutineScope: CoroutineScope, pri
         }
     }
 
-    private suspend fun setContext(subPageIndex: Int): String {
+    private fun setContext(subPageIndex: Int): String {
         val appContext = OperationContext.getByValue(subPageIndex)
         appViewModel.setAppContext(appContext)
         logger.debug("App context is now {}", appContext)

--- a/android/app/src/main/kotlin/com/yubico/authenticator/AppContextManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/AppContextManager.kt
@@ -16,12 +16,37 @@
 
 package com.yubico.authenticator
 
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.yubico.yubikit.core.YubiKeyDevice
 
 /**
  * Provides behavior to run when a YubiKey is inserted/tapped for a specific view of the app.
  */
-interface AppContextManager {
-    suspend fun processYubiKey(device: YubiKeyDevice)
-    fun dispose()
+abstract class AppContextManager(
+    private val lifecycleOwner: LifecycleOwner
+) {
+    abstract suspend fun processYubiKey(device: YubiKeyDevice)
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onPause(owner: LifecycleOwner) {
+            onPause()
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+            onResume()
+        }
+    }
+
+    init {
+        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+    }
+
+    open fun dispose() {
+        lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+    }
+
+    open fun onPause() {}
+
+    open fun onResume() {}
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -302,6 +302,7 @@ class MainActivity : FlutterFragmentActivity() {
             oathViewModel.sessionState.streamTo(this, messenger, "android.oath.sessionState"),
             oathViewModel.credentials.streamTo(this, messenger, "android.oath.credentials"),
             fidoViewModel.sessionState.streamTo(this, messenger, "android.fido.sessionState"),
+            fidoViewModel.credentials.streamTo(this, messenger, "android.fido.credentials"),
         )
 
         viewModel.appContext.observe(this) {
@@ -320,8 +321,7 @@ class MainActivity : FlutterFragmentActivity() {
                     messenger,
                     viewModel,
                     fidoViewModel,
-                    dialogManager,
-                    appPreferences
+                    dialogManager
                 )
                 else -> null
             }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -317,7 +317,7 @@ class MainActivity : FlutterFragmentActivity() {
                     dialogManager,
                     appPreferences
                 )
-                OperationContext.Fido -> FidoManager(
+                OperationContext.FidoPasskeys -> FidoManager(
                     this,
                     messenger,
                     viewModel,

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -39,6 +39,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.color.DynamicColors
+import com.yubico.authenticator.fido.FidoManager
+import com.yubico.authenticator.fido.FidoViewModel
 import com.yubico.authenticator.logging.FlutterLog
 import com.yubico.authenticator.oath.AppLinkMethodChannel
 import com.yubico.authenticator.oath.OathManager
@@ -62,6 +64,7 @@ import java.util.concurrent.Executors
 class MainActivity : FlutterFragmentActivity() {
     private val viewModel: MainViewModel by viewModels()
     private val oathViewModel: OathViewModel by viewModels()
+    private val fidoViewModel: FidoViewModel by viewModels()
 
     private val nfcConfiguration = NfcConfiguration()
 
@@ -298,6 +301,7 @@ class MainActivity : FlutterFragmentActivity() {
             viewModel.deviceInfo.streamTo(this, messenger, "android.devices.deviceInfo"),
             oathViewModel.sessionState.streamTo(this, messenger, "android.oath.sessionState"),
             oathViewModel.credentials.streamTo(this, messenger, "android.oath.credentials"),
+            fidoViewModel.sessionState.streamTo(this, messenger, "android.fido.sessionState"),
         )
 
         viewModel.appContext.observe(this) {
@@ -308,6 +312,14 @@ class MainActivity : FlutterFragmentActivity() {
                     messenger,
                     viewModel,
                     oathViewModel,
+                    dialogManager,
+                    appPreferences
+                )
+                OperationContext.Fido -> FidoManager(
+                    this,
+                    messenger,
+                    viewModel,
+                    fidoViewModel,
                     dialogManager,
                     appPreferences
                 )

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -303,6 +303,7 @@ class MainActivity : FlutterFragmentActivity() {
             oathViewModel.credentials.streamTo(this, messenger, "android.oath.credentials"),
             fidoViewModel.sessionState.streamTo(this, messenger, "android.fido.sessionState"),
             fidoViewModel.credentials.streamTo(this, messenger, "android.fido.credentials"),
+            fidoViewModel.resetState.streamTo(this, messenger, "android.fido.reset"),
         )
 
         viewModel.appContext.observe(this) {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
@@ -23,26 +23,33 @@ import com.yubico.authenticator.device.Info
 import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
 
 enum class OperationContext(val value: Int) {
-    Oath(0), Yubikey(1), Invalid(-1);
+    Oath(0),
+    Fido(1),
+    YubiOtp(2),
+    Piv(3),
+    OpenPgp(4),
+    HsmAuth(5),
+    Management(6),
+    Invalid(-1);
 
     companion object {
-        fun getByValue(value: Int) = values().firstOrNull { it.value == value } ?: Invalid
+        fun getByValue(value: Int) = entries.firstOrNull { it.value == value } ?: Invalid
     }
 }
 
 class MainViewModel : ViewModel() {
-    private var _appContext = MutableLiveData(OperationContext.Oath)
+    private var _appContext = MutableLiveData(OperationContext.Fido)
     val appContext: LiveData<OperationContext> = _appContext
     fun setAppContext(appContext: OperationContext) {
         // Don't reset the context unless it actually changes
-        if(appContext != _appContext.value) {
+        if (appContext != _appContext.value) {
             _appContext.postValue(appContext)
         }
     }
 
     private val _connectedYubiKey = MutableLiveData<UsbYubiKeyDevice?>()
     val connectedYubiKey: LiveData<UsbYubiKeyDevice?> = _connectedYubiKey
-    fun setConnectedYubiKey(device: UsbYubiKeyDevice, onDisconnect: () -> Unit ) {
+    fun setConnectedYubiKey(device: UsbYubiKeyDevice, onDisconnect: () -> Unit) {
         _connectedYubiKey.postValue(device)
         device.setOnClosed {
             _connectedYubiKey.postValue(null)

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
@@ -38,7 +38,7 @@ enum class OperationContext(val value: Int) {
 }
 
 class MainViewModel : ViewModel() {
-    private var _appContext = MutableLiveData(OperationContext.Fido)
+    private var _appContext = MutableLiveData(OperationContext.Oath)
     val appContext: LiveData<OperationContext> = _appContext
     fun setAppContext(appContext: OperationContext) {
         // Don't reset the context unless it actually changes

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainViewModel.kt
@@ -24,12 +24,14 @@ import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
 
 enum class OperationContext(val value: Int) {
     Oath(0),
-    Fido(1),
-    YubiOtp(2),
-    Piv(3),
-    OpenPgp(4),
-    HsmAuth(5),
-    Management(6),
+    FidoU2f(1),
+    FidoFingerprints(2),
+    FidoPasskeys(3),
+    YubiOtp(4),
+    Piv(5),
+    OpenPgp(6),
+    HsmAuth(7),
+    Management(8),
     Invalid(-1);
 
     companion object {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/device/DeviceManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/device/DeviceManager.kt
@@ -1,0 +1,173 @@
+package com.yubico.authenticator.device
+
+import androidx.collection.ArraySet
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
+import com.yubico.authenticator.MainViewModel
+import com.yubico.authenticator.OperationContext
+import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
+import com.yubico.yubikit.core.YubiKeyDevice
+import com.yubico.yubikit.core.fido.FidoConnection
+import com.yubico.yubikit.core.smartcard.SmartCardConnection
+import com.yubico.yubikit.fido.ctap.Ctap2Session
+import com.yubico.yubikit.oath.OathSession
+import org.slf4j.LoggerFactory
+
+interface DeviceListener {
+    // a USB device is connected
+    fun onConnected(device: YubiKeyDevice) {}
+
+    // a USB device is disconnected
+    fun onDisconnected() {}
+
+    // the app has been paused for more than DeviceManager.NFC_DATA_CLEANUP_DELAY
+    fun onTimeout() {}
+}
+
+class DeviceManager(
+    private val lifecycleOwner: LifecycleOwner,
+    private val appViewModel: MainViewModel
+) {
+    var clearDeviceInfoOnDisconnect: Boolean = true
+
+    private val deviceListeners = HashSet<DeviceListener>()
+
+    fun addDeviceListener(listener: DeviceListener) {
+        deviceListeners.add(listener)
+    }
+
+    fun removeDeviceListener(listener: DeviceListener) {
+        deviceListeners.remove(listener)
+    }
+
+    companion object {
+        const val NFC_DATA_CLEANUP_DELAY = 30L * 1000 // 30s
+        private val logger = LoggerFactory.getLogger(DeviceManager::class.java)
+
+        fun getSupportedContexts(device: YubiKeyDevice) : ArraySet<OperationContext> {
+
+            val operationContexts = ArraySet<OperationContext>()
+
+            if (device.supportsConnection(SmartCardConnection::class.java)) {
+                // try which apps are available
+                device.openConnection(SmartCardConnection::class.java).use {
+                    try {
+                        OathSession(it)
+                        operationContexts.add(OperationContext.Oath)
+                    } catch (e: Throwable) { // ignored
+                    }
+
+                    try {
+                        Ctap2Session(it)
+                        operationContexts.add(OperationContext.FidoPasskeys)
+                        operationContexts.add(OperationContext.FidoFingerprints)
+                    } catch (e: Throwable) { // ignored
+                    }
+
+                }
+            }
+
+            if (device.supportsConnection(FidoConnection::class.java)) {
+                device.openConnection(FidoConnection::class.java).use {
+                    try {
+                        Ctap2Session(it)
+                        operationContexts.add(OperationContext.FidoPasskeys)
+                        operationContexts.add(OperationContext.FidoFingerprints)
+                    } catch (e: Throwable) { // ignored
+                    }
+                }
+            }
+
+            logger.debug("Device supports following contexts: {}", operationContexts)
+            return operationContexts
+        }
+
+        fun getPreferredContext(contexts: ArraySet<OperationContext>) : OperationContext {
+            // custom sort
+            for(context in contexts) {
+                if (context == OperationContext.Oath) {
+                    return context
+                } else if (context == OperationContext.FidoPasskeys) {
+                    return context
+                }
+            }
+
+            return OperationContext.Oath
+        }
+    }
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        private var startTimeMs: Long = -1
+
+        override fun onPause(owner: LifecycleOwner) {
+            startTimeMs = currentTimeMs
+            super.onPause(owner)
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+            super.onResume(owner)
+            if (canInvoke) {
+                if (appViewModel.connectedYubiKey.value == null) {
+                    // no USB YubiKey is connected, reset known data on resume
+                    logger.debug("Removing NFC data after resume.")
+                    if (clearDeviceInfoOnDisconnect) {
+                        appViewModel.setDeviceInfo(null)
+                    }
+                    deviceListeners.forEach { listener ->
+                        listener.onTimeout()
+                    }
+                }
+            }
+        }
+
+        private val currentTimeMs
+            get() = System.currentTimeMillis()
+
+        private val canInvoke: Boolean
+            get() = startTimeMs != -1L && currentTimeMs - startTimeMs > NFC_DATA_CLEANUP_DELAY
+    }
+
+    private val usbObserver = Observer<UsbYubiKeyDevice?> { yubiKeyDevice ->
+        if (yubiKeyDevice == null) {
+            deviceListeners.forEach { listener ->
+                listener.onDisconnected()
+            }
+            if (clearDeviceInfoOnDisconnect) {
+                appViewModel.setDeviceInfo(null)
+            }
+        } else {
+            deviceListeners.forEach { listener ->
+                listener.onConnected(yubiKeyDevice)
+            }
+        }
+    }
+
+    init {
+        appViewModel.connectedYubiKey.observe(lifecycleOwner, usbObserver)
+        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+    }
+
+    fun dispose() {
+        lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+        appViewModel.connectedYubiKey.removeObserver(usbObserver)
+    }
+
+    fun setDeviceInfo(deviceInfo: Info?) {
+        appViewModel.setDeviceInfo(deviceInfo)
+    }
+
+    fun isUsbKeyConnected(): Boolean {
+        return appViewModel.connectedYubiKey.value != null
+    }
+
+    suspend fun <T> withKey(onUsb: suspend (UsbYubiKeyDevice) -> T) =
+        appViewModel.connectedYubiKey.value?.let {
+            onUsb(it)
+        }
+
+    suspend fun <T> withKey(onNfc: suspend () -> T, onUsb: suspend (UsbYubiKeyDevice) -> T) =
+        appViewModel.connectedYubiKey.value?.let {
+            onUsb(it)
+        } ?: onNfc()
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoActionDescription.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoActionDescription.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.yubico.authenticator.fido
 
 const val dialogDescriptionOathIndex = 200

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoActionDescription.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoActionDescription.kt
@@ -22,7 +22,8 @@ enum class FidoActionDescription(private val value: Int) {
     Reset(0),
     Unlock(1),
     SetPin(2),
-    ActionFailure(3);
+    DeleteCredential(3),
+    ActionFailure(4);
 
     val id: Int
         get() = value + dialogDescriptionOathIndex

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoActionDescription.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoActionDescription.kt
@@ -1,0 +1,13 @@
+package com.yubico.authenticator.fido
+
+const val dialogDescriptionOathIndex = 200
+
+enum class FidoActionDescription(private val value: Int) {
+    Reset(0),
+    Unlock(1),
+    SetPin(2),
+    ActionFailure(3);
+
+    val id: Int
+        get() = value + dialogDescriptionOathIndex
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoConnectionHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoConnectionHelper.kt
@@ -20,6 +20,7 @@ import com.yubico.authenticator.DialogIcon
 import com.yubico.authenticator.DialogManager
 import com.yubico.authenticator.DialogTitle
 import com.yubico.authenticator.MainViewModel
+import com.yubico.authenticator.device.DeviceManager
 import com.yubico.authenticator.fido.data.YubiKitFidoSession
 import com.yubico.authenticator.yubikit.withConnection
 import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
@@ -30,7 +31,7 @@ import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.suspendCoroutine
 
 class FidoConnectionHelper(
-    private val appViewModel: MainViewModel,
+    private val deviceManager: DeviceManager,
     private val dialogManager: DialogManager
 ) {
     private var pendingAction: FidoAction? = null
@@ -46,9 +47,9 @@ class FidoConnectionHelper(
         actionDescription: FidoActionDescription,
         action: (YubiKitFidoSession) -> T
     ): T {
-        return appViewModel.connectedYubiKey.value?.let {
-            useSessionUsb(it, action)
-        } ?: useSessionNfc(actionDescription, action)
+        return deviceManager.withKey(
+            onNfc = { useSessionNfc(actionDescription,action) },
+            onUsb = { useSessionUsb(it, action) })
     }
 
     suspend fun <T> useSessionUsb(

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoConnectionHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoConnectionHelper.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator.fido
+
+import com.yubico.authenticator.DialogIcon
+import com.yubico.authenticator.DialogManager
+import com.yubico.authenticator.DialogTitle
+import com.yubico.authenticator.MainViewModel
+import com.yubico.authenticator.fido.data.YubiKitFidoSession
+import com.yubico.authenticator.yubikit.withConnection
+import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
+import com.yubico.yubikit.core.fido.FidoConnection
+import com.yubico.yubikit.core.util.Result
+import org.slf4j.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.suspendCoroutine
+
+class FidoConnectionHelper(
+    private val appViewModel: MainViewModel,
+    private val dialogManager: DialogManager
+) {
+    private var pendingAction: FidoAction? = null
+
+    fun invokePending(fidoSession: YubiKitFidoSession) {
+        pendingAction?.let { action ->
+            action.invoke(Result.success(fidoSession))
+            pendingAction = null
+        }
+    }
+
+    suspend fun <T> useSession(
+        actionDescription: FidoActionDescription,
+        action: (YubiKitFidoSession) -> T
+    ): T {
+        return appViewModel.connectedYubiKey.value?.let {
+            useSessionUsb(it, action)
+        } ?: useSessionNfc(actionDescription, action)
+    }
+
+    suspend fun <T> useSessionUsb(
+        device: UsbYubiKeyDevice,
+        block: (YubiKitFidoSession) -> T
+    ): T = device.withConnection<FidoConnection, T> {
+        block(YubiKitFidoSession(it))
+    }
+
+    suspend fun <T> useSessionNfc(
+        actionDescription: FidoActionDescription,
+        block: (YubiKitFidoSession) -> T
+    ): T {
+        try {
+            val result = suspendCoroutine { outer ->
+                pendingAction = {
+                    outer.resumeWith(runCatching {
+                        block.invoke(it.value)
+                    })
+                }
+                dialogManager.showDialog(
+                    DialogIcon.Nfc,
+                    DialogTitle.TapKey,
+                    actionDescription.id
+                ) {
+                    logger.debug("Cancelled Dialog {}", actionDescription.name)
+                    pendingAction?.invoke(Result.failure(CancellationException()))
+                    pendingAction = null
+                }
+            }
+            return result
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Throwable) {
+            throw error
+        } finally {
+            dialogManager.closeDialog()
+        }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(FidoConnectionHelper::class.java)
+    }
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.yubico.authenticator.fido
 
 import androidx.lifecycle.DefaultLifecycleObserver

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
@@ -1,0 +1,394 @@
+package com.yubico.authenticator.fido
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.Observer
+import com.yubico.authenticator.AppContextManager
+import com.yubico.authenticator.AppPreferences
+import com.yubico.authenticator.DialogIcon
+import com.yubico.authenticator.DialogManager
+import com.yubico.authenticator.DialogTitle
+import com.yubico.authenticator.MainViewModel
+import com.yubico.authenticator.asString
+import com.yubico.authenticator.device.Info
+import com.yubico.authenticator.device.UnknownDevice
+import com.yubico.authenticator.fido.data.Session
+import com.yubico.authenticator.fido.data.YubiKitFidoSession
+import com.yubico.authenticator.setHandler
+import com.yubico.authenticator.yubikit.getDeviceInfo
+import com.yubico.authenticator.yubikit.withConnection
+import com.yubico.yubikit.android.transport.nfc.NfcYubiKeyDevice
+import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
+import com.yubico.yubikit.core.Transport
+import com.yubico.yubikit.core.YubiKeyDevice
+import com.yubico.yubikit.core.application.ApplicationNotAvailableException
+import com.yubico.yubikit.core.fido.CtapException
+import com.yubico.yubikit.core.smartcard.SmartCardConnection
+import com.yubico.yubikit.core.util.Result
+import com.yubico.yubikit.fido.ctap.ClientPin
+import com.yubico.yubikit.fido.ctap.CredentialManagement
+import com.yubico.yubikit.fido.ctap.Ctap2Session
+import com.yubico.yubikit.fido.ctap.Ctap2Session.InfoData
+import com.yubico.yubikit.fido.ctap.PinUvAuthDummyProtocol
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocol
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV1
+import com.yubico.yubikit.fido.ctap.PinUvAuthProtocolV2
+import com.yubico.yubikit.support.DeviceUtil
+import io.flutter.plugin.common.BinaryMessenger
+import io.flutter.plugin.common.MethodChannel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import org.json.JSONObject
+import org.slf4j.LoggerFactory
+import java.util.Arrays
+import java.util.concurrent.Executors
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.suspendCoroutine
+
+typealias FidoAction = (Result<YubiKitFidoSession, Exception>) -> Unit
+
+class FidoManager(
+    private val lifecycleOwner: LifecycleOwner,
+    messenger: BinaryMessenger,
+    private val appViewModel: MainViewModel,
+    private val fidoViewModel: FidoViewModel,
+    private val dialogManager: DialogManager,
+    private val appPreferences: AppPreferences,
+) : AppContextManager {
+
+    companion object {
+        const val NFC_DATA_CLEANUP_DELAY = 30L * 1000 // 30s
+
+        fun getPreferredPinUvAuthProtocol(infoData: InfoData): PinUvAuthProtocol {
+            val pinUvAuthProtocols = infoData.pinUvAuthProtocols
+            val pinSupported = infoData.options["clientPin"] != null
+            if (pinSupported) {
+                for (protocol in pinUvAuthProtocols) {
+                    if (protocol == PinUvAuthProtocolV1.VERSION) {
+                        return PinUvAuthProtocolV1()
+                    }
+                    if (protocol == PinUvAuthProtocolV2.VERSION) {
+                        return PinUvAuthProtocolV2()
+                    }
+                }
+            }
+            return PinUvAuthDummyProtocol()
+        }
+    }
+
+    private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+    private val coroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+
+    private val fidoChannel = MethodChannel(messenger, "android.fido.methods")
+
+    private val logger = LoggerFactory.getLogger(FidoManager::class.java)
+    private var pendingAction: FidoAction? = null
+    private var token: ByteArray? = null
+
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+
+        private var startTimeMs: Long = -1
+
+        override fun onPause(owner: LifecycleOwner) {
+            startTimeMs = currentTimeMs
+            super.onPause(owner)
+        }
+
+        override fun onResume(owner: LifecycleOwner) {
+            super.onResume(owner)
+            if (canInvoke) {
+                if (appViewModel.connectedYubiKey.value == null) {
+                    // no USB YubiKey is connected, reset known data on resume
+                    logger.debug("Removing NFC data after resume.")
+                    appViewModel.setDeviceInfo(null)
+                    fidoViewModel.setSessionState(null)
+                }
+            }
+        }
+
+        private val currentTimeMs
+            get() = System.currentTimeMillis()
+
+        private val canInvoke: Boolean
+            get() = startTimeMs != -1L && currentTimeMs - startTimeMs > NFC_DATA_CLEANUP_DELAY
+    }
+
+    private val usbObserver = Observer<UsbYubiKeyDevice?> {
+        if (it == null) {
+            appViewModel.setDeviceInfo(null)
+            fidoViewModel.setSessionState(null)
+        }
+    }
+
+    init {
+        appViewModel.connectedYubiKey.observe(lifecycleOwner, usbObserver)
+        //fidoViewModel.credentials.observe(lifecycleOwner, credentialObserver)
+
+        // FIDO methods callable from Flutter:
+        fidoChannel.setHandler(coroutineScope) { method, args ->
+            when (method) {
+                "reset" -> noop()
+
+                "unlock" -> unlock(
+                    (args["pin"] as String).toCharArray()
+                )
+
+                "set_pin" -> setPin(
+                    (args["pin"] as String?)?.toCharArray(),
+                    (args["new_pin"] as String).toCharArray(),
+                )
+
+                else -> throw NotImplementedError()
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+    }
+
+    override fun dispose() {
+        lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
+        appViewModel.connectedYubiKey.removeObserver(usbObserver)
+        // oathViewModel.credentials.removeObserver(credentialObserver)
+        fidoChannel.setMethodCallHandler(null)
+        coroutineScope.cancel()
+    }
+
+    private fun noop(): String = ""
+
+    override suspend fun processYubiKey(device: YubiKeyDevice) {
+        try {
+            device.withConnection<SmartCardConnection, Unit> { connection ->
+                val session = YubiKitFidoSession(connection)
+
+                val previousAaguid = fidoViewModel.sessionState.value?.info?.aaguid?.asString()
+                val sessionAaguid = session.cachedInfo.aaguid.asString()
+
+                logger.debug(
+                    "Previous aaguid: {}, current aaguid: {}",
+                    previousAaguid,
+                    sessionAaguid
+                )
+
+                if (sessionAaguid == previousAaguid && device is NfcYubiKeyDevice) {
+                    // Run any pending action
+                    pendingAction?.let { action ->
+                        action.invoke(Result.success(session))
+                        pendingAction = null
+                    }
+                } else {
+
+                    if (sessionAaguid != previousAaguid) {
+                        // different key
+                        logger.debug("This is a different key than previous, invalidating the PIN token")
+                        if (token != null) {
+                            Arrays.fill(token!!, 0.toByte())
+                            token = null
+                        }
+                    }
+
+                    fidoViewModel.setSessionState(
+                        Session(
+                            session,
+                            token != null
+                        )
+                    )
+
+                    // Update deviceInfo since the deviceId has changed
+                    val pid = (device as? UsbYubiKeyDevice)?.pid
+                    val deviceInfo = DeviceUtil.readInfo(connection, pid)
+                    appViewModel.setDeviceInfo(
+                        Info(
+                            name = DeviceUtil.getName(deviceInfo, pid?.type),
+                            isNfc = device.transport == Transport.NFC,
+                            usbPid = pid?.value,
+                            deviceInfo = deviceInfo
+                        )
+                    )
+                }
+
+            }
+        } catch (e: Exception) {
+            // OATH not enabled/supported, try to get DeviceInfo over other USB interfaces
+            logger.error("Failed to connect to CCID", e)
+            if (device.transport == Transport.USB || e is ApplicationNotAvailableException) {
+                val deviceInfo = try {
+                    getDeviceInfo(device)
+                } catch (e: IllegalArgumentException) {
+                    logger.debug("Device was not recognized")
+                    UnknownDevice.copy(isNfc = device.transport == Transport.NFC)
+                } catch (e: Exception) {
+                    logger.error("Failure getting device info", e)
+                    null
+                }
+
+                logger.debug("Setting device info: {}", deviceInfo)
+                appViewModel.setDeviceInfo(deviceInfo)
+            }
+
+            // Clear any cached OATH state
+            fidoViewModel.setSessionState(null)
+        } finally {
+
+        }
+    }
+
+    private fun unlockSession(
+        ctap2Session: Ctap2Session,
+        clientPin: ClientPin,
+        pin: CharArray
+    ): String {
+        val permissions =
+            if (CredentialManagement.isSupported(ctap2Session.cachedInfo))
+                ClientPin.PIN_PERMISSION_CM
+            else
+                0
+        // TODO: Add bio Enrollment permissions if supported
+
+        if (permissions != 0) {
+            token = clientPin.getPinToken(pin, permissions, "")
+        } else {
+            clientPin.getPinToken(pin, permissions, "yubico-authenticator.example.com")
+        }
+
+        fidoViewModel.setSessionState(
+            Session(
+                ctap2Session,
+                token != null
+            )
+        )
+        return JSONObject(mapOf("success" to true)).toString()
+    }
+
+    private fun catchPinErrors(clientPin: ClientPin, block: () -> String): String =
+        try {
+            block()
+        } catch (ctapException: CtapException) {
+            if (ctapException.ctapError == CtapException.ERR_PIN_INVALID ||
+                ctapException.ctapError == CtapException.ERR_PIN_BLOCKED ||
+                ctapException.ctapError == CtapException.ERR_PIN_AUTH_BLOCKED
+            ) {
+                token = null
+                val pinRetriesResult = clientPin.pinRetries
+                JSONObject(
+                    mapOf(
+                        "success" to false,
+                        "pinRetries" to pinRetriesResult.count,
+                        "authBlocked" to (ctapException.ctapError == CtapException.ERR_PIN_AUTH_BLOCKED)
+                    )
+                ).toString()
+            } else {
+                throw ctapException
+            }
+        }
+
+    private suspend fun unlock(pin: CharArray): String =
+        useSession(FidoActionDescription.Unlock) { ctap2Session ->
+            val clientPin =
+                ClientPin(ctap2Session, getPreferredPinUvAuthProtocol(ctap2Session.cachedInfo))
+            try {
+                catchPinErrors(clientPin) {
+                    unlockSession(ctap2Session, clientPin, pin)
+                }
+
+            } finally {
+                Arrays.fill(pin, 0.toChar())
+            }
+        }
+
+    private fun setOrChangePin(
+        ctap2Session: Ctap2Session,
+        clientPin: ClientPin,
+        pin: CharArray?,
+        newPin: CharArray
+    ) {
+        val infoData = ctap2Session.cachedInfo
+        val hasPin = infoData.options["clientPin"] == true
+
+        if (hasPin) {
+            clientPin.changePin(pin!!, newPin)
+        } else {
+            clientPin.setPin(newPin)
+        }
+    }
+
+    private suspend fun setPin(pin: CharArray?, newPin: CharArray): String =
+        useSession(FidoActionDescription.SetPin) { ctap2Session ->
+            val clientPin =
+                ClientPin(ctap2Session, getPreferredPinUvAuthProtocol(ctap2Session.cachedInfo))
+            try {
+                catchPinErrors(clientPin) {
+                    setOrChangePin(ctap2Session, clientPin, pin, newPin)
+                    unlockSession(ctap2Session, clientPin, newPin)
+                }
+            } finally {
+                Arrays.fill(newPin, 0.toChar())
+                pin?.let {
+                    Arrays.fill(it, 0.toChar())
+                }
+            }
+        }
+
+    private suspend fun <T> useSession(
+        actionDescription: FidoActionDescription,
+        action: (YubiKitFidoSession) -> T
+    ): T {
+        return appViewModel.connectedYubiKey.value?.let {
+            useSessionUsb(it, action)
+        } ?: useSessionNfc(actionDescription, action)
+    }
+
+    private suspend fun <T> useSessionUsb(
+        device: UsbYubiKeyDevice,
+        block: (YubiKitFidoSession) -> T
+    ): T = device.withConnection<SmartCardConnection, T> {
+        block(YubiKitFidoSession(it))
+    }
+
+    private suspend fun <T> useSessionNfc(
+        actionDescription: FidoActionDescription,
+        block: (YubiKitFidoSession) -> T
+    ): T {
+        try {
+            val result = suspendCoroutine { outer ->
+                pendingAction = {
+                    outer.resumeWith(runCatching {
+                        block.invoke(it.value)
+                    })
+                }
+                dialogManager.showDialog(
+                    DialogIcon.Nfc,
+                    DialogTitle.TapKey,
+                    actionDescription.id
+                ) {
+                    logger.debug("Cancelled Dialog {}", actionDescription.name)
+                    pendingAction?.invoke(Result.failure(CancellationException()))
+                    pendingAction = null
+                }
+            }
+            // Personally I find it better to not have the dialog updates for FIDO
+            //    dialogManager.updateDialogState(
+            //        dialogIcon = DialogIcon.Success,
+            //        dialogTitle = DialogTitle.OperationSuccessful
+            //    )
+            //    // TODO: This delays the closing of the dialog, but also the return value
+            //    delay(500)
+            return result
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Throwable) {
+            // Personally I find it better to not have the dialog updates for FIDO
+            //    dialogManager.updateDialogState(
+            //        dialogIcon = DialogIcon.Failure,
+            //        dialogTitle = DialogTitle.OperationFailed,
+            //        dialogDescriptionId = FidoActionDescription.ActionFailure.id
+            //    )
+            //    // TODO: This delays the closing of the dialog, but also the return value
+            //    delay(1500)
+            throw error
+        } finally {
+            dialogManager.closeDialog()
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoPinStore.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoPinStore.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator.fido
+
+class FidoPinStore {
+    private var pin: CharArray? = null
+
+    fun hasPin(): Boolean {
+        return pin != null
+    }
+
+    fun getPin(): CharArray {
+        return pin!!
+    }
+
+    fun setPin(newPin: CharArray?) {
+        pin = newPin?.clone()
+    }
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoResetHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoResetHelper.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator.fido
+
+import androidx.lifecycle.viewModelScope
+import com.yubico.authenticator.MainViewModel
+import com.yubico.authenticator.NULL
+import com.yubico.authenticator.fido.data.FidoResetState
+import com.yubico.authenticator.fido.data.Session
+import com.yubico.authenticator.fido.data.YubiKitFidoSession
+import com.yubico.yubikit.core.application.CommandState
+import com.yubico.yubikit.core.fido.CtapException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+class FidoResetHelper(
+    private val appViewModel: MainViewModel,
+    private val fidoViewModel: FidoViewModel,
+    private val connectionHelper: FidoConnectionHelper,
+    private val pinStore: FidoPinStore
+) {
+
+    var inProgress = false
+
+    private val coroutineScope = fidoViewModel.viewModelScope
+    private var resetCommandState: CommandState? = null
+    private var cancelReset: Boolean = false
+
+    suspend fun reset(): String {
+        try {
+            inProgress = true
+            fidoViewModel.updateResetState(FidoResetState.Remove)
+            val usb = appViewModel.connectedYubiKey.value != null
+            if (usb) {
+                resetOverUSB()
+            } else {
+                resetOverNfc()
+            }
+            logger.info("FIDO reset complete")
+        } catch (e: CancellationException) {
+            logger.debug("FIDO reset cancelled")
+        } finally {
+            inProgress = false
+            if (appViewModel.connectedYubiKey.value == null) {
+                appViewModel.setDeviceInfo(null)
+                fidoViewModel.setSessionState(null)
+                fidoViewModel.updateCredentials(emptyList())
+            }
+        }
+        return NULL
+    }
+
+    fun cancelReset(): String {
+        cancelReset = true
+        resetCommandState?.cancel()
+        inProgress = false
+        return NULL
+    }
+
+    private suspend fun waitForUsbDisconnect() = suspendCoroutine { continuation ->
+        coroutineScope.launch {
+            cancelReset = false
+            while (appViewModel.connectedYubiKey.value != null) {
+                if (cancelReset) {
+                    logger.debug("Reset was cancelled")
+                    continuation.resumeWithException(CancellationException())
+                    return@launch
+                }
+                logger.debug("Waiting for YubiKey to be disconnected")
+                delay(300)
+            }
+            continuation.resume(Unit)
+        }
+    }
+
+    private suspend fun waitForConnection() = suspendCoroutine { continuation ->
+        coroutineScope.launch {
+            fidoViewModel.updateResetState(FidoResetState.Insert)
+            cancelReset = false
+            while (appViewModel.connectedYubiKey.value == null) {
+                if (cancelReset) {
+                    logger.debug("Reset was cancelled")
+                    continuation.resumeWithException(CancellationException())
+                    return@launch
+                }
+                logger.debug("Waiting for YubiKey to be connected")
+                delay(300)
+            }
+            continuation.resume(Unit)
+        }
+    }
+
+
+    private suspend fun resetAfterTouch() = suspendCoroutine { continuation ->
+        coroutineScope.launch(Dispatchers.Main) {
+            fidoViewModel.updateResetState(FidoResetState.Touch)
+            logger.debug("Waiting for touch")
+            connectionHelper.useSessionUsb(appViewModel.connectedYubiKey.value!!) { fidoSession ->
+                resetCommandState = CommandState()
+                try {
+                    doReset(fidoSession)
+                    continuation.resume(Unit)
+                } catch (e: CtapException) {
+                    when (e.ctapError) {
+                        CtapException.ERR_KEEPALIVE_CANCEL -> {
+                            logger.debug("Received ERR_KEEPALIVE_CANCEL during FIDO reset")
+                        }
+
+                        CtapException.ERR_ACTION_TIMEOUT -> {
+                            logger.debug("Received ERR_ACTION_TIMEOUT during FIDO reset")
+                        }
+
+                        else -> {
+                            logger.error("Received CtapException during FIDO reset: ", e)
+                        }
+                    }
+
+                    continuation.resumeWithException(CancellationException())
+                } catch (e: IOException) {
+                    // communication error, key was removed?
+                    logger.error("IOException during FIDO reset: ", e)
+                    // treat it as cancellation
+                    continuation.resumeWithException(CancellationException())
+                } finally {
+                    resetCommandState = null
+                }
+            }
+        }
+    }
+
+
+    private suspend fun resetOverUSB() {
+        waitForUsbDisconnect()
+        waitForConnection()
+        resetAfterTouch()
+    }
+
+    private suspend fun resetOverNfc() = suspendCoroutine { continuation ->
+        fidoViewModel.updateResetState(FidoResetState.Insert)
+        coroutineScope.launch {
+            fidoViewModel.updateResetState(FidoResetState.Touch)
+            try {
+                connectionHelper.useSessionNfc(FidoActionDescription.Reset) { fidoSession ->
+                    doReset(fidoSession)
+                    continuation.resume(Unit)
+                }
+            } catch (e: CancellationException) {
+                logger.debug("FIDO reset over NFC was cancelled")
+                continuation.resumeWithException(e)
+            } catch (e: Throwable) {
+                logger.error("FIDO reset over NFC failed with exception: ", e)
+                continuation.resumeWithException(e)
+            }
+        }
+    }
+
+    private fun doReset(fidoSession: YubiKitFidoSession) {
+        logger.debug("Calling FIDO reset")
+        fidoSession.reset(resetCommandState)
+        pinStore.setPin(null)
+        fidoViewModel.setSessionState(Session(fidoSession.info, true))
+        fidoViewModel.updateCredentials(emptyList())
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(FidoResetHelper::class.java)
+    }
+
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -24,7 +24,7 @@ import com.yubico.authenticator.fido.data.FidoResetState
 import com.yubico.authenticator.fido.data.Session
 
 class FidoViewModel : ViewModel() {
-    private val _sessionState = MutableLiveData<Session?>()
+    private val _sessionState = MutableLiveData<Session?>(null)
     val sessionState: LiveData<Session?> = _sessionState
 
     fun setSessionState(sessionState: Session?) {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.yubico.authenticator.fido
 
 import androidx.lifecycle.LiveData

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 import com.yubico.authenticator.fido.data.Session
+import com.yubico.authenticator.fido.data.FidoCredential
 
 class FidoViewModel : ViewModel() {
     private val _sessionState = MutableLiveData<Session?>()
@@ -12,5 +13,12 @@ class FidoViewModel : ViewModel() {
 
     fun setSessionState(sessionState: Session?) {
         _sessionState.postValue(sessionState)
+    }
+
+    private val _credentials = MutableLiveData<List<FidoCredential>>()
+    val credentials: LiveData<List<FidoCredential>> = _credentials
+
+    fun updateCredentials(credentials: List<FidoCredential>) {
+        _credentials.postValue(credentials)
     }
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -19,10 +19,9 @@ package com.yubico.authenticator.fido
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-
-import com.yubico.authenticator.fido.data.Session
 import com.yubico.authenticator.fido.data.FidoCredential
 import com.yubico.authenticator.fido.data.FidoResetState
+import com.yubico.authenticator.fido.data.Session
 
 class FidoViewModel : ViewModel() {
     private val _sessionState = MutableLiveData<Session?>()
@@ -45,7 +44,7 @@ class FidoViewModel : ViewModel() {
         })
     }
 
-    private val _resetState = MutableLiveData<String>()
+    private val _resetState = MutableLiveData(FidoResetState.Remove.value)
     val resetState: LiveData<String> = _resetState
 
     fun updateResetState(resetState: FidoResetState) {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -1,0 +1,16 @@
+package com.yubico.authenticator.fido
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+import com.yubico.authenticator.fido.data.Session
+
+class FidoViewModel : ViewModel() {
+    private val _sessionState = MutableLiveData<Session?>()
+    val sessionState: LiveData<Session?> = _sessionState
+
+    fun setSessionState(sessionState: Session?) {
+        _sessionState.postValue(sessionState)
+    }
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.ViewModel
 
 import com.yubico.authenticator.fido.data.Session
 import com.yubico.authenticator.fido.data.FidoCredential
+import com.yubico.authenticator.fido.data.FidoResetState
 
 class FidoViewModel : ViewModel() {
     private val _sessionState = MutableLiveData<Session?>()
@@ -42,5 +43,12 @@ class FidoViewModel : ViewModel() {
         _credentials.postValue(_credentials.value?.filter {
             it.credentialId != credentialId || it.rpId != rpId
         })
+    }
+
+    private val _resetState = MutableLiveData<String>()
+    val resetState: LiveData<String> = _resetState
+
+    fun updateResetState(resetState: FidoResetState) {
+        _resetState.postValue(resetState.value)
     }
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoViewModel.kt
@@ -37,4 +37,10 @@ class FidoViewModel : ViewModel() {
     fun updateCredentials(credentials: List<FidoCredential>) {
         _credentials.postValue(credentials)
     }
+
+    fun removeCredential(rpId: String, credentialId: String) {
+        _credentials.postValue(_credentials.value?.filter {
+            it.credentialId != credentialId || it.rpId != rpId
+        })
+    }
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/FidoCredential.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/FidoCredential.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator.fido.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FidoCredential(
+    @SerialName("rp_id")
+    val rpId: String,
+    @SerialName("credential_id")
+    val credentialId: String,
+    @SerialName("user_id")
+    val userId: String,
+    @SerialName("user_name")
+    val userName: String
+)

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/FidoCredential.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/FidoCredential.kt
@@ -18,6 +18,7 @@ package com.yubico.authenticator.fido.data
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 data class FidoCredential(
@@ -28,5 +29,7 @@ data class FidoCredential(
     @SerialName("user_id")
     val userId: String,
     @SerialName("user_name")
-    val userName: String
+    val userName: String,
+    @Transient
+    val publicKeyCredentialDescriptor: Map<String, Any?> = emptyMap()
 )

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/FidoResetState.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/FidoResetState.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yubico.authenticator.fido.data
+
+enum class FidoResetState(val value: String) {
+    Remove("remove"),
+    Insert("insert"),
+    Touch("touch")
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.yubico.authenticator.fido.data
 
 import com.yubico.yubikit.fido.ctap.Ctap2Session.InfoData

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
@@ -87,10 +87,30 @@ data class SessionInfo(
 data class Session(
     @SerialName("info")
     val info: SessionInfo,
-    @SerialName("unlocked")
-    val unlocked: Boolean
+    val unlocked: Boolean,
+    val initialized: Boolean
 ) {
     constructor(infoData: InfoData, unlocked: Boolean) : this(
-        SessionInfo(infoData), unlocked
+        SessionInfo(infoData), unlocked, true
     )
+
+    companion object {
+        val uninitialized = Session(
+            SessionInfo(
+                Options(
+                    clientPin = false,
+                    credMgmt = false,
+                    credentialMgmtPreview = false,
+                    bioEnroll = null,
+                    alwaysUv = false
+                ),
+                aaguid = ByteArray(0),
+                minPinLength = 0,
+                forcePinChange = false
+            ),
+            unlocked = false,
+            initialized = false
+        )
+    }
+
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
@@ -1,0 +1,80 @@
+package com.yubico.authenticator.fido.data
+
+import com.yubico.yubikit.fido.ctap.Ctap2Session.InfoData
+import kotlinx.serialization.*
+
+typealias YubiKitFidoSession = com.yubico.yubikit.fido.ctap.Ctap2Session
+
+@Serializable
+data class Options(
+    val clientPin: Boolean,
+    val credMgmt: Boolean,
+    val credentialMgmtPreview: Boolean,
+    val bioEnroll: Boolean?,
+    val alwaysUv: Boolean
+)
+
+fun Map<String, Any?>.getBoolean(
+    key: String,
+    default: Boolean = false
+): Boolean = get(key) as? Boolean ?: default
+
+fun Map<String, Any?>.getOptionalBoolean(
+    key: String
+): Boolean? = get(key) as? Boolean
+
+@Serializable
+data class SessionInfo(
+    val options: Options,
+    val aaguid: ByteArray,
+    @SerialName("min_pin_length")
+    val minPinLength: Int,
+    @SerialName("force_pin_change")
+    val forcePinChange: Boolean
+) {
+    constructor(infoData: InfoData) : this(
+        Options(
+            infoData.options.getBoolean("clientPin"),
+            infoData.options.getBoolean("credMgmt"),
+            infoData.options.getBoolean("credentialMgmtPreview"),
+            infoData.options.getOptionalBoolean("bioEnroll"),
+            infoData.options.getBoolean("alwaysUv")
+        ),
+        infoData.aaguid,
+        infoData.minPinLength,
+        infoData.forcePinChange
+    )
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SessionInfo
+
+        if (options != other.options) return false
+        if (!aaguid.contentEquals(other.aaguid)) return false
+        if (minPinLength != other.minPinLength) return false
+        return forcePinChange == other.forcePinChange
+    }
+
+    override fun hashCode(): Int {
+        var result = options.hashCode()
+        result = 31 * result + aaguid.contentHashCode()
+        result = 31 * result + minPinLength
+        result = 31 * result + forcePinChange.hashCode()
+        return result
+    }
+
+}
+
+@Serializable
+data class Session(
+    @SerialName("info")
+    val info: SessionInfo,
+    @SerialName("unlocked")
+    val unlocked: Boolean
+) {
+    constructor(fidoSession: YubiKitFidoSession, unlocked: Boolean) : this(
+        SessionInfo(fidoSession.cachedInfo), unlocked
+    )
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
@@ -90,7 +90,7 @@ data class Session(
     @SerialName("unlocked")
     val unlocked: Boolean
 ) {
-    constructor(fidoSession: YubiKitFidoSession, unlocked: Boolean) : this(
-        SessionInfo(fidoSession.cachedInfo), unlocked
+    constructor(infoData: InfoData, unlocked: Boolean) : this(
+        SessionInfo(infoData), unlocked
     )
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -50,6 +50,7 @@ import com.yubico.yubikit.core.Transport
 import com.yubico.yubikit.core.YubiKeyDevice
 import com.yubico.yubikit.core.application.ApplicationNotAvailableException
 import com.yubico.yubikit.core.smartcard.ApduException
+import com.yubico.yubikit.core.smartcard.AppId
 import com.yubico.yubikit.core.smartcard.SW
 import com.yubico.yubikit.core.smartcard.SmartCardConnection
 import com.yubico.yubikit.core.smartcard.SmartCardProtocol
@@ -79,7 +80,6 @@ class OathManager(
 ) : AppContextManager {
     companion object {
         const val NFC_DATA_CLEANUP_DELAY = 30L * 1000 // 30s
-        val OTP_AID = byteArrayOf(0xa0.toByte(), 0x00, 0x00, 0x05, 0x27, 0x20, 0x01, 0x01)
     }
 
     private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
@@ -302,7 +302,7 @@ class OathManager(
                     if (session.version.isLessThan(4, 0, 0) && connection.transport == Transport.NFC) {
                         // NEO over NFC, select OTP applet before reading info
                         try {
-                            SmartCardProtocol(connection).select(OTP_AID)
+                            SmartCardProtocol(connection).select(AppId.OTP)
                         } catch (e: Exception) {
                             logger.error("Failed to recognize this OATH device.")
                             // we know this is NFC device and it supports OATH

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -19,12 +19,13 @@ package com.yubico.authenticator.oath
 import android.annotation.TargetApi
 import android.content.Context
 import android.os.Build
-import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
 import com.yubico.authenticator.*
 import com.yubico.authenticator.device.Capabilities
+import com.yubico.authenticator.device.DeviceListener
+import com.yubico.authenticator.device.DeviceManager
 import com.yubico.authenticator.device.Info
 import com.yubico.authenticator.device.UnknownDevice
 import com.yubico.authenticator.oath.data.Code
@@ -73,13 +74,14 @@ typealias OathAction = (Result<YubiKitOathSession, Exception>) -> Unit
 class OathManager(
     private val lifecycleOwner: LifecycleOwner,
     messenger: BinaryMessenger,
-    private val appViewModel: MainViewModel,
+    private val deviceManager: DeviceManager,
     private val oathViewModel: OathViewModel,
     private val dialogManager: DialogManager,
     private val appPreferences: AppPreferences,
-) : AppContextManager {
+) : AppContextManager(lifecycleOwner), DeviceListener {
+
     companion object {
-        const val NFC_DATA_CLEANUP_DELAY = 30L * 1000 // 30s
+        private val memoryKeyProvider = ClearingMemProvider()
     }
 
     private val dispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
@@ -87,7 +89,6 @@ class OathManager(
 
     private val oathChannel = MethodChannel(messenger, "android.oath.methods")
 
-    private val memoryKeyProvider = ClearingMemProvider()
     private val keyManager by lazy {
         KeyManager(
             compatUtil.from(Build.VERSION_CODES.M) {
@@ -108,60 +109,23 @@ class OathManager(
     private var refreshJob: Job? = null
     private var addToAny = false
 
-    // provides actions for lifecycle events
-    private val lifecycleObserver = object : DefaultLifecycleObserver {
-
-        private var startTimeMs: Long = -1
-
-        override fun onPause(owner: LifecycleOwner) {
-            startTimeMs = currentTimeMs
-
-            // cancel any pending actions, except for addToAny
-            if (!addToAny) {
-                pendingAction?.let {
-                    logger.debug("Cancelling pending action/closing nfc dialog.")
-                    it.invoke(Result.failure(CancellationException()))
-                    coroutineScope.launch {
-                        dialogManager.closeDialog()
-                    }
-                    pendingAction = null
+    override fun onPause() {
+        // cancel any pending actions, except for addToAny
+        if (!addToAny) {
+            pendingAction?.let {
+                logger.debug("Cancelling pending action/closing nfc dialog.")
+                it.invoke(Result.failure(CancellationException()))
+                coroutineScope.launch {
+                    dialogManager.closeDialog()
                 }
+                pendingAction = null
             }
-
-            super.onPause(owner)
-        }
-
-        override fun onResume(owner: LifecycleOwner) {
-            super.onResume(owner)
-            if (canInvoke) {
-                if (appViewModel.connectedYubiKey.value == null) {
-                    // no USB YubiKey is connected, reset known data on resume
-                    logger.debug("Removing NFC data after resume.")
-                    appViewModel.setDeviceInfo(null)
-                    oathViewModel.setSessionState(null)
-                }
-            }
-        }
-
-
-        private val currentTimeMs
-            get() = System.currentTimeMillis()
-
-        private val canInvoke: Boolean
-            get() = startTimeMs != -1L && currentTimeMs - startTimeMs > NFC_DATA_CLEANUP_DELAY
-    }
-
-    private val usbObserver = Observer<UsbYubiKeyDevice?> {
-        refreshJob?.cancel()
-        if (it == null) {
-            appViewModel.setDeviceInfo(null)
-            oathViewModel.setSessionState(null)
         }
     }
 
     private val credentialObserver = Observer<List<CredentialWithCode>?> { codes ->
         refreshJob?.cancel()
-        if (codes != null && appViewModel.connectedYubiKey.value != null) {
+        if (codes != null && deviceManager.isUsbKeyConnected()) {
             val expirations = codes
                 .filter { it.credential.codeType == CodeType.TOTP && !it.credential.touchRequired }
                 .mapNotNull { it.code?.validTo }
@@ -190,7 +154,7 @@ class OathManager(
     }
 
     init {
-        appViewModel.connectedYubiKey.observe(lifecycleOwner, usbObserver)
+        deviceManager.addDeviceListener(this)
         oathViewModel.credentials.observe(lifecycleOwner, credentialObserver)
 
         // OATH methods callable from Flutter:
@@ -237,12 +201,17 @@ class OathManager(
             }
         }
 
-        lifecycleOwner.lifecycle.addObserver(lifecycleObserver)
+        if (!deviceManager.isUsbKeyConnected()) {
+            // for NFC connections require extra tap when switching context
+            if (oathViewModel.sessionState.value == null) {
+                oathViewModel.setSessionState(Session.uninitialized)
+            }
+        }
     }
 
     override fun dispose() {
-        lifecycleOwner.lifecycle.removeObserver(lifecycleObserver)
-        appViewModel.connectedYubiKey.removeObserver(usbObserver)
+        super.dispose()
+        deviceManager.removeDeviceListener(this)
         oathViewModel.credentials.removeObserver(credentialObserver)
         oathChannel.setMethodCallHandler(null)
         coroutineScope.cancel()
@@ -307,7 +276,7 @@ class OathManager(
                             logger.error("Failed to recognize this OATH device.")
                             // we know this is NFC device and it supports OATH
                             val oathCapabilities = Capabilities(nfc = 0x20)
-                            appViewModel.setDeviceInfo(
+                            deviceManager.setDeviceInfo(
                                 UnknownDevice.copy(
                                     config = UnknownDevice.config.copy(enabledCapabilities = oathCapabilities),
                                     name = "Unknown OATH device",
@@ -322,7 +291,7 @@ class OathManager(
                     // Update deviceInfo since the deviceId has changed
                     val pid = (device as? UsbYubiKeyDevice)?.pid
                     val deviceInfo = DeviceUtil.readInfo(connection, pid)
-                    appViewModel.setDeviceInfo(
+                    deviceManager.setDeviceInfo(
                         Info(
                             name = DeviceUtil.getName(deviceInfo, pid?.type),
                             isNfc = device.transport == Transport.NFC,
@@ -330,7 +299,6 @@ class OathManager(
                             deviceInfo = deviceInfo
                         )
                     )
-
                 }
             }
             logger.debug(
@@ -351,7 +319,7 @@ class OathManager(
                 }
 
                 logger.debug("Setting device info: {}", deviceInfo)
-                appViewModel.setDeviceInfo(deviceInfo)
+                deviceManager.setDeviceInfo(deviceInfo)
             }
 
             // Clear any cached OATH state
@@ -450,7 +418,7 @@ class OathManager(
                 oathViewModel.setSessionState(Session(it, remembered))
 
                 // fetch credentials after unlocking only if the YubiKey is connected over USB
-                if ( appViewModel.connectedYubiKey.value != null) {
+                if (deviceManager.isUsbKeyConnected()) {
                     oathViewModel.updateCredentials(calculateOathCodes(it))
                 }
             }
@@ -495,7 +463,7 @@ class OathManager(
             throw Exception("Unset password failed")
         }
 
-    private suspend fun forgetPassword(): String {
+    private fun forgetPassword(): String {
         keyManager.clearAll()
         logger.debug("Cleared all keys.")
         oathViewModel.sessionState.value?.let {
@@ -563,7 +531,7 @@ class OathManager(
             } ?: emptyMap())
         }
 
-        appViewModel.connectedYubiKey.value?.let { usbYubiKeyDevice ->
+        deviceManager.withKey { usbYubiKeyDevice ->
             try {
                 useOathSessionUsb(usbYubiKeyDevice) { session ->
                     try {
@@ -688,7 +656,7 @@ class OathManager(
 
 
     private fun calculateOathCodes(session: YubiKitOathSession): Map<Credential, Code?> {
-        val isUsbKey = appViewModel.connectedYubiKey.value != null
+        val isUsbKey = deviceManager.isUsbKeyConnected()
         var timestamp = System.currentTimeMillis()
         if (!isUsbKey) {
             // NFC, need to pad timer to avoid immediate expiration
@@ -717,9 +685,10 @@ class OathManager(
 
         // callers can decide whether the session should be unlocked first
         unlockOnConnect.set(unlock)
-        return appViewModel.connectedYubiKey.value?.let {
-            useOathSessionUsb(it, action)
-        } ?: useOathSessionNfc(oathActionDescription, action)
+        return deviceManager.withKey(
+            onUsb = { useOathSessionUsb(it, action) },
+            onNfc = { useOathSessionNfc(oathActionDescription, action) }
+        )
     }
 
     private suspend fun <T> useOathSessionUsb(
@@ -775,5 +744,16 @@ class OathManager(
             (credential != null) && credential.id.asString() == credentialId
         } ?: throw Exception("Failed to find account")
 
+    override fun onConnected(device: YubiKeyDevice) {
+        refreshJob?.cancel()
+    }
 
+    override fun onDisconnected() {
+        refreshJob?.cancel()
+        oathViewModel.setSessionState(null)
+    }
+
+    override fun onTimeout() {
+        oathViewModel.setSessionState(null)
+    }
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/data/Session.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/data/Session.kt
@@ -34,7 +34,8 @@ data class Session(
     @SerialName("remembered")
     val isRemembered: Boolean,
     @SerialName("locked")
-    val isLocked: Boolean
+    val isLocked: Boolean,
+    val initialized: Boolean
 ) {
     @SerialName("keystore")
     @Suppress("unused")
@@ -50,6 +51,18 @@ data class Session(
         ),
         oathSession.isAccessKeySet,
         isRemembered,
-        oathSession.isLocked
+        oathSession.isLocked,
+        initialized = true
     )
+
+    companion object {
+        val uninitialized = Session(
+            deviceId = "",
+            version = Version(0, 0, 0),
+            isAccessKeySet = false,
+            isRemembered = false,
+            isLocked = false,
+            initialized = false
+        )
+    }
 }

--- a/android/app/src/test/java/com/yubico/authenticator/oath/ModelTest.kt
+++ b/android/app/src/test/java/com/yubico/authenticator/oath/ModelTest.kt
@@ -44,7 +44,8 @@ class ModelTest {
             Version(1, 2, 3),
             isAccessKeySet = false,
             isRemembered = false,
-            isLocked = false
+            isLocked = false,
+            initialized = true
         )
         )
     }

--- a/android/app/src/test/java/com/yubico/authenticator/oath/SerializationTest.kt
+++ b/android/app/src/test/java/com/yubico/authenticator/oath/SerializationTest.kt
@@ -40,7 +40,8 @@ class SerializationTest {
         Version(1, 2, 3),
         isAccessKeySet = false,
         isRemembered = false,
-        isLocked = false
+        isLocked = false,
+        initialized = true
     )
 
     @Test

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.9.21'
+    ext.kotlin_version = '1.9.22'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.4'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.6'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath 'com.android.tools.build:gradle:8.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
         classpath 'com.google.android.gms:oss-licenses-plugin:0.10.6'

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -23,6 +23,8 @@ import 'package:logging/logging.dart';
 
 import '../../app/logging.dart';
 import '../../app/models.dart';
+import '../../exception/cancellation_exception.dart';
+import '../../exception/platform_exception_decoder.dart';
 import '../../fido/models.dart';
 import '../../fido/state.dart';
 
@@ -79,8 +81,15 @@ class _FidoStateNotifier extends FidoStateNotifier {
       _log.debug('FIDO pin set/change failed');
       return PinResult.failed(
           setPinResponse['pinRetries'], setPinResponse['authBlocked']);
-    } catch (e) {
-      rethrow;
+    } on PlatformException catch (pe) {
+      var decodedException = pe.decode();
+      if (decodedException is CancellationException) {
+        _log.debug('User cancelled Set/Change FIDO PIN operation');
+      } else {
+        _log.error('Set/Change FIDO PIN operation failed.', pe);
+      }
+
+      throw decodedException;
     }
   }
 
@@ -98,8 +107,15 @@ class _FidoStateNotifier extends FidoStateNotifier {
       _log.debug('FIDO applet unlock failed');
       return PinResult.failed(
           unlockResponse['pinRetries'], unlockResponse['authBlocked']);
-    } catch (e) {
-      rethrow;
+    } on PlatformException catch (pe) {
+      var decodedException = pe.decode();
+      if (decodedException is CancellationException) {
+        _log.debug('User cancelled unlock FIDO operation');
+      } else {
+        _log.error('Unlock FIDO operation failed.', pe);
+      }
+
+      throw decodedException;
     }
   }
 }

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2023 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:logging/logging.dart';
+
+import '../../app/logging.dart';
+import '../../app/models.dart';
+import '../../fido/models.dart';
+import '../../fido/state.dart';
+
+final _log = Logger('android.fido.state');
+
+const _methods = MethodChannel('android.fido.methods');
+
+final androidFidoStateProvider = AsyncNotifierProvider.autoDispose
+    .family<FidoStateNotifier, FidoState, DevicePath>(_FidoStateNotifier.new);
+
+class _FidoStateNotifier extends FidoStateNotifier {
+  late StateController<String?> _pinController;
+  final _events = const EventChannel('android.fido.sessionState');
+  late StreamSubscription _sub;
+
+  @override
+  FutureOr<FidoState> build(DevicePath devicePath) async {
+    _sub = _events.receiveBroadcastStream().listen((event) {
+      final json = jsonDecode(event);
+      if (json == null) {
+        state = const AsyncValue.loading();
+      } else {
+        final fidoState = FidoState.fromJson(json);
+        state = AsyncValue.data(fidoState);
+      }
+    }, onError: (err, stackTrace) {
+      state = AsyncValue.error(err, stackTrace);
+    });
+
+    ref.onDispose(_sub.cancel);
+
+    return Completer<FidoState>().future;
+  }
+
+  @override
+  Stream<InteractionEvent> reset() {
+    final controller = StreamController<InteractionEvent>();
+
+    return controller.stream;
+  }
+
+  @override
+  Future<PinResult> setPin(String newPin, {String? oldPin}) async {
+    try {
+      final setPinResponse = jsonDecode(await _methods.invokeMethod('set_pin', {
+        'pin': oldPin,
+        'new_pin': newPin,
+      }));
+      if (setPinResponse['success'] == true) {
+        _log.debug('FIDO pin set/change successful');
+        return PinResult.success();
+      }
+
+      _log.debug('FIDO pin set/change failed');
+      return PinResult.failed(
+          setPinResponse['pinRetries'], setPinResponse['authBlocked']);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  @override
+  Future<PinResult> unlock(String pin) async {
+    try {
+      final unlockResponse =
+          jsonDecode(await _methods.invokeMethod('unlock', {'pin': pin}));
+
+      if (unlockResponse['success'] == true) {
+        _log.debug('FIDO applet unlocked');
+        return PinResult.success();
+      }
+
+      _log.debug('FIDO applet unlock failed');
+      return PinResult.failed(
+          unlockResponse['pinRetries'], unlockResponse['authBlocked']);
+    } catch (e) {
+      rethrow;
+    }
+  }
+}
+
+final androidFingerprintProvider = AsyncNotifierProvider.autoDispose
+    .family<FidoFingerprintsNotifier, List<Fingerprint>, DevicePath>(
+        _FidoFingerprintsNotifier.new);
+
+class _FidoFingerprintsNotifier extends FidoFingerprintsNotifier {
+  @override
+  FutureOr<List<Fingerprint>> build(DevicePath devicePath) async {
+    return [];
+  }
+
+  @override
+  Stream<FingerprintEvent> registerFingerprint({String? name}) {
+    final controller = StreamController<FingerprintEvent>();
+
+    return controller.stream;
+  }
+
+  @override
+  Future<Fingerprint> renameFingerprint(
+      Fingerprint fingerprint, String name) async {
+    return fingerprint;
+  }
+
+  @override
+  Future<void> deleteFingerprint(Fingerprint fingerprint) async {}
+}
+
+final androidCredentialProvider = AsyncNotifierProvider.autoDispose
+    .family<FidoCredentialsNotifier, List<FidoCredential>, DevicePath>(
+        _FidoCredentialsNotifier.new);
+
+class _FidoCredentialsNotifier extends FidoCredentialsNotifier {
+  @override
+  FutureOr<List<FidoCredential>> build(DevicePath devicePath) async {
+    return [];
+  }
+
+  @override
+  Future<void> deleteCredential(FidoCredential credential) async {}
+}

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -66,7 +66,7 @@ class _FidoStateNotifier extends FidoStateNotifier {
       _log.debug('Received event: \'$event\'');
       if (event is String && event.isNotEmpty) {
         controller.sink.add(InteractionEvent.values
-            .firstWhere((e) => '"${e.name}"'== event)); // TODO fix event form
+            .firstWhere((e) => '"${e.name}"' == event)); // TODO fix event form
       }
     });
 

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -62,7 +62,9 @@ class _FidoStateNotifier extends FidoStateNotifier {
   Stream<InteractionEvent> reset() {
     final controller = StreamController<InteractionEvent>();
     const resetEvents = EventChannel('android.fido.reset');
-    final resetSub = resetEvents.receiveBroadcastStream().listen((event) {
+
+    final resetSub =
+        resetEvents.receiveBroadcastStream().skip(1).listen((event) {
       _log.debug('Received event: \'$event\'');
       if (event is String && event.isNotEmpty) {
         controller.sink.add(InteractionEvent.values
@@ -70,9 +72,10 @@ class _FidoStateNotifier extends FidoStateNotifier {
       }
     });
 
-    controller.onCancel = () {
+    controller.onCancel = () async {
+      await _methods.invokeMethod('cancelReset');
       if (!controller.isClosed) {
-        resetSub.cancel();
+        await resetSub.cancel();
       }
     };
 

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -36,7 +36,6 @@ final androidFidoStateProvider = AsyncNotifierProvider.autoDispose
     .family<FidoStateNotifier, FidoState, DevicePath>(_FidoStateNotifier.new);
 
 class _FidoStateNotifier extends FidoStateNotifier {
-  late StateController<String?> _pinController;
   final _events = const EventChannel('android.fido.sessionState');
   late StreamSubscription _sub;
 

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/android/init.dart
+++ b/lib/android/init.dart
@@ -57,7 +57,7 @@ Future<Widget> initialize() async {
     overrides: [
       supportedAppsProvider.overrideWith(implementedApps([
         Application.accounts,
-        Application.webauthn,
+        Application.passkeys,
       ])),
       prefProvider.overrideWithValue(await SharedPreferences.getInstance()),
       logLevelProvider.overrideWith((ref) => AndroidLogger()),

--- a/lib/android/init.dart
+++ b/lib/android/init.dart
@@ -30,9 +30,11 @@ import '../app/models.dart';
 import '../app/state.dart';
 import '../app/views/main_page.dart';
 import '../core/state.dart';
+import '../fido/state.dart';
 import '../management/state.dart';
 import '../oath/state.dart';
 import 'app_methods.dart';
+import 'fido/state.dart';
 import 'logger.dart';
 import 'management/state.dart';
 import 'oath/otp_auth_link_handler.dart';
@@ -55,6 +57,7 @@ Future<Widget> initialize() async {
     overrides: [
       supportedAppsProvider.overrideWith(implementedApps([
         Application.accounts,
+        Application.webauthn,
       ])),
       prefProvider.overrideWithValue(await SharedPreferences.getInstance()),
       logLevelProvider.overrideWith((ref) => AndroidLogger()),
@@ -86,6 +89,11 @@ Future<Widget> initialize() async {
         (ref) => ref.watch(androidSupportedThemesProvider),
       ),
       defaultColorProvider.overrideWithValue(await getPrimaryColor()),
+
+      // FIDO
+      fidoStateProvider.overrideWithProvider(androidFidoStateProvider.call),
+      fingerprintProvider.overrideWithProvider(androidFingerprintProvider.call),
+      credentialProvider.overrideWithProvider(androidCredentialProvider.call),
     ],
     child: DismissKeyboard(
       child: YubicoAuthenticatorApp(page: Consumer(

--- a/lib/android/init.dart
+++ b/lib/android/init.dart
@@ -70,8 +70,15 @@ Future<Widget> initialize() async {
       oathStateProvider.overrideWithProvider(androidOathStateProvider.call),
       credentialListProvider
           .overrideWithProvider(androidCredentialListProvider.call),
-      currentAppProvider.overrideWith(
-          (ref) => AndroidSubPageNotifier(ref.watch(supportedAppsProvider))),
+      currentAppProvider.overrideWith((ref) {
+        final notifier =
+            AndroidSubPageNotifier(ref.watch(supportedAppsProvider));
+        ref.listen<AsyncValue<YubiKeyData>>(currentDeviceDataProvider,
+            (_, data) {
+          notifier.notifyDeviceChanged(data.whenOrNull(data: ((data) => data)));
+        }, fireImmediately: true);
+        return notifier;
+      }),
       managementStateProvider.overrideWithProvider(androidManagementState.call),
       currentDeviceProvider.overrideWith(
         () => AndroidCurrentDeviceNotifier(),

--- a/lib/android/state.dart
+++ b/lib/android/state.dart
@@ -104,6 +104,12 @@ class AndroidSubPageNotifier extends CurrentAppNotifier {
   void _handleSubPage(Application subPage) async {
     await _contextChannel.invokeMethod('setContext', {'index': subPage.index});
   }
+
+  @override
+  void notifyDeviceChanged(YubiKeyData? data) {
+    super.notifyDeviceChanged(data);
+    _handleSubPage(state);
+  }
 }
 
 class AndroidAttachedDevicesNotifier extends AttachedDevicesNotifier {

--- a/lib/android/tap_request_dialog.dart
+++ b/lib/android/tap_request_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/android/tap_request_dialog.dart
+++ b/lib/android/tap_request_dialog.dart
@@ -73,22 +73,33 @@ enum _DDesc {
   oathCalculateCode,
   oathActionFailure,
   oathAddMultipleAccounts,
+  // FIDO descriptions
+  fidoResetApplet,
+  fidoUnlockSession,
+  fidoSetPin,
+  fidoActionFailure,
+  // Others
   invalid;
 
   static const int dialogDescriptionOathIndex = 100;
+  static const int dialogDescriptionFidoIndex = 200;
 
   static _DDesc fromId(int? id) =>
       const {
-        dialogDescriptionOathIndex + 0: _DDesc.oathResetApplet,
-        dialogDescriptionOathIndex + 1: _DDesc.oathUnlockSession,
-        dialogDescriptionOathIndex + 2: _DDesc.oathSetPassword,
-        dialogDescriptionOathIndex + 3: _DDesc.oathUnsetPassword,
-        dialogDescriptionOathIndex + 4: _DDesc.oathAddAccount,
-        dialogDescriptionOathIndex + 5: _DDesc.oathRenameAccount,
-        dialogDescriptionOathIndex + 6: _DDesc.oathDeleteAccount,
-        dialogDescriptionOathIndex + 7: _DDesc.oathCalculateCode,
-        dialogDescriptionOathIndex + 8: _DDesc.oathActionFailure,
-        dialogDescriptionOathIndex + 9: _DDesc.oathAddMultipleAccounts
+        dialogDescriptionOathIndex + 0: oathResetApplet,
+        dialogDescriptionOathIndex + 1: oathUnlockSession,
+        dialogDescriptionOathIndex + 2: oathSetPassword,
+        dialogDescriptionOathIndex + 3: oathUnsetPassword,
+        dialogDescriptionOathIndex + 4: oathAddAccount,
+        dialogDescriptionOathIndex + 5: oathRenameAccount,
+        dialogDescriptionOathIndex + 6: oathDeleteAccount,
+        dialogDescriptionOathIndex + 7: oathCalculateCode,
+        dialogDescriptionOathIndex + 8: oathActionFailure,
+        dialogDescriptionOathIndex + 9: oathAddMultipleAccounts,
+        dialogDescriptionFidoIndex + 0: fidoResetApplet,
+        dialogDescriptionFidoIndex + 1: fidoUnlockSession,
+        dialogDescriptionFidoIndex + 2: fidoSetPin,
+        dialogDescriptionFidoIndex + 3: fidoActionFailure,
       }[id] ??
       _DDesc.invalid;
 }
@@ -162,6 +173,10 @@ class _DialogProvider {
       _DDesc.oathActionFailure => l10n.s_nfc_dialog_oath_failure,
       _DDesc.oathAddMultipleAccounts =>
         l10n.s_nfc_dialog_oath_add_multiple_accounts,
+      _DDesc.fidoResetApplet => l10n.s_nfc_dialog_fido_reset,
+      _DDesc.fidoUnlockSession => l10n.s_nfc_dialog_fido_unlock,
+      _DDesc.fidoSetPin => l10n.s_nfc_dialog_fido_set_pin,
+      _DDesc.fidoActionFailure => l10n.s_nfc_dialog_fido_failure,
       _ => ''
     };
   }

--- a/lib/android/tap_request_dialog.dart
+++ b/lib/android/tap_request_dialog.dart
@@ -175,7 +175,7 @@ class _DialogProvider {
         l10n.s_nfc_dialog_oath_add_multiple_accounts,
       _DDesc.fidoResetApplet => l10n.s_nfc_dialog_fido_reset,
       _DDesc.fidoUnlockSession => l10n.s_nfc_dialog_fido_unlock,
-      _DDesc.fidoSetPin => l10n.s_nfc_dialog_fido_set_pin,
+      _DDesc.fidoSetPin => l10n.l_nfc_dialog_fido_set_pin,
       _DDesc.fidoActionFailure => l10n.s_nfc_dialog_fido_failure,
       _ => ''
     };

--- a/lib/android/tap_request_dialog.dart
+++ b/lib/android/tap_request_dialog.dart
@@ -77,6 +77,7 @@ enum _DDesc {
   fidoResetApplet,
   fidoUnlockSession,
   fidoSetPin,
+  fidoDeleteCredential,
   fidoActionFailure,
   // Others
   invalid;
@@ -99,7 +100,8 @@ enum _DDesc {
         dialogDescriptionFidoIndex + 0: fidoResetApplet,
         dialogDescriptionFidoIndex + 1: fidoUnlockSession,
         dialogDescriptionFidoIndex + 2: fidoSetPin,
-        dialogDescriptionFidoIndex + 3: fidoActionFailure,
+        dialogDescriptionFidoIndex + 3: fidoDeleteCredential,
+        dialogDescriptionFidoIndex + 4: fidoActionFailure,
       }[id] ??
       _DDesc.invalid;
 }
@@ -176,6 +178,7 @@ class _DialogProvider {
       _DDesc.fidoResetApplet => l10n.s_nfc_dialog_fido_reset,
       _DDesc.fidoUnlockSession => l10n.s_nfc_dialog_fido_unlock,
       _DDesc.fidoSetPin => l10n.l_nfc_dialog_fido_set_pin,
+      _DDesc.fidoDeleteCredential => l10n.s_nfc_dialog_fido_delete_credential,
       _DDesc.fidoActionFailure => l10n.s_nfc_dialog_fido_failure,
       _ => ''
     };

--- a/lib/app/state.dart
+++ b/lib/app/state.dart
@@ -209,7 +209,7 @@ final currentAppProvider =
     StateNotifierProvider<CurrentAppNotifier, Application>((ref) {
   final notifier = CurrentAppNotifier(ref.watch(supportedAppsProvider));
   ref.listen<AsyncValue<YubiKeyData>>(currentDeviceDataProvider, (_, data) {
-    notifier._notifyDeviceChanged(data.whenOrNull(data: ((data) => data)));
+    notifier.notifyDeviceChanged(data.whenOrNull(data: ((data) => data)));
   }, fireImmediately: true);
   return notifier;
 });
@@ -223,7 +223,7 @@ class CurrentAppNotifier extends StateNotifier<Application> {
     state = app;
   }
 
-  void _notifyDeviceChanged(YubiKeyData? data) {
+  void notifyDeviceChanged(YubiKeyData? data) {
     if (data == null ||
         state.getAvailability(data) != Availability.unsupported) {
       // Keep current app

--- a/lib/desktop/models.freezed.dart
+++ b/lib/desktop/models.freezed.dart
@@ -179,7 +179,7 @@ class _$SuccessImpl implements Success {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$SuccessImpl &&
@@ -358,7 +358,7 @@ class _$SignalImpl implements Signal {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$SignalImpl &&
@@ -547,7 +547,7 @@ class _$RpcErrorImpl implements RpcError {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RpcErrorImpl &&
@@ -773,7 +773,7 @@ class _$RpcStateImpl implements _RpcState {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$RpcStateImpl &&

--- a/lib/fido/models.dart
+++ b/lib/fido/models.dart
@@ -27,7 +27,8 @@ class FidoState with _$FidoState {
 
   factory FidoState(
       {required Map<String, dynamic> info,
-      required bool unlocked}) = _FidoState;
+      required bool unlocked,
+      @Default(true) bool initialized}) = _FidoState;
 
   factory FidoState.fromJson(Map<String, dynamic> json) =>
       _$FidoStateFromJson(json);

--- a/lib/fido/models.freezed.dart
+++ b/lib/fido/models.freezed.dart
@@ -22,6 +22,7 @@ FidoState _$FidoStateFromJson(Map<String, dynamic> json) {
 mixin _$FidoState {
   Map<String, dynamic> get info => throw _privateConstructorUsedError;
   bool get unlocked => throw _privateConstructorUsedError;
+  bool get initialized => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -34,7 +35,7 @@ abstract class $FidoStateCopyWith<$Res> {
   factory $FidoStateCopyWith(FidoState value, $Res Function(FidoState) then) =
       _$FidoStateCopyWithImpl<$Res, FidoState>;
   @useResult
-  $Res call({Map<String, dynamic> info, bool unlocked});
+  $Res call({Map<String, dynamic> info, bool unlocked, bool initialized});
 }
 
 /// @nodoc
@@ -52,6 +53,7 @@ class _$FidoStateCopyWithImpl<$Res, $Val extends FidoState>
   $Res call({
     Object? info = null,
     Object? unlocked = null,
+    Object? initialized = null,
   }) {
     return _then(_value.copyWith(
       info: null == info
@@ -61,6 +63,10 @@ class _$FidoStateCopyWithImpl<$Res, $Val extends FidoState>
       unlocked: null == unlocked
           ? _value.unlocked
           : unlocked // ignore: cast_nullable_to_non_nullable
+              as bool,
+      initialized: null == initialized
+          ? _value.initialized
+          : initialized // ignore: cast_nullable_to_non_nullable
               as bool,
     ) as $Val);
   }
@@ -74,7 +80,7 @@ abstract class _$$FidoStateImplCopyWith<$Res>
       __$$FidoStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({Map<String, dynamic> info, bool unlocked});
+  $Res call({Map<String, dynamic> info, bool unlocked, bool initialized});
 }
 
 /// @nodoc
@@ -90,6 +96,7 @@ class __$$FidoStateImplCopyWithImpl<$Res>
   $Res call({
     Object? info = null,
     Object? unlocked = null,
+    Object? initialized = null,
   }) {
     return _then(_$FidoStateImpl(
       info: null == info
@@ -100,6 +107,10 @@ class __$$FidoStateImplCopyWithImpl<$Res>
           ? _value.unlocked
           : unlocked // ignore: cast_nullable_to_non_nullable
               as bool,
+      initialized: null == initialized
+          ? _value.initialized
+          : initialized // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -108,7 +119,9 @@ class __$$FidoStateImplCopyWithImpl<$Res>
 @JsonSerializable()
 class _$FidoStateImpl extends _FidoState {
   _$FidoStateImpl(
-      {required final Map<String, dynamic> info, required this.unlocked})
+      {required final Map<String, dynamic> info,
+      required this.unlocked,
+      this.initialized = true})
       : _info = info,
         super._();
 
@@ -125,26 +138,31 @@ class _$FidoStateImpl extends _FidoState {
 
   @override
   final bool unlocked;
+  @override
+  @JsonKey()
+  final bool initialized;
 
   @override
   String toString() {
-    return 'FidoState(info: $info, unlocked: $unlocked)';
+    return 'FidoState(info: $info, unlocked: $unlocked, initialized: $initialized)';
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$FidoStateImpl &&
             const DeepCollectionEquality().equals(other._info, _info) &&
             (identical(other.unlocked, unlocked) ||
-                other.unlocked == unlocked));
+                other.unlocked == unlocked) &&
+            (identical(other.initialized, initialized) ||
+                other.initialized == initialized));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, const DeepCollectionEquality().hash(_info), unlocked);
+  int get hashCode => Object.hash(runtimeType,
+      const DeepCollectionEquality().hash(_info), unlocked, initialized);
 
   @JsonKey(ignore: true)
   @override
@@ -163,7 +181,8 @@ class _$FidoStateImpl extends _FidoState {
 abstract class _FidoState extends FidoState {
   factory _FidoState(
       {required final Map<String, dynamic> info,
-      required final bool unlocked}) = _$FidoStateImpl;
+      required final bool unlocked,
+      final bool initialized}) = _$FidoStateImpl;
   _FidoState._() : super._();
 
   factory _FidoState.fromJson(Map<String, dynamic> json) =
@@ -173,6 +192,8 @@ abstract class _FidoState extends FidoState {
   Map<String, dynamic> get info;
   @override
   bool get unlocked;
+  @override
+  bool get initialized;
   @override
   @JsonKey(ignore: true)
   _$$FidoStateImplCopyWith<_$FidoStateImpl> get copyWith =>
@@ -265,7 +286,7 @@ class _$PinSuccessImpl implements _PinSuccess {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType && other is _$PinSuccessImpl);
   }
@@ -392,7 +413,7 @@ class _$PinFailureImpl implements _PinFailure {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$PinFailureImpl &&
@@ -594,7 +615,7 @@ class _$FingerprintImpl extends _Fingerprint {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$FingerprintImpl &&
@@ -750,7 +771,7 @@ class _$EventCaptureImpl implements _EventCapture {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EventCaptureImpl &&
@@ -900,7 +921,7 @@ class _$EventCompleteImpl implements _EventComplete {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EventCompleteImpl &&
@@ -1040,7 +1061,7 @@ class _$EventErrorImpl implements _EventError {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$EventErrorImpl &&
@@ -1274,7 +1295,7 @@ class _$FidoCredentialImpl implements _FidoCredential {
   }
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$FidoCredentialImpl &&

--- a/lib/fido/models.g.dart
+++ b/lib/fido/models.g.dart
@@ -10,12 +10,14 @@ _$FidoStateImpl _$$FidoStateImplFromJson(Map<String, dynamic> json) =>
     _$FidoStateImpl(
       info: json['info'] as Map<String, dynamic>,
       unlocked: json['unlocked'] as bool,
+      initialized: json['initialized'] as bool? ?? true,
     );
 
 Map<String, dynamic> _$$FidoStateImplToJson(_$FidoStateImpl instance) =>
     <String, dynamic>{
       'info': instance.info,
       'unlocked': instance.unlocked,
+      'initialized': instance.initialized,
     };
 
 _$FingerprintImpl _$$FingerprintImplFromJson(Map<String, dynamic> json) =>

--- a/lib/fido/views/passkeys_screen.dart
+++ b/lib/fido/views/passkeys_screen.dart
@@ -43,6 +43,7 @@ import 'pin_entry_form.dart';
 
 class PasskeysScreen extends ConsumerWidget {
   final YubiKeyData deviceData;
+
   const PasskeysScreen(this.deviceData, {super.key});
 
   @override
@@ -73,10 +74,27 @@ class PasskeysScreen extends ConsumerWidget {
           );
         },
         data: (fidoState) {
-          return fidoState.unlocked
-              ? _FidoUnlockedPage(deviceData.node, fidoState)
-              : _FidoLockedPage(deviceData.node, fidoState);
+          return fidoState.initialized
+              ? fidoState.unlocked
+                  ? _FidoUnlockedPage(deviceData.node, fidoState)
+                  : _FidoLockedPage(deviceData.node, fidoState)
+              : const _FidoInsertTapPage();
         });
+  }
+}
+
+class _FidoInsertTapPage extends ConsumerWidget {
+  const _FidoInsertTapPage();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    return MessagePage(
+      title: l10n.s_passkeys,
+      centered: false,
+      capabilities: const [Capability.fido2],
+      header: l10n.l_insert_or_tap_yk,
+    );
   }
 }
 

--- a/lib/fido/views/pin_dialog.dart
+++ b/lib/fido/views/pin_dialog.dart
@@ -36,6 +36,7 @@ final _log = Logger('fido.views.pin_dialog');
 class FidoPinDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
   final FidoState state;
+
   const FidoPinDialog(this.devicePath, this.state, {super.key});
 
   @override
@@ -216,7 +217,7 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
           }
         });
       });
-    }  on CancellationException catch (_) {
+    } on CancellationException catch (_) {
       // ignored
     } catch (e) {
       _log.error('Failed to set PIN', e);

--- a/lib/fido/views/pin_dialog.dart
+++ b/lib/fido/views/pin_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/fido/views/pin_dialog.dart
+++ b/lib/fido/views/pin_dialog.dart
@@ -24,6 +24,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../desktop/models.dart';
+import '../../exception/cancellation_exception.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_form_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -215,6 +216,8 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
           }
         });
       });
+    }  on CancellationException catch (_) {
+      // ignored
     } catch (e) {
       _log.error('Failed to set PIN', e);
       final String errorMessage;

--- a/lib/fido/views/pin_entry_form.dart
+++ b/lib/fido/views/pin_entry_form.dart
@@ -19,6 +19,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/models.dart';
+import '../../exception/cancellation_exception.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../models.dart';
@@ -45,17 +46,21 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
       _pinIsWrong = false;
       _isObscure = true;
     });
-    final result = await ref
-        .read(fidoStateProvider(widget._deviceNode.path).notifier)
-        .unlock(_pinController.text);
-    result.whenOrNull(failed: (retries, authBlocked) {
-      setState(() {
-        _pinController.clear();
-        _pinIsWrong = true;
-        _retries = retries;
-        _blocked = authBlocked;
+    try {
+      final result = await ref
+          .read(fidoStateProvider(widget._deviceNode.path).notifier)
+          .unlock(_pinController.text);
+      result.whenOrNull(failed: (retries, authBlocked) {
+        setState(() {
+          _pinController.clear();
+          _pinIsWrong = true;
+          _retries = retries;
+          _blocked = authBlocked;
+        });
       });
-    });
+    } on CancellationException catch (_) {
+      // ignored
+    }
   }
 
   String? _getErrorText() {

--- a/lib/fido/views/pin_entry_form.dart
+++ b/lib/fido/views/pin_entry_form.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -725,6 +725,7 @@
     "s_nfc_dialog_fido_reset": null,
     "s_nfc_dialog_fido_unlock": null,
     "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_delete_credential": null,
     "s_nfc_dialog_fido_failure": null,
 
     "@_ndef": {},

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -722,6 +722,11 @@
     "s_nfc_dialog_oath_failure": null,
     "s_nfc_dialog_oath_add_multiple_accounts": null,
 
+    "s_nfc_dialog_fido_reset": null,
+    "s_nfc_dialog_fido_unlock": null,
+    "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_failure": null,
+
     "@_ndef": {},
     "p_ndef_set_otp": null,
     "p_ndef_set_password": null,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -725,6 +725,7 @@
     "s_nfc_dialog_fido_reset": "Action: reset FIDO applet",
     "s_nfc_dialog_fido_unlock": "Action: unlock FIDO applet",
     "l_nfc_dialog_fido_set_pin": "Action: set or change FIDO applet PIN",
+    "s_nfc_dialog_fido_delete_credential": "Action: delete Passkey",
     "s_nfc_dialog_fido_failure": "FIDO operation failed",
 
     "@_ndef": {},

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -722,6 +722,11 @@
     "s_nfc_dialog_oath_failure": "OATH operation failed",
     "s_nfc_dialog_oath_add_multiple_accounts": "Action: add multiple accounts",
 
+    "s_nfc_dialog_fido_reset": "Action: reset FIDO applet",
+    "s_nfc_dialog_fido_unlock": "Action: unlock FIDO applet",
+    "s_nfc_dialog_fido_set_pin": "Action: set or change FIDO applet PIN",
+    "s_nfc_dialog_fido_failure": "FIDO operation failed",
+
     "@_ndef": {},
     "p_ndef_set_otp": "Successfully copied OTP code from YubiKey to clipboard.",
     "p_ndef_set_password": "Successfully copied password from YubiKey to clipboard.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -724,7 +724,7 @@
 
     "s_nfc_dialog_fido_reset": "Action: reset FIDO applet",
     "s_nfc_dialog_fido_unlock": "Action: unlock FIDO applet",
-    "s_nfc_dialog_fido_set_pin": "Action: set or change FIDO applet PIN",
+    "l_nfc_dialog_fido_set_pin": "Action: set or change FIDO applet PIN",
     "s_nfc_dialog_fido_failure": "FIDO operation failed",
 
     "@_ndef": {},

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -725,6 +725,7 @@
     "s_nfc_dialog_fido_reset": null,
     "s_nfc_dialog_fido_unlock": null,
     "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_delete_credential": null,
     "s_nfc_dialog_fido_failure": null,
 
     "@_ndef": {},

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -722,6 +722,11 @@
     "s_nfc_dialog_oath_failure": "Échec de l'opération OATH",
     "s_nfc_dialog_oath_add_multiple_accounts": "Action: ajouter plusieurs comptes",
 
+    "s_nfc_dialog_fido_reset": null,
+    "s_nfc_dialog_fido_unlock": null,
+    "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_failure": null,
+
     "@_ndef": {},
     "p_ndef_set_otp": null,
     "p_ndef_set_password": null,

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -722,6 +722,11 @@
     "s_nfc_dialog_oath_failure": "OATH操作は失敗しました",
     "s_nfc_dialog_oath_add_multiple_accounts": "操作：複数アカウントの追加",
 
+    "s_nfc_dialog_fido_reset": null,
+    "s_nfc_dialog_fido_unlock": null,
+    "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_failure": null,
+
     "@_ndef": {},
     "p_ndef_set_otp": null,
     "p_ndef_set_password": null,

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -725,6 +725,7 @@
     "s_nfc_dialog_fido_reset": null,
     "s_nfc_dialog_fido_unlock": null,
     "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_delete_credential": null,
     "s_nfc_dialog_fido_failure": null,
 
     "@_ndef": {},

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -725,6 +725,7 @@
     "s_nfc_dialog_fido_reset": null,
     "s_nfc_dialog_fido_unlock": null,
     "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_delete_credential": null,
     "s_nfc_dialog_fido_failure": null,
 
     "@_ndef": {},

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -722,6 +722,11 @@
     "s_nfc_dialog_oath_failure": "Operacja OATH nie powiodła się",
     "s_nfc_dialog_oath_add_multiple_accounts": "Działanie: dodawanie wielu kont",
 
+    "s_nfc_dialog_fido_reset": null,
+    "s_nfc_dialog_fido_unlock": null,
+    "l_nfc_dialog_fido_set_pin": null,
+    "s_nfc_dialog_fido_failure": null,
+
     "@_ndef": {},
     "p_ndef_set_otp": "OTP zostało skopiowane do schowka.",
     "p_ndef_set_password": "Hasło statyczne zostało skopiowane do schowka.",

--- a/lib/oath/models.dart
+++ b/lib/oath/models.dart
@@ -110,6 +110,7 @@ class OathState with _$OathState {
     required bool remembered,
     required bool locked,
     required KeystoreState keystore,
+    @Default(true) bool initialized,
   }) = _OathState;
 
   factory OathState.fromJson(Map<String, dynamic> json) =>

--- a/lib/oath/models.freezed.dart
+++ b/lib/oath/models.freezed.dart
@@ -639,6 +639,7 @@ mixin _$OathState {
   bool get remembered => throw _privateConstructorUsedError;
   bool get locked => throw _privateConstructorUsedError;
   KeystoreState get keystore => throw _privateConstructorUsedError;
+  bool get initialized => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -657,7 +658,8 @@ abstract class $OathStateCopyWith<$Res> {
       bool hasKey,
       bool remembered,
       bool locked,
-      KeystoreState keystore});
+      KeystoreState keystore,
+      bool initialized});
 
   $VersionCopyWith<$Res> get version;
 }
@@ -681,6 +683,7 @@ class _$OathStateCopyWithImpl<$Res, $Val extends OathState>
     Object? remembered = null,
     Object? locked = null,
     Object? keystore = null,
+    Object? initialized = null,
   }) {
     return _then(_value.copyWith(
       deviceId: null == deviceId
@@ -707,6 +710,10 @@ class _$OathStateCopyWithImpl<$Res, $Val extends OathState>
           ? _value.keystore
           : keystore // ignore: cast_nullable_to_non_nullable
               as KeystoreState,
+      initialized: null == initialized
+          ? _value.initialized
+          : initialized // ignore: cast_nullable_to_non_nullable
+              as bool,
     ) as $Val);
   }
 
@@ -733,7 +740,8 @@ abstract class _$$OathStateImplCopyWith<$Res>
       bool hasKey,
       bool remembered,
       bool locked,
-      KeystoreState keystore});
+      KeystoreState keystore,
+      bool initialized});
 
   @override
   $VersionCopyWith<$Res> get version;
@@ -756,6 +764,7 @@ class __$$OathStateImplCopyWithImpl<$Res>
     Object? remembered = null,
     Object? locked = null,
     Object? keystore = null,
+    Object? initialized = null,
   }) {
     return _then(_$OathStateImpl(
       null == deviceId
@@ -782,6 +791,10 @@ class __$$OathStateImplCopyWithImpl<$Res>
           ? _value.keystore
           : keystore // ignore: cast_nullable_to_non_nullable
               as KeystoreState,
+      initialized: null == initialized
+          ? _value.initialized
+          : initialized // ignore: cast_nullable_to_non_nullable
+              as bool,
     ));
   }
 }
@@ -793,7 +806,8 @@ class _$OathStateImpl implements _OathState {
       {required this.hasKey,
       required this.remembered,
       required this.locked,
-      required this.keystore});
+      required this.keystore,
+      this.initialized = true});
 
   factory _$OathStateImpl.fromJson(Map<String, dynamic> json) =>
       _$$OathStateImplFromJson(json);
@@ -810,10 +824,13 @@ class _$OathStateImpl implements _OathState {
   final bool locked;
   @override
   final KeystoreState keystore;
+  @override
+  @JsonKey()
+  final bool initialized;
 
   @override
   String toString() {
-    return 'OathState(deviceId: $deviceId, version: $version, hasKey: $hasKey, remembered: $remembered, locked: $locked, keystore: $keystore)';
+    return 'OathState(deviceId: $deviceId, version: $version, hasKey: $hasKey, remembered: $remembered, locked: $locked, keystore: $keystore, initialized: $initialized)';
   }
 
   @override
@@ -829,13 +846,15 @@ class _$OathStateImpl implements _OathState {
                 other.remembered == remembered) &&
             (identical(other.locked, locked) || other.locked == locked) &&
             (identical(other.keystore, keystore) ||
-                other.keystore == keystore));
+                other.keystore == keystore) &&
+            (identical(other.initialized, initialized) ||
+                other.initialized == initialized));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType, deviceId, version, hasKey, remembered, locked, keystore);
+  int get hashCode => Object.hash(runtimeType, deviceId, version, hasKey,
+      remembered, locked, keystore, initialized);
 
   @JsonKey(ignore: true)
   @override
@@ -856,7 +875,8 @@ abstract class _OathState implements OathState {
       {required final bool hasKey,
       required final bool remembered,
       required final bool locked,
-      required final KeystoreState keystore}) = _$OathStateImpl;
+      required final KeystoreState keystore,
+      final bool initialized}) = _$OathStateImpl;
 
   factory _OathState.fromJson(Map<String, dynamic> json) =
       _$OathStateImpl.fromJson;
@@ -873,6 +893,8 @@ abstract class _OathState implements OathState {
   bool get locked;
   @override
   KeystoreState get keystore;
+  @override
+  bool get initialized;
   @override
   @JsonKey(ignore: true)
   _$$OathStateImplCopyWith<_$OathStateImpl> get copyWith =>

--- a/lib/oath/models.g.dart
+++ b/lib/oath/models.g.dart
@@ -70,6 +70,7 @@ _$OathStateImpl _$$OathStateImplFromJson(Map<String, dynamic> json) =>
       remembered: json['remembered'] as bool,
       locked: json['locked'] as bool,
       keystore: $enumDecode(_$KeystoreStateEnumMap, json['keystore']),
+      initialized: json['initialized'] as bool? ?? true,
     );
 
 Map<String, dynamic> _$$OathStateImplToJson(_$OathStateImpl instance) =>
@@ -80,6 +81,7 @@ Map<String, dynamic> _$$OathStateImplToJson(_$OathStateImpl instance) =>
       'remembered': instance.remembered,
       'locked': instance.locked,
       'keystore': _$KeystoreStateEnumMap[instance.keystore]!,
+      'initialized': instance.initialized,
     };
 
 const _$KeystoreStateEnumMap = {

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -65,10 +65,27 @@ class OathScreen extends ConsumerWidget {
           error: (error, _) => AppFailurePage(
             cause: error,
           ),
-          data: (oathState) => oathState.locked
-              ? _LockedView(devicePath, oathState)
-              : _UnlockedView(devicePath, oathState),
+          data: (oathState) => oathState.initialized
+              ? oathState.locked
+                  ? _LockedView(devicePath, oathState)
+                  : _UnlockedView(devicePath, oathState)
+              : const _InsertTapView(),
         );
+  }
+}
+
+class _InsertTapView extends ConsumerWidget {
+  const _InsertTapView();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    return MessagePage(
+      title: AppLocalizations.of(context)!.s_accounts,
+      centered: false,
+      capabilities: const [Capability.oath],
+      header: l10n.l_insert_or_tap_yk,
+    );
   }
 }
 

--- a/lib/piv/views/pin_dialog.dart
+++ b/lib/piv/views/pin_dialog.dart
@@ -28,6 +28,7 @@ import '../state.dart';
 
 class PinDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
+
   const PinDialog(this.devicePath, {super.key});
 
   @override

--- a/lib/piv/views/pin_dialog.dart
+++ b/lib/piv/views/pin_dialog.dart
@@ -28,7 +28,6 @@ import '../state.dart';
 
 class PinDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
-
   const PinDialog(this.devicePath, {super.key});
 
   @override


### PR DESCRIPTION
With this change, users can use both OATH and FIDO functionality on keys which support those over NFC and USB.

Implements PIN management, passkey management and FIDO reset for the FIDO applet. 
