### PR TITLE
[Android] Probe HW key applications if getDeviceInfo fails

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -40,7 +40,6 @@ import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.color.DynamicColors
 import com.yubico.authenticator.device.DeviceManager
-import com.yubico.authenticator.device.UnknownDevice
 import com.yubico.authenticator.fido.FidoManager
 import com.yubico.authenticator.fido.FidoViewModel
 import com.yubico.authenticator.logging.FlutterLog
@@ -54,7 +53,6 @@ import com.yubico.yubikit.android.transport.nfc.NfcConfiguration
 import com.yubico.yubikit.android.transport.nfc.NfcNotAvailable
 import com.yubico.yubikit.android.transport.nfc.NfcYubiKeyDevice
 import com.yubico.yubikit.android.transport.usb.UsbConfiguration
-import com.yubico.yubikit.core.Transport
 import com.yubico.yubikit.core.YubiKeyDevice
 import io.flutter.embedding.android.FlutterFragmentActivity
 import io.flutter.embedding.engine.FlutterEngine
@@ -273,17 +271,7 @@ class MainActivity : FlutterFragmentActivity() {
 
     private fun processYubiKey(device: YubiKeyDevice) {
         lifecycleScope.launch {
-
-            val deviceInfo = try {
-                getDeviceInfo(device)
-            } catch (e: IllegalArgumentException) {
-                logger.debug("Device was not recognized")
-                UnknownDevice.copy(isNfc = device.transport == Transport.NFC)
-            } catch (e: Exception) {
-                logger.error("Failure getting device info", e)
-                null
-            }
-
+            val deviceInfo = getDeviceInfo(device)
             deviceManager.setDeviceInfo(deviceInfo)
 
             if (deviceInfo == null) {

--- a/android/app/src/main/kotlin/com/yubico/authenticator/device/UnknownDevice.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/device/UnknownDevice.kt
@@ -1,5 +1,7 @@
 package com.yubico.authenticator.device
 
+import com.yubico.yubikit.core.Transport
+import com.yubico.yubikit.management.Capability
 import com.yubico.yubikit.management.FormFactor
 
 val UnknownDevice = Info(
@@ -21,3 +23,28 @@ val UnknownDevice = Info(
     pinComplexity = false,
     supportedCapabilities = Capabilities()
 )
+
+fun unknownDeviceWithCapability(transport: Transport, bit: Int = 0) : Info {
+    val isNfc = transport == Transport.NFC
+    val capabilities = Capabilities(
+        nfc = if (isNfc)  bit else null,
+        usb = if (!isNfc) bit else null
+    )
+    return UnknownDevice.copy(
+        isNfc = isNfc,
+        config = UnknownDevice.config.copy(enabledCapabilities = capabilities),
+        supportedCapabilities = capabilities
+    )
+}
+
+fun unknownOathDeviceInfo(transport: Transport) : Info {
+    return unknownDeviceWithCapability(transport, Capability.OATH.bit).copy(
+        name = "OATH device"
+    )
+}
+
+fun unknownFido2DeviceInfo(transport: Transport) : Info {
+    return unknownDeviceWithCapability(transport, Capability.FIDO2.bit).copy(
+        name = "FIDO2 device"
+    )
+}

--- a/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/DeviceInfoHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/DeviceInfoHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,24 @@ package com.yubico.authenticator.yubikit
 
 import com.yubico.authenticator.device.Info
 import com.yubico.authenticator.compatUtil
+import com.yubico.authenticator.device.unknownDeviceWithCapability
+import com.yubico.authenticator.device.unknownFido2DeviceInfo
+import com.yubico.authenticator.device.unknownOathDeviceInfo
 import com.yubico.yubikit.android.transport.nfc.NfcYubiKeyDevice
 import com.yubico.yubikit.android.transport.usb.UsbYubiKeyDevice
 import com.yubico.yubikit.core.YubiKeyDevice
+import com.yubico.yubikit.core.application.ApplicationNotAvailableException
 import com.yubico.yubikit.core.fido.FidoConnection
 import com.yubico.yubikit.core.otp.OtpConnection
 import com.yubico.yubikit.core.smartcard.SmartCardConnection
+import com.yubico.yubikit.fido.ctap.Ctap2Session
 import com.yubico.yubikit.management.DeviceInfo
+import com.yubico.yubikit.oath.OathSession
 import com.yubico.yubikit.support.DeviceUtil
 
 import org.slf4j.LoggerFactory
 
-suspend fun getDeviceInfo(device: YubiKeyDevice): Info {
+suspend fun getDeviceInfo(device: YubiKeyDevice): Info? {
     val pid = (device as? UsbYubiKeyDevice)?.pid
     val logger = LoggerFactory.getLogger("getDeviceInfo")
 
@@ -45,8 +51,31 @@ suspend fun getDeviceInfo(device: YubiKeyDevice): Info {
         logger.debug("FIDO connection not available: {}", t.message)
         return SkyHelper(compatUtil).getDeviceInfo(device)
     }.getOrElse {
-        logger.debug("Failed to recognize device: {}", it.message)
-        throw it
+        // this is not a YubiKey
+        logger.debug("Probing unknown device")
+        try {
+            device.openConnection(SmartCardConnection::class.java).use { smartCardConnection ->
+                try {
+                    // if OATH session is available use it
+                    OathSession(smartCardConnection)
+                    logger.debug("Device supports OATH")
+                    return unknownOathDeviceInfo(device.transport)
+                } catch (applicationNotAvailable: ApplicationNotAvailableException) {
+                    try {
+                        // probe for CTAP2 availability
+                        Ctap2Session(smartCardConnection)
+                        logger.debug("Device supports FIDO2")
+                        return unknownFido2DeviceInfo(device.transport)
+                    } catch (applicationNotAvailable: ApplicationNotAvailableException) {
+                        logger.debug("Device not recognized")
+                        return unknownDeviceWithCapability(device.transport)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            // no smart card connectivity
+            return null
+        }
     }
 
     val name = DeviceUtil.getName(deviceInfo, pid?.type)

--- a/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/DeviceInfoHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/DeviceInfoHelper.kt
@@ -74,6 +74,7 @@ suspend fun getDeviceInfo(device: YubiKeyDevice): Info? {
             }
         } catch (e: Exception) {
             // no smart card connectivity
+            logger.error("Failure getting device info", e)
             return null
         }
     }

--- a/lib/home/views/home_screen.dart
+++ b/lib/home/views/home_screen.dart
@@ -105,21 +105,22 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                       ],
                     ),
                   ),
-                  Flexible(
-                    flex: 6,
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 200),
-                      child: _HeroAvatar(
-                        color: keyCustomization?.color ?? primaryColor,
-                        child: ProductImage(
-                          name: widget.deviceData.name,
-                          formFactor: widget.deviceData.info.formFactor,
-                          isNfc: widget.deviceData.info.supportedCapabilities
-                              .containsKey(Transport.nfc),
+                  if (widget.deviceData.info.version != const Version(0, 0, 0))
+                    Flexible(
+                      flex: 6,
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 200),
+                        child: _HeroAvatar(
+                          color: keyCustomization?.color ?? primaryColor,
+                          child: ProductImage(
+                            name: widget.deviceData.name,
+                            formFactor: widget.deviceData.info.formFactor,
+                            isNfc: widget.deviceData.info.supportedCapabilities
+                                .containsKey(Transport.nfc),
+                          ),
                         ),
                       ),
-                    ),
-                  )
+                    )
                 ],
               )
             ],
