### PR TITLE
Mended the broken Factory reset functionality

### DIFF
--- a/integration_test/oath_test.dart
+++ b/integration_test/oath_test.dart
@@ -45,9 +45,9 @@ void main() {
   group('Account creation', () {
     appTest('Initial reset OATH', (WidgetTester tester) async {
       /// reset OATH application
-      await tester.tapAppDrawerButton(oathAppDrawer);
+      //await tester.tapAppDrawerButton(oathAppDrawer);
       await tester.resetOATH();
-      await tester.longWait();
+      await tester.shortWait();
     });
     appTest('Create 32 Accounts', (WidgetTester tester) async {
       await tester.tapAppDrawerButton(oathAppDrawer);

--- a/integration_test/utils/oath_test_util.dart
+++ b/integration_test/utils/oath_test_util.dart
@@ -303,26 +303,14 @@ extension OathFunctions on WidgetTester {
 
   /// Factory reset OATH application
   Future<void> resetOATH() async {
-
-    // TODO: Implement this using new Reset Dialog
-
-    /// 1. instead of tapping actioniconbutton, first click navigation
+    /// 1. open drawer if needed
     await openDrawer();
     await shortWait();
 
-    //     await tapActionIconButton();
-    // Future<void> tapActionIconButton() async {
-    //   await tap(findActionIconButton());
-    //   await pump(const Duration(milliseconds: 500));
-    // }
-
     /// 2. then click the meatball button+'Factory reset' for correct S/N
-    // stealing some of startUp to get serialnumber check:
     await collectYubiKeyInformation();
     final approvedSerialNumbers = await getApprovedSerialNumbers();
-
     if (approvedSerialNumbers.contains(yubiKeySerialNumber)) {
-      // this does not work, yubikeyPopupMenuButton probably wrong!?
       await tap(find.byKey(yubikeyPopupMenuButton).hitTestable());
       await shortWait();
       await tap(find.byKey(yubikeyFactoryResetMenuButton).hitTestable());

--- a/integration_test/utils/oath_test_util.dart
+++ b/integration_test/utils/oath_test_util.dart
@@ -17,6 +17,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:yubico_authenticator/app/views/keys.dart' as app_keys;
+import 'package:yubico_authenticator/app/views/keys.dart';
 import 'package:yubico_authenticator/core/state.dart';
 import 'package:yubico_authenticator/oath/keys.dart' as keys;
 import 'package:yubico_authenticator/oath/models.dart';
@@ -302,12 +303,38 @@ extension OathFunctions on WidgetTester {
 
   /// Factory reset OATH application
   Future<void> resetOATH() async {
+
     // TODO: Implement this using new Reset Dialog
-    await tapActionIconButton();
+
+    /// 1. instead of tapping actioniconbutton, first click navigation
+    await openDrawer();
     await shortWait();
-    //await tap(find.byKey(keys.resetAction));
-    await shortWait();
-    await tap(find.text('Reset'));
+
+    //     await tapActionIconButton();
+    // Future<void> tapActionIconButton() async {
+    //   await tap(findActionIconButton());
+    //   await pump(const Duration(milliseconds: 500));
+    // }
+
+    /// 2. then click the meatball button+'Factory reset' for correct S/N
+    // stealing some of startUp to get serialnumber check:
+    await collectYubiKeyInformation();
+    final approvedSerialNumbers = await getApprovedSerialNumbers();
+
+    if (approvedSerialNumbers.contains(yubiKeySerialNumber)) {
+      // this does not work, yubikeyPopupMenuButton probably wrong!?
+      await tap(find.byKey(yubikeyPopupMenuButton).hitTestable());
+      await shortWait();
+      await tap(find.byKey(yubikeyFactoryResetMenuButton).hitTestable());
+      await longWait();
+    }
+
+    /// 3. then toggle 'OATH' in the 'Factory reset' reset_dialog.dart
+    await tap(find.byKey(factoryResetPickResetOath));
+    await longWait();
+
+    /// 4. Click reset TextButton: done
+    await tap(find.byKey(factoryResetReset));
     await shortWait();
   }
 

--- a/integration_test/utils/oath_test_util.dart
+++ b/integration_test/utils/oath_test_util.dart
@@ -303,19 +303,17 @@ extension OathFunctions on WidgetTester {
 
   /// Factory reset OATH application
   Future<void> resetOATH() async {
-    /// 1. open drawer if needed
-    await openDrawer();
+    final targetKey = approvedKeys[0]; // only reset approved keys!
+
+    /// 1. make sure we are using approved key
+    await switchToKey(targetKey);
     await shortWait();
 
-    /// 2. then click the meatball button+'Factory reset' for correct S/N
-    await collectYubiKeyInformation();
-    final approvedSerialNumbers = await getApprovedSerialNumbers();
-    if (approvedSerialNumbers.contains(yubiKeySerialNumber)) {
-      await tap(find.byKey(yubikeyPopupMenuButton).hitTestable());
-      await shortWait();
-      await tap(find.byKey(yubikeyFactoryResetMenuButton).hitTestable());
-      await longWait();
-    }
+    /// 2. open the key menu
+    await tapPopupMenu(targetKey);
+    await shortWait();
+    await tap(find.byKey(yubikeyFactoryResetMenuButton).hitTestable());
+    await longWait();
 
     /// 3. then toggle 'OATH' in the 'Factory reset' reset_dialog.dart
     await tap(find.byKey(factoryResetPickResetOath));

--- a/integration_test/utils/piv_test_util.dart
+++ b/integration_test/utils/piv_test_util.dart
@@ -48,24 +48,29 @@ extension PIVFunctions on WidgetTester {
     await sendKeyEvent(LogicalKeyboardKey.escape);
   }
 
-  /// Resets the PIV application of a key
+  /// Factory reset Piv application
   Future<void> resetPiv() async {
-    // TODO: Implement this using new Reset Dialog
-    // 1. open PIV view
-    var pivDrawerButton = find.byKey(pivAppDrawer).hitTestable();
-    await tap(pivDrawerButton);
+    final targetKey = approvedKeys[0]; // only reset approved keys!
+
+    /// 1. make sure we are using approved key
+    await switchToKey(targetKey);
+    await shortWait();
+
+    /// 2. open the key menu
+    await tapPopupMenu(targetKey);
+    await shortWait();
+    await tap(find.byKey(yubikeyFactoryResetMenuButton).hitTestable());
     await longWait();
-    // 1.3. Reset PIV
-    // 1. Click Configure YubiKey
-    await tap(find.byKey(actionsIconButtonKey).hitTestable());
+
+    /// 3. then toggle 'Piv' in the 'Factory reset' reset_dialog.dart
+    await tap(find.byKey(factoryResetPickResetPiv));
     await longWait();
-    // 2. Click Reset PIV
-    //await tap(find.byKey(resetAction).hitTestable());
-    await longWait();
-    // 3. Click Reset
-    await tap(find.byKey(resetButton).hitTestable());
-    await longWait();
-    // 4. Verify Resetedness
+
+    /// 4. Click reset TextButton: done
+    await tap(find.byKey(factoryResetReset));
+    await shortWait();
+
+    // 5. Verify Resetedness
     // /// TODO: this expect algorithm is flaky
     // expect(find.byWidgetPredicate((widget) {
     //   if (widget is AppListItem) {

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:yubico_authenticator/app/views/keys.dart' as app_keys;
+import 'package:yubico_authenticator/app/views/device_picker.dart';
 import 'package:yubico_authenticator/app/views/keys.dart';
 import 'package:yubico_authenticator/core/state.dart';
 import 'package:yubico_authenticator/management/views/keys.dart';
@@ -30,10 +31,82 @@ const shortWaitMs = 200;
 const longWaitMs = 500;
 const ultraLongWaitMs = 5000;
 
-/// information about YubiKey as seen by the app
-String? yubiKeyName;
-String? yubiKeyFirmware;
-String? yubiKeySerialNumber;
+class ConnectedKey {
+  final String? name;
+  final String? serialNumber;
+  final String? firmware;
+
+  const ConnectedKey(this.name, this.serialNumber, this.firmware);
+
+  @override
+  String toString() {
+    return 'ConnectedYubiKey{name: $name, serialNumber: $serialNumber, firmware: $firmware}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConnectedKey &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          serialNumber == other.serialNumber &&
+          firmware == other.firmware;
+
+  @override
+  int get hashCode => name.hashCode ^ serialNumber.hashCode ^ firmware.hashCode;
+}
+
+extension ConnectedKeyExt on List<ConnectedKey> {
+  String serialNumbers() => where((e) => e.serialNumber != null)
+      .map((e) => e.serialNumber!)
+      .toList()
+      .join(',');
+
+  String prettyList() {
+    var retval = '';
+    if (this.isEmpty) {
+      return 'No keys.';
+    }
+    for (final (index, connectedKey) in indexed) {
+      retval += '${index + 1}: ${connectedKey.name} / '
+          'SN: ${connectedKey.serialNumber} / '
+          'FW: ${connectedKey.firmware}\n';
+    }
+    return retval;
+  }
+}
+
+extension ListTileInfoExt on ListTile {
+  ConnectedKey getKeyInfo() {
+    final itemName = (title as Text).data;
+    String? itemSerialNumber;
+    String? itemFirmware;
+    var subtitle = (this.subtitle as Text?)?.data;
+
+    if (subtitle != null) {
+      RegExpMatch? match =
+          RegExp(r'S/N: (\d.*) F/W: (\d\.\d\.\d)').firstMatch(subtitle);
+      if (match != null) {
+        itemSerialNumber = match.group(1);
+        itemFirmware = match.group(2);
+      } else {
+        match = RegExp(r'F/W: (\d\.\d\.\d)').firstMatch(subtitle);
+        if (match != null) {
+          itemFirmware = match.group(1);
+        }
+      }
+    }
+
+    return ConnectedKey(
+      itemName,
+      itemSerialNumber,
+      itemFirmware,
+    );
+  }
+}
+
+/// contains information about connected YubiKeys approved for testing
+final approvedKeys = <ConnectedKey>[];
 bool collectedYubiKeyInformation = false;
 
 extension AppWidgetTester on WidgetTester {
@@ -75,8 +148,11 @@ extension AppWidgetTester on WidgetTester {
   }
 
   Future<void> tapActionIconButton() async {
-    await tap(findActionIconButton());
-    await pump(const Duration(milliseconds: 500));
+    final actionIconButtonFinder = findActionIconButton();
+    if (actionIconButtonFinder.evaluate().isNotEmpty) {
+      await tap(actionIconButtonFinder);
+      await pump(const Duration(milliseconds: 500));
+    }
   }
 
   Future<void> tapTopLeftCorner() async {
@@ -87,12 +163,15 @@ extension AppWidgetTester on WidgetTester {
   /// Drawer helpers
   bool hasDrawer() => scaffoldGlobalKey.currentState!.hasDrawer;
 
-  /// Open drawer
-  Future<void> openDrawer() async {
-    if (hasDrawer()) {
+  /// Open drawer if not opened
+  /// return open state
+  Future<bool> openDrawer() async {
+    bool isOpened = isDrawerOpened();
+    if (hasDrawer() && !isOpened) {
       scaffoldGlobalKey.currentState!.openDrawer();
       await pump(const Duration(milliseconds: 500));
     }
+    return isOpened;
   }
 
   /// Close drawer
@@ -118,6 +197,41 @@ extension AppWidgetTester on WidgetTester {
     var appButtonFinder = find.byKey(appKey).hitTestable();
     await tap(appButtonFinder);
     await longWait();
+  }
+
+  Future<void> switchToKey(ConnectedKey key) async {
+    await openDrawer();
+    final drawerDevicesFinder = await getDrawerDevices();
+    var itemIndex = 0;
+    for (var element in drawerDevicesFinder.evaluate()) {
+      final listTile = element.widget as ListTile;
+      if (key == listTile.getKeyInfo()) {
+        await tap(drawerDevicesFinder.at(itemIndex));
+        break;
+      }
+      itemIndex++;
+    }
+
+    await closeDrawer();
+  }
+
+  Future<void> tapPopupMenu(ConnectedKey key) async {
+    await openDrawer();
+    final drawerDevicesFinder = await getDrawerDevices();
+    var itemIndex = 0;
+    for (var element in drawerDevicesFinder.evaluate()) {
+      final listTile = element.widget as ListTile;
+      if (key == listTile.getKeyInfo()) {
+        // find the popup menu
+        final popupMenu = find.descendant(
+            of: drawerDevicesFinder.at(itemIndex),
+            matching: find.byKey(yubikeyPopupMenuButton));
+        expect(popupMenu, findsOne);
+        await tap(popupMenu);
+        break;
+      }
+      itemIndex++;
+    }
   }
 
   /// Management screen
@@ -161,9 +275,10 @@ extension AppWidgetTester on WidgetTester {
       testLog(false, 'Failed to read $approvedKeysResource');
     }
 
-    return (approved + (approved.isEmpty ? ',' : '') + envVar)
+    return (approved + (approved.isEmpty ? '' : ',') + envVar)
         .split(',')
         .map((e) => e.trim())
+        .sorted()
         .toList(growable: false);
   }
 
@@ -172,19 +287,29 @@ extension AppWidgetTester on WidgetTester {
         ? await android_test_util.startUp(this, startUpParams)
         : await desktop_test_util.startUp(this, startUpParams);
 
-    await collectYubiKeyInformation();
+    if (!collectedYubiKeyInformation) {
+      final connectedKeys = await collectYubiKeyInformation();
+      if (connectedKeys.isEmpty) {
+        fail('No YubiKey connected');
+      }
 
-    if (yubiKeySerialNumber == null) {
-      fail('No YubiKey connected');
-    }
+      final approvedSerialNumbers = await getApprovedSerialNumbers();
 
-    final approvedSerialNumbers = await getApprovedSerialNumbers();
+      approvedKeys.addAll(connectedKeys
+          .where(
+              (element) => approvedSerialNumbers.contains(element.serialNumber))
+          .toList(growable: false));
 
-    if (!approvedSerialNumbers.contains(yubiKeySerialNumber)) {
-      fail('YubiKey with S/N $yubiKeySerialNumber is not approved for '
-          'integration tests.\nUse --dart-define='
-          'YA_TEST_APPROVED_KEY_SN=$yubiKeySerialNumber test '
-          'parameter to approve it.');
+      testLog(false, 'Approved keys:');
+      testLog(false, approvedKeys.prettyList());
+
+      if (approvedKeys.isEmpty) {
+        final connectedSerials = connectedKeys.serialNumbers();
+        fail('None of the connected YubiKeys ($connectedSerials) '
+            'is approved for integration tests.\nUse --dart-define='
+            'YA_TEST_APPROVED_KEY_SN=$connectedSerials test '
+            'parameter to approve it.');
+      }
     }
 
     return result;
@@ -197,48 +322,36 @@ extension AppWidgetTester on WidgetTester {
   }
 
   /// get key information
-  Future<void> collectYubiKeyInformation() async {
-    if (collectedYubiKeyInformation) {
-      return;
-    }
+  Future<Finder> getDrawerDevices() async {
+    var devicePickerContent =
+        await waitForFinder(find.byType(DevicePickerContent));
+
+    var deviceRows = find.descendant(
+        of: devicePickerContent, matching: find.byType(ListTile));
+
+    return deviceRows;
+  }
+
+  Future<List<ConnectedKey>> collectYubiKeyInformation() async {
+    final connectedKeys = <ConnectedKey>[];
 
     await openDrawer();
 
-    var deviceInfo =
-        await waitForFinder(find.byKey(app_keys.deviceInfoListTile));
-    if (deviceInfo.evaluate().isNotEmpty) {
-      ListTile lt = find
-          .descendant(of: deviceInfo, matching: find.byType(ListTile))
-          .evaluate()
-          .single
-          .widget as ListTile;
-
-      yubiKeyName = (lt.title as Text).data;
-      var subtitle = (lt.subtitle as Text?)?.data;
-
-      if (subtitle != null) {
-        RegExpMatch? match =
-            RegExp(r'S/N: (\d.*) F/W: (\d\.\d\.\d)').firstMatch(subtitle);
-        if (match != null) {
-          yubiKeySerialNumber = match.group(1);
-          yubiKeyFirmware = match.group(2);
-        } else {
-          match = RegExp(r'F/W: (\d\.\d\.\d)').firstMatch(subtitle);
-          if (match != null) {
-            yubiKeyFirmware = match.group(1);
-          }
-        }
-      }
+    final drawerDevicesFinder = await getDrawerDevices();
+    for (var element in drawerDevicesFinder.evaluate()) {
+      final listTile = element.widget as ListTile;
+      connectedKeys.add(listTile.getKeyInfo());
     }
 
     // close the opened menu
     await closeDrawer();
 
-    if (yubiKeySerialNumber != null) {
-      testLog(false,
-          'Connected YubiKey: $yubiKeySerialNumber/$yubiKeyFirmware - $yubiKeyName');
-    }
+    testLog(false, 'Connected YubiKeys:');
+    testLog(false, connectedKeys.prettyList());
+
     collectedYubiKeyInformation = true;
+
+    return connectedKeys;
   }
 
   bool isTextButtonEnabled(Key buttonKey) {

--- a/lib/app/views/device_picker.dart
+++ b/lib/app/views/device_picker.dart
@@ -32,6 +32,7 @@ import '../models.dart';
 import '../state.dart';
 import 'device_avatar.dart';
 import 'keys.dart' as keys;
+import 'keys.dart';
 import 'reset_dialog.dart';
 
 final _hiddenDevicesProvider =
@@ -347,6 +348,7 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
       if (serial != null)
         PopupMenuItem(
           enabled: true,
+          key: yubikeyPopupMenuButton,
           onTap: () async {
             await ref.read(withContextProvider)((context) async {
               await _showKeyCustomizationDialog(
@@ -358,6 +360,7 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
           child: ListTile(
               title: Text(l10n.s_customize_key_action),
               leading: const Icon(Icons.palette_outlined),
+              key: yubikeyLabelColorMenuButton,
               dense: true,
               contentPadding: EdgeInsets.zero,
               enabled: true),
@@ -401,6 +404,7 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
                 ? l10n.s_toggle_applications
                 : l10n.s_toggle_interfaces),
             leading: const Icon(Icons.construction),
+            key: yubikeyApplicationToggleMenuButton,
             dense: true,
             contentPadding: EdgeInsets.zero,
           ),
@@ -416,6 +420,7 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
           child: ListTile(
             title: Text(l10n.s_factory_reset),
             leading: const Icon(Icons.delete_forever),
+            key: yubikeyFactoryResetMenuButton,
             dense: true,
             contentPadding: EdgeInsets.zero,
           ),

--- a/lib/app/views/device_picker.dart
+++ b/lib/app/views/device_picker.dart
@@ -178,6 +178,7 @@ class _DeviceMenuButton extends ConsumerWidget {
       child: Opacity(
         opacity: menuItems.isNotEmpty ? opacity : 0.0,
         child: PopupMenuButton(
+          key: yubikeyPopupMenuButton,
           enabled: menuItems.isNotEmpty,
           icon: const Icon(Icons.more_horiz_outlined),
           tooltip: '',
@@ -348,7 +349,6 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
       if (serial != null)
         PopupMenuItem(
           enabled: true,
-          key: yubikeyPopupMenuButton,
           onTap: () async {
             await ref.read(withContextProvider)((context) async {
               await _showKeyCustomizationDialog(

--- a/lib/app/views/keys.dart
+++ b/lib/app/views/keys.dart
@@ -37,9 +37,12 @@ const openpgpAppDrawer = Key('$_prefix.drawer.openpgp');
 
 // drawer yubikey more items
 const yubikeyPopupMenuButton = Key('$_prefix.yubikey_popup_menu_button');
-const yubikeyLabelColorMenuButton = Key('$_prefix.yubikey_label_color_menu_button');
-const yubikeyApplicationToggleMenuButton = Key('$_prefix.yubikey_application_toggle_menu_button');
-const yubikeyFactoryResetMenuButton = Key('$_prefix.yubikey_factory_reset_menu_button');
+const yubikeyLabelColorMenuButton =
+    Key('$_prefix.yubikey_label_color_menu_button');
+const yubikeyApplicationToggleMenuButton =
+    Key('$_prefix.yubikey_application_toggle_menu_button');
+const yubikeyFactoryResetMenuButton =
+    Key('$_prefix.yubikey_factory_reset_menu_button');
 
 // factory reset dialog
 const factoryResetPickResetOath = Key('$_prefix.yubikey_factory_reset_oath');
@@ -47,7 +50,6 @@ const factoryResetPickResetFido2 = Key('$_prefix.yubikey_factory_reset_fido2');
 const factoryResetPickResetPiv = Key('$_prefix.yubikey_factory_reset_piv');
 const factoryResetCancel = Key('$_prefix.yubikey_factory_reset_cancel');
 const factoryResetReset = Key('$_prefix.yubikey_factory_reset_reset');
-
 
 // settings page
 const settingDrawerIcon = Key('$_prefix.settings_drawer_icon');

--- a/lib/app/views/keys.dart
+++ b/lib/app/views/keys.dart
@@ -35,6 +35,20 @@ const pivAppDrawer = Key('$_prefix.drawer.piv');
 const hsmauthAppDrawer = Key('$_prefix.drawer.hsmauth');
 const openpgpAppDrawer = Key('$_prefix.drawer.openpgp');
 
+// drawer yubikey more items
+const yubikeyPopupMenuButton = Key('$_prefix.yubikey_popup_menu_button');
+const yubikeyLabelColorMenuButton = Key('$_prefix.yubikey_label_color_menu_button');
+const yubikeyApplicationToggleMenuButton = Key('$_prefix.yubikey_application_toggle_menu_button');
+const yubikeyFactoryResetMenuButton = Key('$_prefix.yubikey_factory_reset_menu_button');
+
+// factory reset dialog
+const factoryResetPickResetOath = Key('$_prefix.yubikey_factory_reset_oath');
+const factoryResetPickResetFido2 = Key('$_prefix.yubikey_factory_reset_fido2');
+const factoryResetPickResetPiv = Key('$_prefix.yubikey_factory_reset_piv');
+const factoryResetCancel = Key('$_prefix.yubikey_factory_reset_cancel');
+const factoryResetReset = Key('$_prefix.yubikey_factory_reset_reset');
+
+
 // settings page
 const settingDrawerIcon = Key('$_prefix.settings_drawer_icon');
 const helpDrawerIcon = Key('$_prefix.setting_drawer_icon');

--- a/lib/app/views/reset_dialog.dart
+++ b/lib/app/views/reset_dialog.dart
@@ -33,6 +33,7 @@ import '../../widgets/responsive_dialog.dart';
 import '../message.dart';
 import '../models.dart';
 import '../state.dart';
+import 'keys.dart';
 
 final _log = Logger('fido.views.reset_dialog');
 
@@ -79,6 +80,7 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
     double progress = _currentStep == -1 ? 0.0 : _currentStep / (_totalSteps);
     return ResponsiveDialog(
       title: Text(l10n.s_factory_reset),
+      key: factoryResetCancel,
       onCancel: switch (_application) {
         Capability.fido2 => _currentStep < 3
             ? () {
@@ -155,6 +157,7 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
               _ => throw UnsupportedError('Application cannot be reset'),
             },
             child: Text(l10n.s_reset),
+            key: factoryResetReset,
           )
       ],
       child: Padding(

--- a/lib/app/views/reset_dialog.dart
+++ b/lib/app/views/reset_dialog.dart
@@ -156,8 +156,8 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
               null => null,
               _ => throw UnsupportedError('Application cannot be reset'),
             },
-            child: Text(l10n.s_reset),
             key: factoryResetReset,
+            child: Text(l10n.s_reset),
           )
       ],
       child: Padding(
@@ -177,6 +177,12 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
                         value: c,
                         icon: const Icon(null),
                         label: Padding(
+                          key: switch (c) {
+                            Capability.oath => factoryResetPickResetOath,
+                            Capability.fido2 => factoryResetPickResetFido2,
+                            Capability.piv => factoryResetPickResetPiv,
+                            _ => const Key('_invalid') // no reset
+                          },
                           padding: const EdgeInsets.only(right: 22),
                           child: Text(c.getDisplayName(l10n)),
                         ),


### PR DESCRIPTION
Since transferring the views for factory reset of apps on the key, the tests sadly was broken. This PR fixes those (for OATH and Piv), adds some more logic surrounding which key action are run on, and some security to not run actions on non-approved keys.

To test this, you should be able to run all tests in oath_test.dart and piv_test.dart on a key. Mind you that that tests still have to be run with the correct window width until that have been take care of.