### PR TITLE
Read device info on connect

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
@@ -188,21 +188,7 @@ class FidoManager(
             }
         } catch (e: Exception) {
             // something went wrong, try to get DeviceInfo from any available connection type
-            logger.error("Failure when processing YubiKey", e)
-            if (device.transport == Transport.USB || e is ApplicationNotAvailableException) {
-                val deviceInfo = try {
-                    getDeviceInfo(device)
-                } catch (e: IllegalArgumentException) {
-                    logger.debug("Device was not recognized")
-                    UnknownDevice.copy(isNfc = device.transport == Transport.NFC)
-                } catch (e: Exception) {
-                    logger.error("Failure getting device info", e)
-                    null
-                }
-
-                logger.debug("Setting device info: {}", deviceInfo)
-                deviceManager.setDeviceInfo(deviceInfo)
-            }
+            logger.error("Failure when processing YubiKey: ", e)
 
             // Clear any cached FIDO state
             fidoViewModel.clearSessionState()
@@ -242,18 +228,6 @@ class FidoManager(
             fidoViewModel.setSessionState(
                 Session(
                     fidoSession.cachedInfo, pinStore.hasPin()
-                )
-            )
-
-            // Update deviceInfo since the deviceId has changed
-            val pid = (device as? UsbYubiKeyDevice)?.pid
-            val deviceInfo = DeviceUtil.readInfo(connection, pid)
-            deviceManager.setDeviceInfo(
-                Info(
-                    name = DeviceUtil.getName(deviceInfo, pid?.type),
-                    isNfc = device.transport == Transport.NFC,
-                    usbPid = pid?.value,
-                    deviceInfo = deviceInfo
                 )
             )
         }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -282,18 +282,6 @@ class OathManager(
                             return@withConnection
                         }
                     }
-
-                    // Update deviceInfo since the deviceId has changed
-                    val pid = (device as? UsbYubiKeyDevice)?.pid
-                    val deviceInfo = DeviceUtil.readInfo(connection, pid)
-                    deviceManager.setDeviceInfo(
-                        Info(
-                            name = DeviceUtil.getName(deviceInfo, pid?.type),
-                            isNfc = device.transport == Transport.NFC,
-                            usbPid = pid?.value,
-                            deviceInfo = deviceInfo
-                        )
-                    )
                 }
             }
             logger.debug(
@@ -301,21 +289,7 @@ class OathManager(
             )
         } catch (e: Exception) {
             // OATH not enabled/supported, try to get DeviceInfo over other USB interfaces
-            logger.error("Failed to connect to CCID", e)
-            if (device.transport == Transport.USB || e is ApplicationNotAvailableException) {
-                val deviceInfo = try {
-                    getDeviceInfo(device)
-                } catch (e: IllegalArgumentException) {
-                    logger.debug("Device was not recognized")
-                    UnknownDevice.copy(isNfc = device.transport == Transport.NFC)
-                } catch (e: Exception) {
-                    logger.error("Failure getting device info", e)
-                    null
-                }
-
-                logger.debug("Setting device info: {}", deviceInfo)
-                deviceManager.setDeviceInfo(deviceInfo)
-            }
+            logger.error("Failed to connect to CCID: ", e)
 
             // Clear any cached OATH state
             oathViewModel.clearSession()


### PR DESCRIPTION
With the addition of FIDO application, Yubico Authenticator needs to understand what features the key which is being connected (over USB or tapped on the NFC sensor) supports to quickly switch the UI to the most appropriate view.

This PR change refactors the way how we query for the YubiKey's capabilities so that we do it in the most compatible way: after a connect event, we first query the device info and peek the `enabledCapabilities` to understand what kind of contexts the application can show.

The acquired information is directly forwarded to flutter so that it can show appropriate information in the Home section. That also means we don't need to call getDevice info in the Fido or Oath managers.