### PR TITLE
Add sliver functionality with dynamic `AppBar`

### DIFF
--- a/lib/app/views/action_list.dart
+++ b/lib/app/views/action_list.dart
@@ -53,7 +53,7 @@ class ActionListItem extends StatelessWidget {
     // };
 
     return ListTile(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(48)),
       title: Text(title),
       subtitle: subtitle != null ? Text(subtitle!) : null,
       leading: Opacity(

--- a/lib/app/views/app_list_item.dart
+++ b/lib/app/views/app_list_item.dart
@@ -77,7 +77,7 @@ class _AppListItemState<T> extends ConsumerState<AppListItem> {
         item: widget.item,
         child: InkWell(
           focusNode: _focusNode,
-          borderRadius: BorderRadius.circular(30),
+          borderRadius: BorderRadius.circular(48),
           onSecondaryTapDown: buildPopupActions == null
               ? null
               : (details) {

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -331,12 +331,14 @@ class _AppPageState extends ConsumerState<AppPage> {
       ]);
     }
     if (widget.title != null) {
-      return NotificationListener(
-        onNotification: (_) {
+      return NotificationListener<ScrollNotification>(
+        onNotification: (scrollNotification) {
+          final scrollOffset = scrollNotification.metrics.pixels;
           Timer.run(() {
             setState(() {
               _isSliverTitleScrolledUnder =
-                  _scrolledUnderAppBar(_sliverTitleGlobalKey);
+                  _scrolledUnderAppBar(_sliverTitleGlobalKey) &&
+                      scrollOffset != 0;
             });
           });
           return false;
@@ -394,10 +396,12 @@ class _AppPageState extends ConsumerState<AppPage> {
           if (hasRail && (!fullyExpanded || !showNavigation))
             SizedBox(
               width: 72,
-              child: NotificationListener(
-                onNotification: (_) {
+              child: NotificationListener<ScrollNotification>(
+                onNotification: (scrollNotification) {
+                  final scrollOffset = scrollNotification.metrics.pixels;
                   setState(() {
-                    _isNavigationScrolledUnder = _scrolledUnderAppBar(_navKey);
+                    _isNavigationScrolledUnder =
+                        _scrolledUnderAppBar(_navKey) && scrollOffset != 0;
                   });
                   return false;
                 },
@@ -413,11 +417,13 @@ class _AppPageState extends ConsumerState<AppPage> {
           if (fullyExpanded && showNavigation)
             SizedBox(
               width: 280,
-              child: NotificationListener(
-                onNotification: (_) {
+              child: NotificationListener<ScrollNotification>(
+                onNotification: (scrollNotification) {
+                  final scrollOffset = scrollNotification.metrics.pixels;
                   setState(() {
                     _isNavigationScrolledUnder =
-                        _scrolledUnderAppBar(_navExpandedKey);
+                        _scrolledUnderAppBar(_navExpandedKey) &&
+                            scrollOffset != 0;
                   });
                   return false;
                 },
@@ -447,11 +453,13 @@ class _AppPageState extends ConsumerState<AppPage> {
           if (hasManage &&
               (widget.detailViewBuilder != null ||
                   widget.keyActionsBuilder != null))
-            NotificationListener(
-              onNotification: (_) {
+            NotificationListener<ScrollNotification>(
+              onNotification: (scrollNotification) {
+                final scrollOffset = scrollNotification.metrics.pixels;
                 setState(() {
                   _isDetailsScrolledUnder =
-                      _scrolledUnderAppBar(_detailsViewGlobalKey);
+                      _scrolledUnderAppBar(_detailsViewGlobalKey) &&
+                          scrollOffset != 0;
                 });
                 return false;
               },

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -115,6 +115,7 @@ class _AppPageState extends ConsumerState<AppPage> {
   @override
   void dispose() {
     _sliverTitleController.dispose();
+    _headerSliverController.dispose();
     _navController.dispose();
     _detailsController.dispose();
     _scrolledUnderController.dispose();
@@ -780,9 +781,11 @@ class _VisibilityListenerState extends State<_VisibilityListener> {
                 disableScroll = true;
               });
               Timer(const Duration(seconds: 1), () {
-                setState(() {
-                  disableScroll = false;
-                });
+                if (mounted) {
+                  setState(() {
+                    disableScroll = false;
+                  });
+                }
               });
             }
           }

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -41,6 +41,7 @@ final _mainContentGlobalKey = GlobalKey();
 
 class AppPage extends StatefulWidget {
   final String? title;
+  final String? alternativeTitle;
   final String? footnote;
   final Widget Function(BuildContext context, bool expanded) builder;
   final Widget Function(BuildContext context)? detailViewBuilder;
@@ -58,6 +59,7 @@ class AppPage extends StatefulWidget {
   const AppPage(
       {super.key,
       this.title,
+      this.alternativeTitle,
       this.footnote,
       required this.builder,
       this.centered = false,
@@ -215,31 +217,38 @@ class _AppPageState extends State<AppPage> {
         AnimatedOpacity(
           opacity: !_isSliverTitleScrolledUnder ? 1 : 0,
           duration: const Duration(milliseconds: 300),
-          child: Wrap(
-              alignment: WrapAlignment.spaceBetween,
-              crossAxisAlignment: WrapCrossAlignment.center,
-              spacing: 2.0,
-              runSpacing: 8.0,
-              children: [
-                Text(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Flexible(
+                child: Text(
                   key: _sliverTitleGlobalKey,
-                  widget.title!,
+                  widget.alternativeTitle ?? widget.title!,
                   style: Theme.of(context).textTheme.displaySmall!.copyWith(
-                        color: Theme.of(context)
-                            .colorScheme
-                            .primary
-                            .withOpacity(0.9),
+                        color: widget.alternativeTitle != null
+                            ? Theme.of(context)
+                                .colorScheme
+                                .onSurfaceVariant
+                                .withOpacity(0.4)
+                            : Theme.of(context)
+                                .colorScheme
+                                .primary
+                                .withOpacity(0.9),
                       ),
+                  overflow: TextOverflow.ellipsis,
                 ),
-                if (widget.capabilities != null)
-                  Wrap(
-                    spacing: 4.0,
-                    runSpacing: 8.0,
-                    children: [
-                      ...widget.capabilities!.map((c) => CapabilityBadge(c))
-                    ],
-                  )
-              ]),
+              ),
+              if (widget.capabilities != null &&
+                  widget.alternativeTitle == null)
+                Wrap(
+                  spacing: 4.0,
+                  runSpacing: 8.0,
+                  children: [
+                    ...widget.capabilities!.map((c) => CapabilityBadge(c))
+                  ],
+                )
+            ],
+          ),
         )
       ],
     );
@@ -267,7 +276,7 @@ class _AppPageState extends State<AppPage> {
         child: AnimatedOpacity(
           duration: const Duration(milliseconds: 300),
           opacity: _isSliverTitleScrolledUnder ? 1 : 0,
-          child: Text(widget.title!),
+          child: Text(widget.alternativeTitle ?? widget.title!),
         ),
       );
     }

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -111,6 +111,7 @@ class _AppPageState extends ConsumerState<AppPage> {
   final _detailsViewProvider =
       StateNotifierProvider<_ScrolledUnderProvider, bool>(
           (ref) => _ScrolledUnderProvider());
+
   bool _scrolledUnderAppBar(GlobalKey key) {
     final currentContext = key.currentContext;
     if (currentContext != null) {
@@ -204,7 +205,6 @@ class _AppPageState extends ConsumerState<AppPage> {
             children: [
               Flexible(
                 child: Text(
-                  key: _sliverTitleGlobalKey,
                   widget.alternativeTitle ?? widget.title!,
                   style: Theme.of(context).textTheme.displaySmall!.copyWith(
                         color: widget.alternativeTitle != null
@@ -346,9 +346,18 @@ class _AppPageState extends ConsumerState<AppPage> {
     if (widget.title != null) {
       return NotificationListener<ScrollMetricsNotification>(
         onNotification: (notification) {
+          final isSliverScrolledUnder = ref.read(_sliverTitleProvider);
+          final scrolledUnder = _scrolledUnderAppBar(_sliverTitleGlobalKey);
+          if (isSliverScrolledUnder != scrolledUnder &&
+              isSliverScrolledUnder &&
+              !scrolledUnder) {
+            Scrollable.ensureVisible(_sliverTitleGlobalKey.currentContext!,
+                duration: const Duration(milliseconds: 300));
+          }
           ref
               .read(_sliverTitleProvider.notifier)
-              .toggleScrolledUnder(_scrolledUnderAppBar(_sliverTitleGlobalKey));
+              .toggleScrolledUnder(scrolledUnder);
+
           return false;
         },
         child: CustomScrollView(
@@ -360,6 +369,7 @@ class _AppPageState extends ConsumerState<AppPage> {
                   child: ColoredBox(
                     color: Theme.of(context).colorScheme.background,
                     child: Padding(
+                        key: _sliverTitleGlobalKey,
                         padding: const EdgeInsets.only(
                             left: 16.0, right: 16.0, bottom: 12.0, top: 4.0),
                         child: Consumer(

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:sliver_tools/sliver_tools.dart';
 
 import '../../core/state.dart';
 import '../../management/models.dart';
@@ -30,11 +31,15 @@ import 'fs_dialog.dart';
 import 'keys.dart';
 import 'navigation.dart';
 
-// We use global keys here to maintain the NavigatorContent between AppPages.
+// We use global keys here to maintain the content between AppPages,
+// and keep track of what has been scrolled under AppBar
 final _navKey = GlobalKey();
 final _navExpandedKey = GlobalKey();
+final _sliverTitleGlobalKey = GlobalKey();
+final _detailsViewGlobalKey = GlobalKey();
+final _mainContentGlobalKey = GlobalKey();
 
-class AppPage extends StatelessWidget {
+class AppPage extends StatefulWidget {
   final String? title;
   final String? footnote;
   final Widget Function(BuildContext context, bool expanded) builder;
@@ -49,29 +54,96 @@ class AppPage extends StatelessWidget {
   final Widget? fileDropOverlay;
   final Function(File file)? onFileDropped;
   final List<Capability>? capabilities;
-  const AppPage({
-    super.key,
-    this.title,
-    this.footnote,
-    required this.builder,
-    this.centered = false,
-    this.keyActionsBuilder,
-    this.detailViewBuilder,
-    this.actionButtonBuilder,
-    this.actionsBuilder,
-    this.fileDropOverlay,
-    this.capabilities,
-    this.onFileDropped,
-    this.delayedContent = false,
-    this.keyActionsBadge = false,
-  }) : assert(!(onFileDropped != null && fileDropOverlay == null),
+  final Widget? headerSliver;
+  const AppPage(
+      {super.key,
+      this.title,
+      this.footnote,
+      required this.builder,
+      this.centered = false,
+      this.keyActionsBuilder,
+      this.detailViewBuilder,
+      this.actionButtonBuilder,
+      this.actionsBuilder,
+      this.fileDropOverlay,
+      this.capabilities,
+      this.onFileDropped,
+      this.delayedContent = false,
+      this.keyActionsBadge = false,
+      this.headerSliver})
+      : assert(!(onFileDropped != null && fileDropOverlay == null),
             'Declaring onFileDropped requires declaring a fileDropOverlay');
+  @override
+  State<AppPage> createState() => _AppPageState();
+}
+
+class _AppPageState extends State<AppPage> {
+  final ScrollController _mainScrollController = ScrollController();
+  final ScrollController _navScrollController = ScrollController();
+  final ScrollController _detailsScrollController = ScrollController();
+
+  bool _showFullNavigation = true;
+  bool _isSliverTitleScrolledUnder = false;
+  bool _isNavigationScrolledUnder = false;
+  bool _isDetailsScrolledUnder = false;
+
+  bool _scrolledUnderAppBar(GlobalKey key) {
+    final currentContext = key.currentContext;
+    if (currentContext != null) {
+      final RenderBox renderBox =
+          currentContext.findRenderObject() as RenderBox;
+      final appBarHeight = MediaQuery.of(context).padding.top + kToolbarHeight;
+      final position = renderBox.localToGlobal(Offset.zero);
+
+      return appBarHeight - position.dy > 0;
+    }
+    return false;
+  }
+
+  @override
+  void dispose() {
+    _mainScrollController.dispose();
+    _navScrollController.dispose();
+    _detailsScrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    _mainScrollController.addListener(() {
+      setState(() {
+        _isSliverTitleScrolledUnder =
+            _scrolledUnderAppBar(_sliverTitleGlobalKey);
+      });
+    });
+    _navScrollController.addListener(() {
+      setState(() {
+        _isNavigationScrolledUnder = _scrolledUnderAppBar(_navKey) ||
+            _scrolledUnderAppBar(_navExpandedKey);
+      });
+    });
+    _detailsScrollController.addListener(() {
+      setState(() {
+        _isDetailsScrolledUnder = _scrolledUnderAppBar(_detailsViewGlobalKey);
+      });
+    });
+  }
 
   @override
   Widget build(BuildContext context) => LayoutBuilder(
         builder: (context, constraints) {
           final width = constraints.maxWidth;
-
+          // Reset state on screen width change, to make sure
+          // navigation always expands in fully expanded layout
+          if (width < 1000) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              setState(() {
+                _showFullNavigation = true;
+              });
+            });
+          }
           if (width < 400 ||
               (isAndroid && width < 600 && width < constraints.maxHeight)) {
             return _buildScaffold(context, true, false, false);
@@ -87,31 +159,7 @@ class AppPage extends StatelessWidget {
             if (scaffoldState?.isDrawerOpen == true) {
               scaffoldState?.openEndDrawer();
             }
-            return Scaffold(
-              body: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  SizedBox(
-                    width: 280,
-                    child: SingleChildScrollView(
-                      child: Column(
-                        children: [
-                          _buildLogo(context),
-                          NavigationContent(
-                            key: _navExpandedKey,
-                            shouldPop: false,
-                            extended: true,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: _buildScaffold(context, false, false, true),
-                  ),
-                ],
-              ),
-            );
+            return _buildScaffold(context, false, true, true);
           }
         },
       );
@@ -164,36 +212,82 @@ class AppPage extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Text(title!,
-            style: Theme.of(context).textTheme.displaySmall!.copyWith(
-                color: Theme.of(context).colorScheme.primary.withOpacity(0.9))),
-        if (capabilities != null)
-          Wrap(
-            spacing: 4.0,
-            runSpacing: 8.0,
-            children: [...capabilities!.map((c) => CapabilityBadge(c))],
-          )
+        AnimatedOpacity(
+          opacity: !_isSliverTitleScrolledUnder ? 1 : 0,
+          duration: const Duration(milliseconds: 300),
+          child: Wrap(
+              alignment: WrapAlignment.spaceBetween,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              spacing: 2.0,
+              runSpacing: 8.0,
+              children: [
+                Text(
+                  key: _sliverTitleGlobalKey,
+                  widget.title!,
+                  style: Theme.of(context).textTheme.displaySmall!.copyWith(
+                        color: Theme.of(context)
+                            .colorScheme
+                            .primary
+                            .withOpacity(0.9),
+                      ),
+                ),
+                if (widget.capabilities != null)
+                  Wrap(
+                    spacing: 4.0,
+                    runSpacing: 8.0,
+                    children: [
+                      ...widget.capabilities!.map((c) => CapabilityBadge(c))
+                    ],
+                  )
+              ]),
+        )
       ],
     );
   }
 
+  Widget? _buildAppBarTitle(
+      BuildContext context, bool hasRail, bool hasManage, bool fullyExpanded) {
+    EdgeInsets padding;
+    if (fullyExpanded) {
+      padding =
+          EdgeInsets.only(left: _showFullNavigation ? 280 : 72, right: 320);
+    } else if (!hasRail && hasManage) {
+      padding = const EdgeInsets.only(right: 320);
+    } else if (hasRail && hasManage) {
+      padding = const EdgeInsets.only(left: 72, right: 320);
+    } else if (hasRail && !hasManage) {
+      padding = const EdgeInsets.only(left: 72);
+    } else {
+      padding = const EdgeInsets.all(0);
+    }
+
+    if (widget.title != null) {
+      return Padding(
+        padding: padding,
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 300),
+          opacity: _isSliverTitleScrolledUnder ? 1 : 0,
+          child: Text(widget.title!),
+        ),
+      );
+    }
+
+    return null;
+  }
+
   Widget _buildMainContent(BuildContext context, bool expanded) {
-    final actions = actionsBuilder?.call(context, expanded) ?? [];
+    final actions = widget.actionsBuilder?.call(context, expanded) ?? [];
     final content = Column(
       mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment:
-          centered ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+      crossAxisAlignment: widget.centered
+          ? CrossAxisAlignment.center
+          : CrossAxisAlignment.start,
       children: [
-        if (title != null && !centered)
-          Padding(
-            padding:
-                const EdgeInsets.only(left: 16.0, right: 16.0, bottom: 24.0),
-            child: _buildTitle(context),
-          ),
-        builder(context, expanded),
+        widget.builder(context, expanded),
         if (actions.isNotEmpty)
           Align(
-            alignment: centered ? Alignment.center : Alignment.centerLeft,
+            alignment:
+                widget.centered ? Alignment.center : Alignment.centerLeft,
             child: Padding(
               padding: const EdgeInsets.only(
                   top: 16, bottom: 0, left: 16, right: 16),
@@ -204,14 +298,14 @@ class AppPage extends StatelessWidget {
               ),
             ),
           ),
-        if (footnote != null)
+        if (widget.footnote != null)
           Padding(
             padding:
                 const EdgeInsets.only(bottom: 16, top: 33, left: 16, right: 16),
             child: Opacity(
               opacity: 0.6,
               child: Text(
-                footnote!,
+                widget.footnote!,
                 style: Theme.of(context).textTheme.bodySmall,
               ),
             ),
@@ -220,7 +314,7 @@ class AppPage extends StatelessWidget {
     );
 
     final safeArea = SafeArea(
-      child: delayedContent
+      child: widget.delayedContent
           ? DelayedVisibility(
               key: GlobalKey(), // Ensure we reset the delay on rebuild
               delay: const Duration(milliseconds: 400),
@@ -229,39 +323,67 @@ class AppPage extends StatelessWidget {
           : content,
     );
 
-    if (centered) {
-      return Stack(
-        children: [
-          if (title != null)
-            Positioned.fill(
-              child: Align(
-                alignment: Alignment.topLeft,
-                child: Padding(
-                  padding: const EdgeInsets.only(
-                      left: 16.0, right: 16.0, bottom: 24.0),
-                  child: _buildTitle(context),
-                ),
-              ),
-            ),
+    if (widget.centered) {
+      return Stack(children: [
+        if (widget.title != null)
           Positioned.fill(
-            top: title != null ? 68.0 : 0,
             child: Align(
-              alignment: Alignment.center,
-              child: ScrollConfiguration(
-                behavior:
-                    ScrollConfiguration.of(context).copyWith(scrollbars: false),
-                child: SingleChildScrollView(
-                  physics: const NeverScrollableScrollPhysics(),
-                  child: safeArea,
-                ),
+              alignment: Alignment.topLeft,
+              child: Padding(
+                padding: const EdgeInsets.only(
+                    left: 16.0, right: 16.0, bottom: 24.0),
+                child: _buildTitle(context),
               ),
             ),
-          )
+          ),
+        Positioned.fill(
+          top: widget.title != null ? 68.0 : 0,
+          child: Align(
+            alignment: Alignment.center,
+            child: ScrollConfiguration(
+              behavior:
+                  ScrollConfiguration.of(context).copyWith(scrollbars: false),
+              child: SingleChildScrollView(
+                physics: const NeverScrollableScrollPhysics(),
+                child: safeArea,
+              ),
+            ),
+          ),
+        )
+      ]);
+    }
+    if (widget.title != null) {
+      return CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        key: _mainContentGlobalKey,
+        controller: _mainScrollController,
+        slivers: [
+          SliverMainAxisGroup(
+            slivers: [
+              SliverPinnedHeader(
+                child: ColoredBox(
+                  color: Theme.of(context).colorScheme.background,
+                  child: Padding(
+                    padding: const EdgeInsets.only(
+                        left: 16.0, right: 16.0, bottom: 12.0, top: 4.0),
+                    child: _buildTitle(context),
+                  ),
+                ),
+              ),
+              if (widget.headerSliver != null)
+                SliverToBoxAdapter(
+                  child: widget.headerSliver,
+                )
+            ],
+          ),
+          SliverToBoxAdapter(child: safeArea)
         ],
       );
     }
 
     return SingleChildScrollView(
+      key: _mainContentGlobalKey,
+      controller: _mainScrollController,
       primary: false,
       child: safeArea,
     );
@@ -269,12 +391,13 @@ class AppPage extends StatelessWidget {
 
   Scaffold _buildScaffold(
       BuildContext context, bool hasDrawer, bool hasRail, bool hasManage) {
+    final fullyExpanded = !hasDrawer && hasRail && hasManage;
     var body = _buildMainContent(context, hasManage);
 
-    if (onFileDropped != null) {
+    if (widget.onFileDropped != null) {
       body = FileDropTarget(
-        onFileDropped: onFileDropped!,
-        overlay: fileDropOverlay!,
+        onFileDropped: widget.onFileDropped!,
+        overlay: widget.fileDropOverlay!,
         child: body,
       );
     }
@@ -282,14 +405,27 @@ class AppPage extends StatelessWidget {
       body = Row(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          if (hasRail)
+          if (hasRail && (!fullyExpanded || !_showFullNavigation))
             SizedBox(
               width: 72,
               child: SingleChildScrollView(
+                controller: _navScrollController,
                 child: NavigationContent(
                   key: _navKey,
                   shouldPop: false,
                   extended: false,
+                ),
+              ),
+            ),
+          if (fullyExpanded && _showFullNavigation)
+            SizedBox(
+              width: 280,
+              child: SingleChildScrollView(
+                controller: _navScrollController,
+                child: NavigationContent(
+                  key: _navExpandedKey,
+                  shouldPop: false,
+                  extended: true,
                 ),
               ),
             ),
@@ -308,18 +444,21 @@ class AppPage extends StatelessWidget {
             ]),
           )),
           if (hasManage &&
-              (detailViewBuilder != null || keyActionsBuilder != null))
+              (widget.detailViewBuilder != null ||
+                  widget.keyActionsBuilder != null))
             SingleChildScrollView(
+              controller: _detailsScrollController,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8),
                 child: SizedBox(
                   width: 320,
                   child: Column(
+                    key: _detailsViewGlobalKey,
                     children: [
-                      if (detailViewBuilder != null)
-                        detailViewBuilder!(context),
-                      if (keyActionsBuilder != null)
-                        keyActionsBuilder!(context),
+                      if (widget.detailViewBuilder != null)
+                        widget.detailViewBuilder!(context),
+                      if (widget.keyActionsBuilder != null)
+                        widget.keyActionsBuilder!(context),
                     ],
                   ),
                 ),
@@ -331,24 +470,49 @@ class AppPage extends StatelessWidget {
     return Scaffold(
       key: scaffoldGlobalKey,
       appBar: AppBar(
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(1.0),
+          child: AnimatedOpacity(
+            duration: const Duration(milliseconds: 300),
+            opacity: _isSliverTitleScrolledUnder ||
+                    _isNavigationScrolledUnder ||
+                    _isDetailsScrolledUnder
+                ? 1
+                : 0,
+            child: Container(
+              color: Theme.of(context).colorScheme.secondaryContainer,
+              height: 1.0,
+            ),
+          ),
+        ),
         scrolledUnderElevation: 0.0,
         leadingWidth: hasRail ? 84 : null,
+        backgroundColor: Theme.of(context).colorScheme.background,
+        title: _buildAppBarTitle(context, hasRail, hasManage, fullyExpanded),
         leading: hasRail
-            ? const Row(
+            ? Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: [
                   Expanded(
                       child: Padding(
-                    padding: EdgeInsets.symmetric(horizontal: 8),
-                    child: DrawerButton(),
+                    padding: const EdgeInsets.symmetric(horizontal: 8),
+                    child: DrawerButton(
+                      onPressed: fullyExpanded
+                          ? () {
+                              setState(() {
+                                _showFullNavigation = !_showFullNavigation;
+                              });
+                            }
+                          : null,
+                    ),
                   )),
-                  SizedBox(width: 12),
+                  const SizedBox(width: 12),
                 ],
               )
             : null,
         actions: [
-          if (actionButtonBuilder == null &&
-              (keyActionsBuilder != null && !hasManage))
+          if (widget.actionButtonBuilder == null &&
+              (widget.keyActionsBuilder != null && !hasManage))
             Padding(
               padding: const EdgeInsets.only(left: 4),
               child: IconButton(
@@ -360,12 +524,12 @@ class AppPage extends StatelessWidget {
                     builder: (context) => FsDialog(
                       child: Padding(
                         padding: const EdgeInsets.only(top: 32),
-                        child: keyActionsBuilder!(context),
+                        child: widget.keyActionsBuilder!(context),
                       ),
                     ),
                   );
                 },
-                icon: keyActionsBadge
+                icon: widget.keyActionsBadge
                     ? const Badge(
                         child: Icon(Symbols.more_vert),
                       )
@@ -375,10 +539,10 @@ class AppPage extends StatelessWidget {
                 padding: const EdgeInsets.all(12),
               ),
             ),
-          if (actionButtonBuilder != null)
+          if (widget.actionButtonBuilder != null)
             Padding(
               padding: const EdgeInsets.only(right: 12),
-              child: actionButtonBuilder!.call(context),
+              child: widget.actionButtonBuilder!.call(context),
             ),
         ],
       ),

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -334,13 +334,15 @@ class _AppPageState extends ConsumerState<AppPage> {
       return NotificationListener<ScrollNotification>(
         onNotification: (scrollNotification) {
           final scrollOffset = scrollNotification.metrics.pixels;
-          Timer.run(() {
-            setState(() {
-              _isSliverTitleScrolledUnder =
-                  _scrolledUnderAppBar(_sliverTitleGlobalKey) &&
-                      scrollOffset != 0;
+          final scrolledUnder = _scrolledUnderAppBar(_sliverTitleGlobalKey);
+          if (_isSliverTitleScrolledUnder != scrolledUnder) {
+            Timer.run(() {
+              setState(() {
+                _isSliverTitleScrolledUnder =
+                    scrolledUnder && scrollOffset != 0;
+              });
             });
-          });
+          }
           return false;
         },
         child: CustomScrollView(
@@ -399,10 +401,13 @@ class _AppPageState extends ConsumerState<AppPage> {
               child: NotificationListener<ScrollNotification>(
                 onNotification: (scrollNotification) {
                   final scrollOffset = scrollNotification.metrics.pixels;
-                  setState(() {
-                    _isNavigationScrolledUnder =
-                        _scrolledUnderAppBar(_navKey) && scrollOffset != 0;
-                  });
+                  final scrolledUnder = _scrolledUnderAppBar(_navKey);
+                  if (_isNavigationScrolledUnder != scrolledUnder) {
+                    setState(() {
+                      _isNavigationScrolledUnder =
+                          scrolledUnder && scrollOffset != 0;
+                    });
+                  }
                   return false;
                 },
                 child: SingleChildScrollView(
@@ -420,11 +425,13 @@ class _AppPageState extends ConsumerState<AppPage> {
               child: NotificationListener<ScrollNotification>(
                 onNotification: (scrollNotification) {
                   final scrollOffset = scrollNotification.metrics.pixels;
-                  setState(() {
-                    _isNavigationScrolledUnder =
-                        _scrolledUnderAppBar(_navExpandedKey) &&
-                            scrollOffset != 0;
-                  });
+                  final scrolledUnder = _scrolledUnderAppBar(_navExpandedKey);
+                  if (_isNavigationScrolledUnder != scrolledUnder) {
+                    setState(() {
+                      _isNavigationScrolledUnder =
+                          scrolledUnder && scrollOffset != 0;
+                    });
+                  }
                   return false;
                 },
                 child: SingleChildScrollView(
@@ -456,11 +463,14 @@ class _AppPageState extends ConsumerState<AppPage> {
             NotificationListener<ScrollNotification>(
               onNotification: (scrollNotification) {
                 final scrollOffset = scrollNotification.metrics.pixels;
-                setState(() {
-                  _isDetailsScrolledUnder =
-                      _scrolledUnderAppBar(_detailsViewGlobalKey) &&
-                          scrollOffset != 0;
-                });
+                final scrolledUnder =
+                    _scrolledUnderAppBar(_detailsViewGlobalKey);
+                if (_isDetailsScrolledUnder != scrolledUnder) {
+                  setState(() {
+                    _isDetailsScrolledUnder =
+                        scrolledUnder && scrollOffset != 0;
+                  });
+                }
                 return false;
               },
               child: SingleChildScrollView(

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -759,19 +759,29 @@ class _VisibilityListener extends StatefulWidget {
 }
 
 class _VisibilityListenerState extends State<_VisibilityListener> {
-  bool isMouseWheel = false;
+  bool disableScroll = false;
 
   @override
   Widget build(BuildContext context) => Listener(
+        onPointerDown: (event) {
+          setState(() {
+            disableScroll = true;
+          });
+        },
+        onPointerUp: (event) {
+          setState(() {
+            disableScroll = false;
+          });
+        },
         onPointerSignal: (event) {
           if (event is PointerScrollEvent) {
-            if (!isMouseWheel) {
+            if (!disableScroll) {
               setState(() {
-                isMouseWheel = true;
+                disableScroll = true;
               });
               Timer(const Duration(seconds: 1), () {
                 setState(() {
-                  isMouseWheel = false;
+                  disableScroll = false;
                 });
               });
             }
@@ -786,7 +796,7 @@ class _VisibilityListenerState extends State<_VisibilityListener> {
 
             if (notification is ScrollEndNotification &&
                 widget.child is CustomScrollView) {
-              // Disable auto scrolling for mouse wheel
+              // Disable auto scrolling for mouse wheel and scrollbar
               _handleScrollEnd(context);
             }
             return false;
@@ -810,7 +820,7 @@ class _VisibilityListenerState extends State<_VisibilityListener> {
   void _handleScrollEnd(
     BuildContext context,
   ) {
-    if (!isMouseWheel) {
+    if (!disableScroll) {
       widget.controller.notifyScroll(_getSrollDirection(
           _scrolledUnderState(context, widget.targetKey, null)));
 

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -449,10 +449,13 @@ class _AppPageState extends ConsumerState<AppPage> {
                   controller: _navController,
                   targetKey: _navExpandedKey,
                   child: SingleChildScrollView(
-                    child: NavigationContent(
-                      key: _navExpandedKey,
-                      shouldPop: false,
-                      extended: true,
+                    child: Material(
+                      type: MaterialType.transparency,
+                      child: NavigationContent(
+                        key: _navExpandedKey,
+                        shouldPop: false,
+                        extended: true,
+                      ),
                     ),
                   ),
                 )),

--- a/lib/app/views/device_picker.dart
+++ b/lib/app/views/device_picker.dart
@@ -131,7 +131,16 @@ class DevicePickerContent extends ConsumerWidget {
       ),
     ];
 
-    return Column(children: children);
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: !extended && children.length > 1
+            ? 13
+            : !extended
+                ? 6.5
+                : 0,
+      ),
+      child: Column(children: children),
+    );
   }
 }
 
@@ -311,7 +320,7 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
             isDesktop && menuItems.isNotEmpty ? showMenuFn : null,
         onLongPressStart: isAndroid ? showMenuFn : null,
         child: Padding(
-          padding: const EdgeInsets.symmetric(vertical: 6.5),
+          padding: const EdgeInsets.only(bottom: 6.5),
           child: widget.selected
               ? IconButton.filled(
                   tooltip: isDesktop ? tooltip : null,

--- a/lib/app/views/navigation.dart
+++ b/lib/app/views/navigation.dart
@@ -128,7 +128,8 @@ class NavigationContent extends ConsumerWidget {
     final currentSection = ref.watch(currentSectionProvider);
 
     return Padding(
-      padding: const EdgeInsets.all(8.0),
+      padding:
+          const EdgeInsets.only(left: 8.0, right: 8.0, bottom: 8.0, top: 12),
       child: Column(
         children: [
           AnimatedSize(

--- a/lib/fido/views/webauthn_page.dart
+++ b/lib/fido/views/webauthn_page.dart
@@ -14,21 +14,39 @@
  * limitations under the License.
  */
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../app/views/message_page.dart';
 import '../../management/models.dart';
 
-class WebAuthnScreen extends StatelessWidget {
+class WebAuthnScreen extends StatefulWidget {
   const WebAuthnScreen({super.key});
 
   @override
+  State<WebAuthnScreen> createState() => _WebAuthnScreenState();
+}
+
+class _WebAuthnScreenState extends State<WebAuthnScreen> {
+  bool hide = true;
+  @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
+
+    // We need this to avoid unwanted app switch animation
+    if (hide) {
+      Timer.run(() {
+        setState(() {
+          hide = false;
+        });
+      });
+    }
     return MessagePage(
-      title: l10n.s_security_key,
+      title: hide ? null : l10n.s_security_key,
       capabilities: const [Capability.u2f],
+      delayedContent: hide,
       header: l10n.l_ready_to_use,
       message: l10n.l_register_sk_on_websites,
     );

--- a/lib/oath/views/account_list.dart
+++ b/lib/oath/views/account_list.dart
@@ -57,9 +57,11 @@ class AccountList extends ConsumerWidget {
             ),
           ),
           if (pinnedCreds.isNotEmpty && creds.isNotEmpty)
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 16.0),
-              child: Divider(),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: Divider(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+              ),
             ),
           ...creds.map(
             (entry) => AccountView(

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -144,6 +144,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
         .select((value) => value?.length));
     final hasFeature = ref.watch(featureProvider);
     final hasActions = hasFeature(features.actions);
+    final searchText = searchController.text;
 
     Future<void> onFileDropped(File file) async {
       final qrScanner = ref.read(qrScannerProvider);
@@ -262,6 +263,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
       },
       builder: (context) => AppPage(
         title: l10n.s_accounts,
+        alternativeTitle: searchText != '' ? 'Results for "$searchText"' : null,
         capabilities: const [Capability.oath],
         keyActionsBuilder: hasActions
             ? (context) => oathBuildActions(
@@ -381,7 +383,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
                     ?.copyWith(fontSize: textTheme.titleSmall?.fontSize),
                 decoration: AppInputDecoration(
                   border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(32),
+                    borderRadius: BorderRadius.circular(48),
                     borderSide: BorderSide(
                       width: 0,
                       style: searchFocus.hasFocus

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -350,6 +350,77 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
                 );
               }
             : null,
+        headerSliver: Focus(
+          canRequestFocus: false,
+          onKeyEvent: (node, event) {
+            if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+              node.focusInDirection(TraversalDirection.down);
+              return KeyEventResult.handled;
+            }
+            if (event.logicalKey == LogicalKeyboardKey.escape) {
+              searchController.clear();
+              ref.read(searchProvider.notifier).setFilter('');
+              node.unfocus();
+              setState(() {});
+              return KeyEventResult.handled;
+            }
+            return KeyEventResult.ignored;
+          },
+          child: Builder(builder: (context) {
+            final textTheme = Theme.of(context).textTheme;
+            return Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+              child: AppTextFormField(
+                key: keys.searchAccountsField,
+                controller: searchController,
+                focusNode: searchFocus,
+                // Use the default style, but with a smaller font size:
+                style: textTheme.titleMedium
+                    ?.copyWith(fontSize: textTheme.titleSmall?.fontSize),
+                decoration: AppInputDecoration(
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(32),
+                    borderSide: BorderSide(
+                      width: 0,
+                      style: searchFocus.hasFocus
+                          ? BorderStyle.solid
+                          : BorderStyle.none,
+                    ),
+                  ),
+                  contentPadding: const EdgeInsets.all(16),
+                  fillColor: Theme.of(context).hoverColor,
+                  filled: true,
+                  hintText: l10n.s_search_accounts,
+                  isDense: true,
+                  prefixIcon: const Padding(
+                    padding: EdgeInsetsDirectional.only(start: 8.0),
+                    child: Icon(Icons.search_outlined),
+                  ),
+                  suffixIcon: searchController.text.isNotEmpty
+                      ? IconButton(
+                          icon: const Icon(Icons.clear),
+                          iconSize: 16,
+                          onPressed: () {
+                            searchController.clear();
+                            ref.read(searchProvider.notifier).setFilter('');
+                            setState(() {});
+                          },
+                        )
+                      : null,
+                ),
+                onChanged: (value) {
+                  ref.read(searchProvider.notifier).setFilter(value);
+                  setState(() {});
+                },
+                textInputAction: TextInputAction.next,
+                onFieldSubmitted: (value) {
+                  Focus.of(context).focusInDirection(TraversalDirection.down);
+                },
+              ),
+            );
+          }),
+        ),
         builder: (context, expanded) {
           // De-select if window is resized to be non-expanded.
           if (!expanded && _selected != null) {
@@ -373,80 +444,6 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
             },
             child: Column(
               children: [
-                Focus(
-                  canRequestFocus: false,
-                  onKeyEvent: (node, event) {
-                    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-                      node.focusInDirection(TraversalDirection.down);
-                      return KeyEventResult.handled;
-                    }
-                    if (event.logicalKey == LogicalKeyboardKey.escape) {
-                      searchController.clear();
-                      ref.read(searchProvider.notifier).setFilter('');
-                      node.unfocus();
-                      setState(() {});
-                      return KeyEventResult.handled;
-                    }
-                    return KeyEventResult.ignored;
-                  },
-                  child: Builder(builder: (context) {
-                    final textTheme = Theme.of(context).textTheme;
-                    return Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 16.0, vertical: 8.0),
-                      child: AppTextFormField(
-                        key: keys.searchAccountsField,
-                        controller: searchController,
-                        focusNode: searchFocus,
-                        // Use the default style, but with a smaller font size:
-                        style: textTheme.titleMedium?.copyWith(
-                            fontSize: textTheme.titleSmall?.fontSize),
-                        decoration: AppInputDecoration(
-                          border: OutlineInputBorder(
-                            borderRadius: BorderRadius.circular(32),
-                            borderSide: BorderSide(
-                              width: 0,
-                              style: searchFocus.hasFocus
-                                  ? BorderStyle.solid
-                                  : BorderStyle.none,
-                            ),
-                          ),
-                          contentPadding: const EdgeInsets.all(16),
-                          fillColor: Theme.of(context).hoverColor,
-                          filled: true,
-                          hintText: l10n.s_search_accounts,
-                          isDense: true,
-                          prefixIcon: const Padding(
-                            padding: EdgeInsetsDirectional.only(start: 8.0),
-                            child: Icon(Symbols.search),
-                          ),
-                          suffixIcon: searchController.text.isNotEmpty
-                              ? IconButton(
-                                  icon: const Icon(Symbols.clear),
-                                  iconSize: 16,
-                                  onPressed: () {
-                                    searchController.clear();
-                                    ref
-                                        .read(searchProvider.notifier)
-                                        .setFilter('');
-                                    setState(() {});
-                                  },
-                                )
-                              : null,
-                        ),
-                        onChanged: (value) {
-                          ref.read(searchProvider.notifier).setFilter(value);
-                          setState(() {});
-                        },
-                        textInputAction: TextInputAction.next,
-                        onFieldSubmitted: (value) {
-                          Focus.of(context)
-                              .focusInDirection(TraversalDirection.down);
-                        },
-                      ).init(),
-                    );
-                  }),
-                ),
                 Consumer(
                   builder: (context, ref, _) {
                     return AccountList(

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -210,7 +210,8 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
         SearchIntent: CallbackAction<SearchIntent>(onInvoke: (_) {
           searchController.selection = TextSelection(
               baseOffset: 0, extentOffset: searchController.text.length);
-          searchFocus.requestFocus();
+          searchFocus.unfocus();
+          Timer.run(() => searchFocus.requestFocus());
           return null;
         }),
         EscapeIntent: CallbackAction<EscapeIntent>(onInvoke: (intent) {

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -34,6 +34,9 @@ class AppTheme {
           onSurfaceVariant: const Color(0x99000000),
         ),
         fontFamily: 'Roboto',
+        appBarTheme: const AppBarTheme(
+          color: Colors.transparent,
+        ),
         listTileTheme: const ListTileThemeData(
           // For alignment under menu button
           contentPadding: EdgeInsets.symmetric(horizontal: 18.0),
@@ -59,6 +62,9 @@ class AppTheme {
           onSurfaceVariant: const Color(0xaaffffff),
         ),
         fontFamily: 'Roboto',
+        appBarTheme: const AppBarTheme(
+          color: Colors.transparent,
+        ),
         listTileTheme: const ListTileThemeData(
           // For alignment under menu button
           contentPadding: EdgeInsets.symmetric(horizontal: 18.0),

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -34,9 +34,6 @@ class AppTheme {
           onSurfaceVariant: const Color(0x99000000),
         ),
         fontFamily: 'Roboto',
-        appBarTheme: const AppBarTheme(
-          color: Colors.transparent,
-        ),
         listTileTheme: const ListTileThemeData(
           // For alignment under menu button
           contentPadding: EdgeInsets.symmetric(horizontal: 18.0),
@@ -62,9 +59,6 @@ class AppTheme {
           onSurfaceVariant: const Color(0xaaffffff),
         ),
         fontFamily: 'Roboto',
-        appBarTheme: const AppBarTheme(
-          color: Colors.transparent,
-        ),
         listTileTheme: const ListTileThemeData(
           // For alignment under menu button
           contentPadding: EdgeInsets.symmetric(horizontal: 18.0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -815,6 +815,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  sliver_tools:
+    dependency: "direct main"
+    description:
+      name: sliver_tools
+      sha256: eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.12"
   source_gen:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,7 @@ dependencies:
   flutter_riverpod: ^2.4.10
   json_annotation: ^4.8.1
   freezed_annotation: ^2.4.1
-  window_manager: 
+  window_manager:
     git:
       url: https://github.com/fdennis/window_manager.git
       ref: 2272d45bcf46d7e2b452a038906fbc85df3ce83d
@@ -71,6 +71,7 @@ dependencies:
   base32: ^2.1.3
   convert: ^3.1.1
   material_symbols_icons: ^4.2719.1
+  sliver_tools: ^0.2.12
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
This PR implements enhancements to the scrolling behavior and AppBar interaction within the application.

**Key changes:**

* **Enhanced Scrolling:** The scrolling behavior has been refined to offer a smoother experience.
* **Sliver functionality** The main title remains pinned until a `headerSliver` (optional) is scrolled under it. This mainly concerns the OATH view in which the search field is first scrolled under the main title. Subesquently, when the main title is scrolled under the `AppBar`, the title is rendered there instead. 