### PR TITLE
Uncustomizable devices will use last used color

### DIFF
--- a/lib/app/state.dart
+++ b/lib/app/state.dart
@@ -152,7 +152,6 @@ final primaryColorProvider = Provider<Color>((ref) {
   final data = ref.watch(currentDeviceDataProvider).valueOrNull;
   final defaultColor = ref.watch(defaultColorProvider);
   if (data != null) {
-    // A device was connected, use custom color if available
     final serial = data.info.serial;
     if (serial != null) {
       final customization = ref.watch(keyCustomizationManagerProvider)[serial];
@@ -167,7 +166,6 @@ final primaryColorProvider = Provider<Color>((ref) {
     }
   }
 
-  // a device was disconnected or is not customizable
   final lastUsedColor = prefs.getInt(prefLastUsedColor);
   return lastUsedColor != null ? Color(lastUsedColor) : defaultColor;
 });

--- a/lib/app/state.dart
+++ b/lib/app/state.dart
@@ -152,7 +152,7 @@ final primaryColorProvider = Provider<Color>((ref) {
   final data = ref.watch(currentDeviceDataProvider).valueOrNull;
   final defaultColor = ref.watch(defaultColorProvider);
   if (data != null) {
-    // We have a device, use its color, or the default color
+    // A device was connected, use custom color if available
     final serial = data.info.serial;
     if (serial != null) {
       final customization = ref.watch(keyCustomizationManagerProvider)[serial];
@@ -165,16 +165,11 @@ final primaryColorProvider = Provider<Color>((ref) {
         return defaultColor;
       }
     }
-  } else {
-    // We don't have a device, use the last used color, if saved
-    final lastUsedColor = prefs.getInt(prefLastUsedColor);
-    if (lastUsedColor != null) {
-      return Color(lastUsedColor);
-    }
   }
 
-  // Default color if nothing else
-  return defaultColor;
+  // a device was disconnected or is not customizable
+  final lastUsedColor = prefs.getInt(prefLastUsedColor);
+  return lastUsedColor != null ? Color(lastUsedColor) : defaultColor;
 });
 
 // Override with platform implementation


### PR DESCRIPTION
Before this change, uncustomizable devices used the default color.