### PR TITLE
[Android] Better FIDO over USB reset functionality

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/AppContextManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/AppContextManager.kt
@@ -27,6 +27,4 @@ abstract class AppContextManager {
     open fun dispose() {}
 
     open fun onPause() {}
-
-    open fun onResume() {}
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -258,8 +258,6 @@ class MainActivity : FlutterFragmentActivity() {
         appPreferences.registerListener(sharedPreferencesListener)
 
         preserveConnectionOnPause = false
-
-        contextManager?.onResume()
     }
 
     override fun onMultiWindowModeChanged(isInMultiWindowMode: Boolean, newConfig: Configuration) {
@@ -390,6 +388,7 @@ class MainActivity : FlutterFragmentActivity() {
                 OperationContext.FidoFingerprints,
                 OperationContext.FidoPasskeys -> FidoManager(
                     messenger,
+                    this,
                     deviceManager,
                     fidoViewModel,
                     viewModel,


### PR DESCRIPTION
Improves the reset over USB for situations when the key does not have the "Open by default" flag. In that case, the system always shows "Allow Yubico Authenticator to handle YubiKey" dialog on USB connection.

The fix is simply that we always cancel an ongoing reset in `onStop` lifecycle event and don't need to track the `onPause/onResume` events. 

As part of this PR I removed all unused lifetime events from the AppContextManager interface.

This was tested with several devices.

Tip: to reset the default flag of a YubiKey, open Yubico Authenticator system app settings and clear the defaults.