### PR TITLE
Improve transitions when switching applications

### DIFF
--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -545,7 +545,11 @@ class _AppPageState extends ConsumerState<AppPage> {
               body
             ]),
           )),
-          if (hasManage && !hasDetailsOrKeyActions)
+          if (hasManage &&
+              !hasDetailsOrKeyActions &&
+              widget.capabilities?.first != Capability.u2f)
+            // Add a placeholder for the Manage/Details column, but not for
+            // the "Security Key" because it does not have any actions/details.
             const SizedBox(width: 336), // simulate column
           if (hasManage && hasDetailsOrKeyActions)
             _VisibilityListener(

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -547,9 +547,11 @@ class _AppPageState extends ConsumerState<AppPage> {
           )),
           if (hasManage &&
               !hasDetailsOrKeyActions &&
+              widget.capabilities != null &&
               widget.capabilities?.first != Capability.u2f)
-            // Add a placeholder for the Manage/Details column, but not for
-            // the "Security Key" because it does not have any actions/details.
+            // Add a placeholder for the Manage/Details column. Exceptions are:
+            // - the "Security Key" because it does not have any actions/details.
+            // - pages without Capabilities
             const SizedBox(width: 336), // simulate column
           if (hasManage && hasDetailsOrKeyActions)
             _VisibilityListener(

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -384,7 +384,7 @@ class _AppPageState extends ConsumerState<AppPage> {
               alignment: Alignment.topLeft,
               child: Padding(
                 padding: const EdgeInsets.only(
-                    left: 16.0, right: 16.0, bottom: 24.0),
+                    left: 16.0, right: 16.0, bottom: 24.0, top: 4.0),
                 child: _buildTitle(context),
               ),
             ),

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -545,7 +545,7 @@ class _AppPageState extends ConsumerState<AppPage> {
               body
             ]),
           )),
-          if (!hasDetailsOrKeyActions)
+          if (hasManage && !hasDetailsOrKeyActions)
             const SizedBox(width: 336), // simulate column
           if (hasManage && hasDetailsOrKeyActions)
             _VisibilityListener(

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -484,6 +484,8 @@ class _AppPageState extends ConsumerState<AppPage> {
     final l10n = AppLocalizations.of(context)!;
     final fullyExpanded = !hasDrawer && hasRail && hasManage;
     final showNavigation = ref.watch(_navigationProvider);
+    final hasDetailsOrKeyActions =
+        widget.detailViewBuilder != null || widget.keyActionsBuilder != null;
     var body = _buildMainContent(context, hasManage);
 
     if (widget.onFileDropped != null) {
@@ -543,9 +545,9 @@ class _AppPageState extends ConsumerState<AppPage> {
               body
             ]),
           )),
