### PR TITLE
[Android] Always request focus for OATH and FIDO2 auth

### DIFF
--- a/lib/fido/views/pin_entry_form.dart
+++ b/lib/fido/views/pin_entry_form.dart
@@ -45,6 +45,12 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
   bool _isObscure = true;
 
   @override
+  void initState() {
+    super.initState();
+    _pinFocus.requestFocus();
+  }
+
+  @override
   void dispose() {
     _pinController.dispose();
     _pinFocus.dispose();

--- a/lib/oath/views/unlock_form.dart
+++ b/lib/oath/views/unlock_form.dart
@@ -44,6 +44,19 @@ class _UnlockFormState extends ConsumerState<UnlockForm> {
   bool _passwordIsWrong = false;
   bool _isObscure = true;
 
+  @override
+  void initState() {
+    super.initState();
+    _passwordFocus.requestFocus();
+  }
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _passwordFocus.dispose();
+    super.dispose();
+  }
+
   void _submit() async {
     setState(() {
       _passwordIsWrong = false;


### PR DESCRIPTION
When switching sections on Android, the text Password (OATH) and PIN (FIDO2) text fields did not get focus automatically, this explicitly requests the focus when the widgets are initialized.