### PR TITLE
Fix Add OATH Account functionality

### DIFF
--- a/lib/android/init.dart
+++ b/lib/android/init.dart
@@ -64,6 +64,7 @@ Future<Widget> initialize() async {
       currentDeviceDataProvider.overrideWith(
         (ref) => ref.watch(androidDeviceDataProvider),
       ),
+      addOathAccount.overrideWith((ref) => ref.read(androidAddOathAccount)),
       oathStateProvider.overrideWithProvider(androidOathStateProvider.call),
       credentialListProvider
           .overrideWithProvider(androidCredentialListProvider.call),

--- a/lib/android/oath/state.dart
+++ b/lib/android/oath/state.dart
@@ -39,26 +39,29 @@ final _log = Logger('android.oath.state');
 const _methods = MethodChannel('android.oath.methods');
 
 // handles adding account on Android
-final androidAddAccountFlowProvider =
-    Provider<void Function(BuildContext)>((ref) => (context) async {
-          final l10n = AppLocalizations.of(context)!;
-          final withContext = ref.read(withContextProvider);
-          final qrScanner = ref.read(qrScannerProvider);
-          if (qrScanner != null) {
-            try {
-              final qrData = await qrScanner.scanQr();
-              await AndroidQrScanner.handleScannedData(
-                  qrData, withContext, qrScanner, l10n);
-            } on CancellationException catch (_) {
-              //ignored - user cancelled
-              return;
-            }
-          } else {
-            // no QR scanner - enter data manually
-            await AndroidQrScanner.showAccountManualEntryDialog(
-                withContext, l10n);
-          }
-        });
+final androidAddOathAccount = Provider<
+    void Function(
+      BuildContext, [
+      DevicePath? devicePath,
+      OathState? oathState,
+    ])>((ref) => (context, [devicePath, oathState]) async {
+      final l10n = AppLocalizations.of(context)!;
+      final withContext = ref.read(withContextProvider);
+      final qrScanner = ref.read(qrScannerProvider);
+      if (qrScanner != null) {
+        try {
+          final qrData = await qrScanner.scanQr();
+          await AndroidQrScanner.handleScannedData(
+              qrData, withContext, qrScanner, l10n);
+        } on CancellationException catch (_) {
+          //ignored - user cancelled
+          return;
+        }
+      } else {
+        // no QR scanner - enter data manually
+        await AndroidQrScanner.showAccountManualEntryDialog(withContext, l10n);
+      }
+    });
 
 final androidOathStateProvider = AsyncNotifierProvider.autoDispose
     .family<OathStateNotifier, OathState, DevicePath>(

--- a/lib/android/oath/state.dart
+++ b/lib/android/oath/state.dart
@@ -32,10 +32,33 @@ import '../../exception/cancellation_exception.dart';
 import '../../exception/platform_exception_decoder.dart';
 import '../../oath/models.dart';
 import '../../oath/state.dart';
+import '../qr_scanner/qr_scanner_provider.dart';
 
 final _log = Logger('android.oath.state');
 
 const _methods = MethodChannel('android.oath.methods');
+
+// handles adding account on Android
+final androidAddAccountFlowProvider =
+    Provider<void Function(BuildContext)>((ref) => (context) async {
+          final l10n = AppLocalizations.of(context)!;
+          final withContext = ref.read(withContextProvider);
+          final qrScanner = ref.read(qrScannerProvider);
+          if (qrScanner != null) {
+            try {
+              final qrData = await qrScanner.scanQr();
+              await AndroidQrScanner.handleScannedData(
+                  qrData, withContext, qrScanner, l10n);
+            } on CancellationException catch (_) {
+              //ignored - user cancelled
+              return;
+            }
+          } else {
+            // no QR scanner - enter data manually
+            await AndroidQrScanner.showAccountManualEntryDialog(
+                withContext, l10n);
+          }
+        });
 
 final androidOathStateProvider = AsyncNotifierProvider.autoDispose
     .family<OathStateNotifier, OathState, DevicePath>(

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -19,6 +19,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../android/app_methods.dart';
+import '../../android/oath/state.dart';
 import '../../android/qr_scanner/qr_scanner_provider.dart';
 import '../../android/state.dart';
 import '../../core/state.dart';
@@ -102,22 +103,7 @@ class MainPage extends ConsumerWidget {
             icon: const Icon(Icons.person_add_alt_1),
             tooltip: l10n.s_add_account,
             onPressed: () async {
-              final withContext = ref.read(withContextProvider);
-              final qrScanner = ref.read(qrScannerProvider);
-              if (qrScanner != null) {
-                try {
-                  final qrData = await qrScanner.scanQr();
-                  await AndroidQrScanner.handleScannedData(
-                      qrData, withContext, qrScanner, l10n);
-                } on CancellationException catch (_) {
-                  // ignored - user cancelled
-                  return;
-                }
-              } else {
-                // no QR scanner - enter data manually
-                await AndroidQrScanner.showAccountManualEntryDialog(
-                    withContext, l10n);
-              }
+              ref.read(androidAddAccountFlowProvider)(context);
             },
           ),
         );

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -19,15 +19,13 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../android/app_methods.dart';
-import '../../android/oath/state.dart';
-import '../../android/qr_scanner/qr_scanner_provider.dart';
 import '../../android/state.dart';
 import '../../core/state.dart';
-import '../../exception/cancellation_exception.dart';
 import '../../fido/views/fingerprints_screen.dart';
 import '../../fido/views/passkeys_screen.dart';
 import '../../fido/views/webauthn_page.dart';
 import '../../management/views/management_screen.dart';
+import '../../oath/state.dart';
 import '../../oath/views/oath_screen.dart';
 import '../../otp/views/otp_screen.dart';
 import '../../piv/views/piv_screen.dart';
@@ -103,7 +101,7 @@ class MainPage extends ConsumerWidget {
             icon: const Icon(Icons.person_add_alt_1),
             tooltip: l10n.s_add_account,
             onPressed: () async {
-              ref.read(androidAddAccountFlowProvider)(context);
+              ref.read(addOathAccount)(context);
             },
           ),
         );

--- a/lib/desktop/init.dart
+++ b/lib/desktop/init.dart
@@ -214,6 +214,7 @@ Future<Widget> initialize(List<String> argv) async {
         (ref) => ref.watch(desktopDeviceDataProvider),
       ),
       // OATH
+      addOathAccount.overrideWith((ref) => ref.read(desktopAddOathAccount)),
       oathStateProvider.overrideWithProvider(desktopOathState.call),
       credentialListProvider
           .overrideWithProvider(desktopOathCredentialListProvider.call),

--- a/lib/desktop/oath/state.dart
+++ b/lib/desktop/oath/state.dart
@@ -24,15 +24,29 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 
 import '../../app/logging.dart';
+import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/user_interaction.dart';
 import '../../oath/models.dart';
 import '../../oath/state.dart';
+import '../../oath/views/add_account_dialog.dart';
 import '../rpc.dart';
 import '../state.dart';
 
 final _log = Logger('desktop.oath.state');
+
+final desktopAddOathAccount = Provider<
+    void Function(
+      BuildContext, [
+      DevicePath? devicePath,
+      OathState? oathState,
+    ])>((ref) => (context, [devicePath, oathState]) async {
+      await showBlurDialog(
+        context: context,
+        builder: (context) => AddAccountDialog(devicePath, oathState),
+      );
+    });
 
 final _sessionProvider =
     Provider.autoDispose.family<RpcNodeSession, DevicePath>(
@@ -207,6 +221,7 @@ extension on OathCredential {
 }
 
 const String _steamCharTable = '23456789BCDFGHJKMNPQRTVWXY';
+
 String _formatSteam(String response) {
   final offset = int.parse(response.substring(response.length - 1), radix: 16);
   var number =
@@ -225,6 +240,7 @@ class DesktopCredentialListNotifier extends OathCredentialListNotifier {
   final RpcNodeSession _session;
   final bool _locked;
   Timer? _timer;
+
   DesktopCredentialListNotifier(this._withContext, this._session, this._locked)
       : super();
 

--- a/lib/oath/state.dart
+++ b/lib/oath/state.dart
@@ -26,6 +26,13 @@ import '../app/state.dart';
 import '../core/state.dart';
 import 'models.dart';
 
+final addOathAccount = Provider<
+    void Function(
+      BuildContext, [
+      DevicePath? devicePath,
+      OathState? oathState,
+    ])>((ref) => throw UnimplementedError());
+
 final searchProvider =
     StateNotifierProvider<SearchNotifier, String>((ref) => SearchNotifier());
 

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -18,18 +18,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../android/oath/state.dart';
-import '../../android/qr_scanner/qr_scanner_provider.dart';
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/action_list.dart';
-import '../../core/state.dart';
 import '../features.dart' as features;
 import '../icon_provider/icon_pack_dialog.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
-import 'add_account_dialog.dart';
+import '../state.dart';
 import 'manage_password_dialog.dart';
 
 Widget oathBuildActions(
@@ -59,15 +56,7 @@ Widget oathBuildActions(
             onTap: used != null && (capacity == null || capacity > used)
                 ? (context) async {
                     Navigator.of(context).popUntil((route) => route.isFirst);
-                    if (isAndroid) {
-                      ref.read(androidAddAccountFlowProvider)(context);
-                    } else {
-                      await showBlurDialog(
-                        context: context,
-                        builder: (context) =>
-                            AddAccountDialog(devicePath, oathState),
-                      );
-                    }
+                    ref.read(addOathAccount)(context, devicePath, oathState);
                   }
                 : null),
       ]),

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -18,6 +18,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../android/oath/state.dart';
 import '../../android/qr_scanner/qr_scanner_provider.dart';
 import '../../app/message.dart';
 import '../../app/models.dart';
@@ -59,17 +60,7 @@ Widget oathBuildActions(
                 ? (context) async {
                     Navigator.of(context).popUntil((route) => route.isFirst);
                     if (isAndroid) {
-                      final withContext = ref.read(withContextProvider);
-                      final qrScanner = ref.read(qrScannerProvider);
-                      if (qrScanner != null) {
-                        final qrData = await qrScanner.scanQr();
-                        await AndroidQrScanner.handleScannedData(
-                            qrData, withContext, qrScanner, l10n);
-                      } else {
-                        // no QR scanner - enter data manually
-                        await AndroidQrScanner.showAccountManualEntryDialog(
-                            withContext, l10n);
-                      }
+                      ref.read(androidAddAccountFlowProvider)(context);
                     } else {
                       await showBlurDialog(
                         context: context,

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -22,7 +22,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../android/oath/state.dart';
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/shortcuts.dart';
@@ -45,7 +44,6 @@ import 'account_dialog.dart';
 import 'account_helper.dart';
 import 'account_list.dart';
 import 'actions.dart';
-import 'add_account_dialog.dart';
 import 'key_actions.dart';
 import 'unlock_form.dart';
 import 'utils.dart';
@@ -165,17 +163,11 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
             ActionChip(
               label: Text(l10n.s_add_account),
               onPressed: () async {
-                if (isAndroid) {
-                  ref.read(androidAddAccountFlowProvider)(context);
-                } else {
-                  await showBlurDialog(
-                    context: context,
-                    builder: (context) => AddAccountDialog(
-                      widget.devicePath,
-                      widget.oathState,
-                    ),
-                  );
-                }
+                ref.read(addOathAccount)(
+                  context,
+                  widget.devicePath,
+                  widget.oathState,
+                );
               },
               avatar: const Icon(Icons.person_add_alt_1_outlined),
             )

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -22,6 +22,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../android/oath/state.dart';
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/shortcuts.dart';
@@ -164,13 +165,17 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
             ActionChip(
               label: Text(l10n.s_add_account),
               onPressed: () async {
-                await showBlurDialog(
-                  context: context,
-                  builder: (context) => AddAccountDialog(
-                    widget.devicePath,
-                    widget.oathState,
-                  ),
-                );
+                if (isAndroid) {
+                  ref.read(androidAddAccountFlowProvider)(context);
+                } else {
+                  await showBlurDialog(
+                    context: context,
+                    builder: (context) => AddAccountDialog(
+                      widget.devicePath,
+                      widget.oathState,
+                    ),
+                  );
+                }
               },
               avatar: const Icon(Icons.person_add_alt_1_outlined),
             )


### PR DESCRIPTION
Fixes issue when adding OATH account did not work on Android because desktop specific method was called.

To prevent similar situations in future, and avoid using different code for Android/Desktop, the PR adds a new provider called `addOathAccount` which returns a function for adding a new OATH account. This has an implementation for Android and Desktop.

Instead of 
```
  if (isAndroid) {
    // do something android specific
  } else {
    // do something desktop specific
  }
```

one need just call:
```
  ref.read(addOathAccount)(context, devicePath, oathState);
```

This was tested on Mac and Android.