@@ -141,9 +142,7 @@ class _DeviceContent extends ConsumerWidget {
 
     final name = deviceData.name;
     final serial = deviceData.info.serial;
-    final version = deviceData.info.version == const Version(0, 0, 0)
-        ? 'unknown'
-        : deviceData.info.version;
+    final version = deviceData.info.version;
 
     final label = initialCustomization?.name;
     String displayName = label != null ? '$label ($name)' : name;
@@ -188,13 +187,14 @@ class _DeviceContent extends ConsumerWidget {
                 .titleSmall
                 ?.apply(color: Theme.of(context).colorScheme.onSurfaceVariant),
           ),
-        Text(
-          l10n.l_firmware_version(version),
-          style: Theme.of(context)
-              .textTheme
-              .titleSmall
-              ?.apply(color: Theme.of(context).colorScheme.onSurfaceVariant),
-        ),
+        if (version != const Version(0, 0, 0))
+          Text(
+            l10n.l_firmware_version(version),
+            style: Theme.of(context)
+                .textTheme
+                .titleSmall
+                ?.apply(color: Theme.of(context).colorScheme.onSurfaceVariant),
+          ),
       ],
     );
   }

--- a/lib/home/views/home_screen.dart
+++ b/lib/home/views/home_screen.dart
@@ -141,7 +141,9 @@ class _DeviceContent extends ConsumerWidget {
 
     final name = deviceData.name;
     final serial = deviceData.info.serial;
-    final version = deviceData.info.version;
+    final version = deviceData.info.version == const Version(0, 0, 0)
+        ? 'unknown'
+        : deviceData.info.version;
 
     final label = initialCustomization?.name;
     String displayName = label != null ? '$label ($name)' : name;


### PR DESCRIPTION
If calling `getDeviceInfo()` fails, we probe for OATH and FIDO2 to manually setup `DeviceInfo` information, so that the key can be used with the app.