### PR TITLE
Improve Text input action handling in Android dialogs

### DIFF
--- a/lib/fido/views/add_fingerprint_dialog.dart
+++ b/lib/fido/views/add_fingerprint_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,7 +255,11 @@ class _AddFingerprintDialogState extends ConsumerState<AddFingerprintDialog>
                         });
                       },
                       onFieldSubmitted: (_) {
-                        _submit();
+                        if (_label.isNotEmpty) {
+                          _submit();
+                        } else {
+                          _nameFocus.requestFocus();
+                        }
                       },
                     ).init(),
                   )

--- a/lib/fido/views/pin_dialog.dart
+++ b/lib/fido/views/pin_dialog.dart
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -90,6 +88,9 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
     final isValid =
         currentPinLenOk && newPinLenOk && _newPinController.text == _confirmPin;
 
+    final newPinEnabled = !_isBlocked && currentPinLenOk;
+    final confirmPinEnabled = !_isBlocked && currentPinLenOk && newPinLenOk;
+
     final deviceData = ref.read(currentDeviceDataProvider).valueOrNull;
 
     final hasPinComplexity = deviceData?.info.pinComplexity ?? false;
@@ -139,20 +140,17 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
                   errorText: _currentIsWrong ? _currentPinError : null,
                   errorMaxLines: 3,
                   prefixIcon: const Icon(Symbols.pin),
-                  suffixIcon: ExcludeFocusTraversal(
-                    excluding: Platform.isAndroid,
-                    child: IconButton(
-                      icon: Icon(_isObscureCurrent
-                          ? Symbols.visibility
-                          : Symbols.visibility_off),
-                      onPressed: () {
-                        setState(() {
-                          _isObscureCurrent = !_isObscureCurrent;
-                        });
-                      },
-                      tooltip:
-                          _isObscureCurrent ? l10n.s_show_pin : l10n.s_hide_pin,
-                    ),
+                  suffixIcon: IconButton(
+                    icon: Icon(_isObscureCurrent
+                        ? Symbols.visibility
+                        : Symbols.visibility_off),
+                    onPressed: () {
+                      setState(() {
+                        _isObscureCurrent = !_isObscureCurrent;
+                      });
+                    },
+                    tooltip:
+                        _isObscureCurrent ? l10n.s_show_pin : l10n.s_hide_pin,
                   ),
                 ),
                 textInputAction: TextInputAction.next,
@@ -164,6 +162,8 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
                 onFieldSubmitted: (_) {
                   if (_currentPinController.text.length < minPinLength) {
                     _currentPinFocus.requestFocus();
+                  } else {
+                    _newPinFocus.requestFocus();
                   }
                 },
               ).init(),
@@ -185,12 +185,12 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
               decoration: AppInputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: l10n.s_new_pin,
-                enabled: !_isBlocked && currentPinLenOk,
+                enabled: newPinEnabled,
                 errorText: _newIsWrong ? _newPinError : null,
                 errorMaxLines: 3,
                 prefixIcon: const Icon(Symbols.pin),
                 suffixIcon: ExcludeFocusTraversal(
-                  excluding: Platform.isAndroid,
+                  excluding: !newPinEnabled,
                   child: IconButton(
                     icon: Icon(_isObscureNew
                         ? Symbols.visibility
@@ -213,6 +213,8 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
               onFieldSubmitted: (_) {
                 if (_newPinController.text.length < minPinLength) {
                   _newPinFocus.requestFocus();
+                } else {
+                  _confirmPinFocus.requestFocus();
                 }
               },
             ).init(),
@@ -229,19 +231,22 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
                 border: const OutlineInputBorder(),
                 labelText: l10n.s_confirm_pin,
                 prefixIcon: const Icon(Symbols.pin),
-                suffixIcon: IconButton(
-                  icon: Icon(_isObscureConfirm
-                      ? Symbols.visibility
-                      : Symbols.visibility_off),
-                  onPressed: () {
-                    setState(() {
-                      _isObscureConfirm = !_isObscureConfirm;
-                    });
-                  },
-                  tooltip:
-                      _isObscureConfirm ? l10n.s_show_pin : l10n.s_hide_pin,
+                suffixIcon: ExcludeFocusTraversal(
+                  excluding: !confirmPinEnabled,
+                  child: IconButton(
+                    icon: Icon(_isObscureConfirm
+                        ? Symbols.visibility
+                        : Symbols.visibility_off),
+                    onPressed: () {
+                      setState(() {
+                        _isObscureConfirm = !_isObscureConfirm;
+                      });
+                    },
+                    tooltip:
+                        _isObscureConfirm ? l10n.s_show_pin : l10n.s_hide_pin,
+                  ),
                 ),
-                enabled: !_isBlocked && currentPinLenOk && newPinLenOk,
+                enabled: confirmPinEnabled,
                 errorText:
                     _newPinController.text.length == _confirmPin.length &&
                             _newPinController.text != _confirmPin

--- a/lib/fido/views/rename_fingerprint_dialog.dart
+++ b/lib/fido/views/rename_fingerprint_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,12 +41,20 @@ class RenameFingerprintDialog extends ConsumerStatefulWidget {
 
 class _RenameAccountDialogState extends ConsumerState<RenameFingerprintDialog> {
   late String _label;
+  late FocusNode _labelFocus;
   _RenameAccountDialogState();
 
   @override
   void initState() {
     super.initState();
     _label = widget.fingerprint.name ?? '';
+    _labelFocus = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    _labelFocus.dispose();
+    super.dispose();
   }
 
   _submit() async {
@@ -94,6 +102,7 @@ class _RenameAccountDialogState extends ConsumerState<RenameFingerprintDialog> {
             Text(l10n.p_will_change_label_fp),
             AppTextFormField(
               initialValue: _label,
+              focusNode: _labelFocus,
               maxLength: 15,
               inputFormatters: [limitBytesLength(15)],
               buildCounter: buildByteCounterFor(_label),
@@ -110,6 +119,8 @@ class _RenameAccountDialogState extends ConsumerState<RenameFingerprintDialog> {
               onFieldSubmitted: (_) {
                 if (_label.isNotEmpty) {
                   _submit();
+                } else {
+                  _labelFocus.requestFocus();
                 }
               },
             ).init(),

--- a/lib/fido/views/rename_fingerprint_dialog.dart
+++ b/lib/fido/views/rename_fingerprint_dialog.dart
@@ -101,6 +101,7 @@ class _RenameAccountDialogState extends ConsumerState<RenameFingerprintDialog> {
             Text(l10n.q_rename_target(widget.fingerprint.label)),
             Text(l10n.p_will_change_label_fp),
             AppTextFormField(
+              autofocus: true,
               initialValue: _label,
               focusNode: _labelFocus,
               maxLength: 15,


### PR DESCRIPTION
If several text fields are present in one dialog, we can decide what happens when the user presses the "submit" button on the software keyboard.

On Android this was not handled properly, as if the dialog input was not complete (the submit button was not active), the software keyboard was just closed and there was no focused widget in the dialog.

This PR improves this in following ways:
- if the current input field has a valid value, then submitting the field will move forward the next field (in the case of last field, the dialog is submitted).
- if the current input field does not have a valid value, then hitting the "submit" button on the sw keyboard will keep the field focused.

The change has been done in the dialogs currently used on Android:
- set/manage OATH password
- set/change FIDO pin
- name/change name of a fingerprint

Note: on desktop platforms the TAB key works as before, for example the eye buttons are accessible by pressing tab. 