### PR TITLE
Fix QR scan success icon

### DIFF
--- a/lib/android/qr_scanner/qr_scanner_overlay_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_overlay_view.dart
@@ -122,6 +122,8 @@ class _OverlayPainter extends CustomPainter {
           style: TextStyle(
             fontSize: iconSize,
             fontFamily: icon.fontFamily,
+            fontVariations: const [FontVariation('FILL', 1)],
+            package: icon.fontPackage,
             color: color.withAlpha(240),
           ));
       iconPainter.layout();


### PR DESCRIPTION
Adds properties so that `Symbols.check_circle` is painted same way as `Icons.check_circle`. See [https://pub.dev/packages/material_symbols_icons](https://pub.dev/packages/material_symbols_icons) for more details.