### PR TITLE
Increase NFC timeout period

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : FlutterFragmentActivity() {
     private val viewModel: MainViewModel by viewModels()
     private val oathViewModel: OathViewModel by viewModels()
 
-    private val nfcConfiguration = NfcConfiguration()
+    private val nfcConfiguration = NfcConfiguration().timeout(2000)
 
     private var hasNfc: Boolean = false
 


### PR DESCRIPTION
YubiKey NEO can hold as many accounts as the memory allows. With many account, 1000ms is not enough to read all the information.

This change increases the timeout value to 2s which was tested to be sufficient for 80+ TOTP accounts on YubiKey Neo.

This is related to issue https://github.com/Yubico/yubioath-android/issues/157