### PR TITLE
PIV: Show Private Key: <none> when key is missing

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -55,6 +55,7 @@
             "item": {}
         }
     },
+    "s_none": null,
 
     "s_about": "Über",
     "s_algorithm": null,

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -55,6 +55,7 @@
             "item": {}
         }
     },
+    "s_none": "<none>",
 
     "s_about": "About",
     "s_algorithm": "Algorithm",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -55,6 +55,7 @@
             "item": {}
         }
     },
+    "s_none": null,
 
     "s_about": "À propos",
     "s_algorithm": "Algorithme",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -55,6 +55,7 @@
             "item": {}
         }
     },
+    "s_none": null,
 
     "s_about": "情報",
     "s_algorithm": "アルゴリズム",

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -55,6 +55,7 @@
             "item": {}
         }
     },
+    "s_none": null,
 
     "s_about": "O aplikacji",
     "s_algorithm": "Algorytm",

--- a/lib/piv/views/cert_info_view.dart
+++ b/lib/piv/views/cert_info_view.dart
@@ -90,8 +90,10 @@ class _InfoTable extends ConsumerWidget {
 class CertInfoTable extends ConsumerWidget {
   final CertInfo? certInfo;
   final SlotMetadata? metadata;
+  final bool alwaysIncludePrivate;
 
-  const CertInfoTable(this.certInfo, this.metadata, {super.key});
+  const CertInfoTable(this.certInfo, this.metadata,
+      {super.key, this.alwaysIncludePrivate = false});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -107,6 +109,8 @@ class CertInfoTable extends ConsumerWidget {
           metadata.keyType.getDisplayName(l10n),
           keys.slotMetadataKeyType
         ),
+      if (metadata == null && alwaysIncludePrivate)
+        l10n.s_private_key: (l10n.s_none, keys.slotMetadataKeyType),
       if (certInfo != null) ...{
         l10n.s_public_key: (
           certInfo.keyType?.getDisplayName(l10n) ?? l10n.s_unknown_type,

--- a/lib/piv/views/piv_screen.dart
+++ b/lib/piv/views/piv_screen.dart
@@ -141,8 +141,11 @@ class _PivScreenState extends ConsumerState<PivScreen> {
                                         const SizedBox(height: 16),
                                         if (selected.certInfo != null ||
                                             selected.metadata != null) ...[
-                                          CertInfoTable(selected.certInfo,
-                                              selected.metadata),
+                                          CertInfoTable(
+                                            selected.certInfo,
+                                            selected.metadata,
+                                            alwaysIncludePrivate: true,
+                                          ),
                                           const SizedBox(height: 16),
                                         ],
                                         if (selected.certInfo == null)

--- a/lib/piv/views/slot_dialog.dart
+++ b/lib/piv/views/slot_dialog.dart
@@ -87,7 +87,11 @@ class SlotDialog extends ConsumerWidget {
                             if (certInfo != null || metadata != null) ...[
                               Padding(
                                 padding: const EdgeInsets.only(bottom: 16),
-                                child: CertInfoTable(certInfo, metadata),
+                                child: CertInfoTable(
+                                  certInfo,
+                                  metadata,
+                                  alwaysIncludePrivate: true,
+                                ),
                               ),
                             ],
                             if (certInfo == null) ...[


### PR DESCRIPTION
Small UI enhancement to make it more clear that a certificate exists without a private key.