### PR TITLE
Adds keys to reset ButtonSegments

### DIFF
--- a/lib/app/views/reset_dialog.dart
+++ b/lib/app/views/reset_dialog.dart
@@ -208,7 +208,15 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
                       .where((c) => supported & c.value != 0)
                       .map((c) => ButtonSegment(
                             value: c,
-                            icon: Icon(c._icon),
+                            icon: Icon(
+                              c._icon,
+                              key: switch (c) {
+                                Capability.oath => factoryResetPickResetOath,
+                                Capability.fido2 => factoryResetPickResetFido2,
+                                Capability.piv => factoryResetPickResetPiv,
+                                _ => const Key('_invalid') // no reset
+                              },
+                            ),
                             label: showLabels
                                 ? Text(c.getDisplayName(l10n))
                                 : null,


### PR DESCRIPTION
The keys are needed for integration tests to click on the correct ButtonSegment. 
As ButtonSegment has no `key` property, it is added on the icon which is always shown. Tested on Mac.