### PR TITLE
OATH improvements

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/oath/OathManager.kt
@@ -306,7 +306,7 @@ class OathManager(
         return useOathSessionNfc(OathActionDescription.AddAccount) { session ->
             // We need to check for duplicates here since we haven't yet read the credentials
             if (session.credentials.any { it.id.contentEquals(credentialData.id) }) {
-                throw Exception("A credential with this ID already exists!")
+                throw IllegalArgumentException()
             }
 
             val credential = session.putCredential(credentialData, requireTouch)

--- a/lib/android/oath/state.dart
+++ b/lib/android/oath/state.dart
@@ -29,6 +29,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/user_interaction.dart';
 import '../../core/models.dart';
+import '../../exception/apdu_exception.dart';
 import '../../exception/cancellation_exception.dart';
 import '../../exception/no_data_exception.dart';
 import '../../exception/platform_exception_decoder.dart';
@@ -130,6 +131,29 @@ class _AndroidOathStateNotifier extends OathStateNotifier {
   }
 }
 
+// Converts Platform exception during Add Account operation
+// Returns CancellationException for situations we don't want to show a Toast
+Exception _decodeAddAccountException(PlatformException platformException) {
+  final decodedException = platformException.decode();
+
+  // Auth required, the app will show Unlock dialog
+  if (decodedException is ApduException && decodedException.sw == 0x6982) {
+    _log.error('Add account failed: Auth required');
+    return CancellationException();
+  }
+
+  // Thrown in native code when the account already exists on the YubiKey
+  // The entry dialog will show an error message and that is why we convert
+  // this to CancellationException to avoid showing a Toast
+  if (platformException.code == 'IllegalArgumentException') {
+    _log.error('Add account failed: Account already exists');
+    return CancellationException();
+  }
+
+  // original exception
+  return decodedException;
+}
+
 final addCredentialToAnyProvider =
     Provider((ref) => (Uri credentialUri, {bool requireTouch = false}) async {
           try {
@@ -142,8 +166,7 @@ final addCredentialToAnyProvider =
             var result = jsonDecode(resultString);
             return OathCredential.fromJson(result['credential']);
           } on PlatformException catch (pe) {
-            _log.error('Failed to add account.', pe);
-            throw pe.decode();
+            throw _decodeAddAccountException(pe);
           }
         });
 
@@ -267,8 +290,7 @@ class _AndroidCredentialListNotifier extends OathCredentialListNotifier {
       var result = jsonDecode(resultString);
       return OathCredential.fromJson(result['credential']);
     } on PlatformException catch (pe) {
-      _log.error('Failed to add account.', pe);
-      throw pe.decode();
+      throw _decodeAddAccountException(pe);
     }
   }
 

--- a/lib/android/oath/state.dart
+++ b/lib/android/oath/state.dart
@@ -92,8 +92,13 @@ class _AndroidOathStateNotifier extends OathStateNotifier {
       final remembered = unlockResponse['remembered'] == true;
 
       return (unlocked, remembered);
-    } on PlatformException catch (e) {
-      _log.debug('Calling unlock failed with exception: $e');
+    } on PlatformException catch (pe) {
+      final decoded = pe.decode();
+      if (decoded is CancellationException) {
+        _log.debug('Unlock OATH cancelled');
+        throw decoded;
+      }
+      _log.debug('Calling unlock failed with exception: $pe');
       return (false, false);
     }
   }

--- a/lib/oath/views/unlock_form.dart
+++ b/lib/oath/views/unlock_form.dart
@@ -21,6 +21,7 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
+import '../../exception/cancellation_exception.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../keys.dart' as keys;
@@ -47,19 +48,24 @@ class _UnlockFormState extends ConsumerState<UnlockForm> {
     setState(() {
       _passwordIsWrong = false;
     });
-    final (success, remembered) = await ref
-        .read(oathStateProvider(widget._devicePath).notifier)
-        .unlock(_passwordController.text, remember: _remember);
-    if (!mounted) return;
-    if (!success) {
-      _passwordController.selection = TextSelection(
-          baseOffset: 0, extentOffset: _passwordController.text.length);
-      _passwordFocus.requestFocus();
-      setState(() {
-        _passwordIsWrong = true;
-      });
-    } else if (_remember && !remembered) {
-      showMessage(context, AppLocalizations.of(context)!.l_remember_pw_failed);
+    try {
+      final (success, remembered) = await ref
+          .read(oathStateProvider(widget._devicePath).notifier)
+          .unlock(_passwordController.text, remember: _remember);
+      if (!mounted) return;
+      if (!success) {
+        _passwordController.selection = TextSelection(
+            baseOffset: 0, extentOffset: _passwordController.text.length);
+        _passwordFocus.requestFocus();
+        setState(() {
+          _passwordIsWrong = true;
+        });
+      } else if (_remember && !remembered) {
+        showMessage(
+            context, AppLocalizations.of(context)!.l_remember_pw_failed);
+      }
+    } on CancellationException catch (_) {
+      // ignored
     }
   }
 


### PR DESCRIPTION
Fixes following discovered issues:
- when adding a new account to a key which already holds that account (account name already exists for the issuer), a toast with native exception was shown. This is not needed because the flutter TextField will show an error text in such situation.
- when adding an account to a key which has not been unlocked yet, a toast was shown with a cryptic content: `Failed adding account: SW: 0x9682` - this means that the authentication is required and the app will show the Unlock screen - the toast is not needed.
- When unlocking over NFC and cancelling the NFC dialog, the app interpreted this as a wrong password