-          if (hasManage &&
-              (widget.detailViewBuilder != null ||
-                  widget.keyActionsBuilder != null))
+          if (!hasDetailsOrKeyActions)
+            const SizedBox(width: 336), // simulate column
+          if (hasManage && hasDetailsOrKeyActions)
             _VisibilityListener(
               controller: _detailsController,
               targetKey: _detailsViewGlobalKey,

--- a/lib/app/views/message_page_not_initialized.dart
+++ b/lib/app/views/message_page_not_initialized.dart
@@ -6,11 +6,15 @@ import 'package:material_symbols_icons/symbols.dart';
 import '../../android/app_methods.dart';
 import '../../android/state.dart';
 import '../../core/state.dart';
+import '../../management/models.dart';
 import 'message_page.dart';
 
 class MessagePageNotInitialized extends ConsumerWidget {
   final String title;
-  const MessagePageNotInitialized({super.key, required this.title});
+  final List<Capability>? capabilities;
+
+  const MessagePageNotInitialized(
+      {super.key, required this.title, required this.capabilities});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -27,7 +31,9 @@ class MessagePageNotInitialized extends ConsumerWidget {
       var isNfcEnabled = ref.watch(androidNfcStateProvider);
       return MessagePage(
         title: title,
+        capabilities: capabilities,
         centered: true,
+        delayedContent: true,
         graphic: noKeyImage,
         header: hasNfcSupport && isNfcEnabled
             ? l10n.l_insert_or_tap_yk
@@ -45,6 +51,7 @@ class MessagePageNotInitialized extends ConsumerWidget {
     } else {
       return MessagePage(
         title: title,
+        capabilities: capabilities,
         centered: true,
         delayedContent: false,
         graphic: noKeyImage,

--- a/lib/app/views/message_page_not_initialized.dart
+++ b/lib/app/views/message_page_not_initialized.dart
@@ -5,8 +5,10 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import '../../android/app_methods.dart';
 import '../../android/state.dart';
+import '../../core/models.dart';
 import '../../core/state.dart';
 import '../../management/models.dart';
+import '../state.dart';
 import 'message_page.dart';
 
 class MessagePageNotInitialized extends ConsumerWidget {
@@ -29,11 +31,14 @@ class MessagePageNotInitialized extends ConsumerWidget {
     if (isAndroid) {
       var hasNfcSupport = ref.watch(androidNfcSupportProvider);
       var isNfcEnabled = ref.watch(androidNfcStateProvider);
+      var isUsbYubiKey =
+          ref.watch(attachedDevicesProvider).firstOrNull?.transport ==
+              Transport.usb;
       return MessagePage(
         title: title,
         capabilities: capabilities,
         centered: true,
-        delayedContent: true,
+        delayedContent: isUsbYubiKey,
         graphic: noKeyImage,
         header: hasNfcSupport && isNfcEnabled
             ? l10n.l_insert_or_tap_yk

--- a/lib/app/views/message_page_not_initialized.dart
+++ b/lib/app/views/message_page_not_initialized.dart
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2024 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/fido/views/fingerprints_screen.dart
+++ b/lib/fido/views/fingerprints_screen.dart
@@ -54,6 +54,8 @@ class FingerprintsScreen extends ConsumerWidget {
     final l10n = AppLocalizations.of(context)!;
     return ref.watch(fidoStateProvider(deviceData.node.path)).when(
         loading: () => AppPage(
+              title: l10n.s_fingerprints,
+              capabilities: const [Capability.fido2],
               centered: true,
               delayedContent: true,
               builder: (context, _) => const CircularProgressIndicator(),
@@ -344,6 +346,8 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
   }
 
   Widget _buildLoadingPage(BuildContext context) => AppPage(
+        title: AppLocalizations.of(context)!.s_fingerprints,
+        capabilities: const [Capability.fido2],
         centered: true,
         delayedContent: true,
         builder: (context, _) => const CircularProgressIndicator(),

--- a/lib/fido/views/fingerprints_screen.dart
+++ b/lib/fido/views/fingerprints_screen.dart
@@ -60,7 +60,10 @@ class FingerprintsScreen extends ConsumerWidget {
             ),
         error: (error, _) {
           if (error is NoDataException) {
-            return MessagePageNotInitialized(title: l10n.s_fingerprints);
+            return MessagePageNotInitialized(
+              title: l10n.s_fingerprints,
+              capabilities: const [Capability.fido2],
+            );
           }
           final enabled = deviceData
                   .info.config.enabledCapabilities[deviceData.node.transport] ??

--- a/lib/fido/views/passkeys_screen.dart
+++ b/lib/fido/views/passkeys_screen.dart
@@ -263,7 +263,7 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
 
     final data = ref.watch(credentialProvider(widget.node.path)).asData;
     if (data == null) {
-      return _buildLoadingPage(context);
+      return _buildLoadingPage(l10n, context);
     }
     final credentials = data.value;
     final filteredCredentials =
@@ -502,7 +502,10 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
     );
   }
 
-  Widget _buildLoadingPage(BuildContext context) => AppPage(
+  Widget _buildLoadingPage(AppLocalizations l10n, BuildContext context) =>
+      AppPage(
+        title: l10n.s_passkeys,
+        capabilities: const [Capability.fido2],
         centered: true,
         delayedContent: true,
         builder: (context, _) => const CircularProgressIndicator(),

--- a/lib/fido/views/passkeys_screen.dart
+++ b/lib/fido/views/passkeys_screen.dart
@@ -65,7 +65,10 @@ class PasskeysScreen extends ConsumerWidget {
             ),
         error: (error, _) {
           if (error is NoDataException) {
-            return MessagePageNotInitialized(title: l10n.s_passkeys);
+            return MessagePageNotInitialized(
+              title: l10n.s_passkeys,
+              capabilities: const [Capability.fido2],
+            );
           }
           final enabled = deviceData
                   .info.config.enabledCapabilities[deviceData.node.transport] ??

--- a/lib/fido/views/passkeys_screen.dart
+++ b/lib/fido/views/passkeys_screen.dart
@@ -59,6 +59,8 @@ class PasskeysScreen extends ConsumerWidget {
     final l10n = AppLocalizations.of(context)!;
     return ref.watch(fidoStateProvider(deviceData.node.path)).when(
         loading: () => AppPage(
+              title: l10n.s_passkeys,
+              capabilities: const [Capability.fido2],
               centered: true,
               delayedContent: true,
               builder: (context, _) => const CircularProgressIndicator(),

--- a/lib/fido/views/passkeys_screen.dart
+++ b/lib/fido/views/passkeys_screen.dart
@@ -263,7 +263,7 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
 
     final data = ref.watch(credentialProvider(widget.node.path)).asData;
     if (data == null) {
-      return _buildLoadingPage(l10n, context);
+      return _buildLoadingPage(context);
     }
     final credentials = data.value;
     final filteredCredentials =
@@ -502,9 +502,8 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
     );
   }
 
-  Widget _buildLoadingPage(AppLocalizations l10n, BuildContext context) =>
-      AppPage(
-        title: l10n.s_passkeys,
+  Widget _buildLoadingPage(BuildContext context) => AppPage(
+        title: AppLocalizations.of(context)!.s_passkeys,
         capabilities: const [Capability.fido2],
         centered: true,
         delayedContent: true,

--- a/lib/oath/views/account_icon.dart
+++ b/lib/oath/views/account_icon.dart
@@ -66,15 +66,19 @@ class AccountIcon extends ConsumerWidget {
         fit: BoxFit.fill,
         loader: IconFileLoader(ref, file),
         placeholderBuilder: (BuildContext _) {
-          return DelayedVisibility(
-            delay: const Duration(milliseconds: 10),
-            child: Stack(alignment: Alignment.center, children: [
-              Opacity(
-                opacity: 0.5,
-                child: defaultWidget,
-              ),
-              const CircularProgressIndicator(),
-            ]),
+          return SizedBox(
+            width: _width,
+            height: _height,
+            child: DelayedVisibility(
+              delay: const Duration(milliseconds: 10),
+              child: Stack(alignment: Alignment.center, children: [
+                Opacity(
+                  opacity: 0.5,
+                  child: defaultWidget,
+                ),
+                const CircularProgressIndicator(),
+              ]),
+            ),
           );
         });
   }

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -204,6 +204,8 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
 
     if (numCreds == null) {
       return AppPage(
+        title: AppLocalizations.of(context)!.s_accounts,
+        capabilities: const [Capability.oath],
         centered: true,
         delayedContent: true,
         builder: (context, _) => const CircularProgressIndicator(),

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -61,9 +61,11 @@ class OathScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final l10n = AppLocalizations.of(context)!;
     return ref.watch(oathStateProvider(devicePath)).when(
-        loading: () => const MessagePage(
+        loading: () => MessagePage(
+              title: AppLocalizations.of(context)!.s_accounts,
+              capabilities: const [Capability.oath],
               centered: true,
-              graphic: CircularProgressIndicator(),
+              graphic: const CircularProgressIndicator(),
               delayedContent: true,
             ),
         error: (error, _) => error is NoDataException

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -67,7 +67,10 @@ class OathScreen extends ConsumerWidget {
               delayedContent: true,
             ),
         error: (error, _) => error is NoDataException
-            ? MessagePageNotInitialized(title: l10n.s_accounts)
+            ? MessagePageNotInitialized(
+                title: l10n.s_accounts,
+                capabilities: const [Capability.oath],
+              )
             : AppFailurePage(
                 cause: error,
               ),

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/otp/views/otp_screen.dart
+++ b/lib/otp/views/otp_screen.dart
@@ -57,9 +57,11 @@ class _OtpScreenState extends ConsumerState<OtpScreen> {
     final l10n = AppLocalizations.of(context)!;
     final hasFeature = ref.watch(featureProvider);
     return ref.watch(otpStateProvider(widget.devicePath)).when(
-        loading: () => const MessagePage(
+        loading: () => MessagePage(
+              title: l10n.s_slots,
+              capabilities: const [Capability.otp],
               centered: true,
-              graphic: CircularProgressIndicator(),
+              graphic: const CircularProgressIndicator(),
               delayedContent: true,
             ),
         error: (error, _) => AppFailurePage(cause: error),

--- a/lib/piv/views/piv_screen.dart
+++ b/lib/piv/views/piv_screen.dart
@@ -58,9 +58,11 @@ class _PivScreenState extends ConsumerState<PivScreen> {
     final l10n = AppLocalizations.of(context)!;
     final hasFeature = ref.watch(featureProvider);
     return ref.watch(pivStateProvider(widget.devicePath)).when(
-          loading: () => const MessagePage(
+          loading: () => MessagePage(
+            title: l10n.s_certificates,
+            capabilities: const [Capability.piv],
             centered: true,
-            graphic: CircularProgressIndicator(),
+            graphic: const CircularProgressIndicator(),
             delayedContent: true,
           ),
           error: (error, _) => AppFailurePage(


### PR DESCRIPTION
This PR makes switching between the sections (Accounts/Passkeys/OTP/...) less laggy.

The concrete fixes are:
- added top padding to AppPage so that switching among screens with the same title does not make the title "jump"
- added delay and capability to PageNotInitialized widget. With this change, when switching on USB, the transition is direct, when before the change one could clearly see the "Tap your YubiKey" page.
- Added `title` and `capabilities` to loading pages in application screens. This will keep the Title and capability widgets visible also when the application is loading data from the YubiKey, providing smoother user experience.
- OATH account icons placeholders get a size to prevent flicker when the icon is loaded