### PR TITLE
Fixes to OATH screen and actions

### DIFF
--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -118,7 +118,7 @@ Widget oathBuildActions(
             trailing: fipsCapable && !fipsApproved ? alertIcon : null,
             onTap: (context) {
               Navigator.of(context).popUntil((route) => route.isFirst);
-              setManagePassword(context, ref, devicePath, oathState);
+              managePassword(context, ref, devicePath, oathState);
             }),
       ]),
     ],

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023,2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import '../features.dart' as features;
 import '../icon_provider/icon_pack_dialog.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
-import 'manage_password_dialog.dart';
 import 'utils.dart';
 
 Widget oathBuildActions(
@@ -105,11 +104,7 @@ Widget oathBuildActions(
             icon: const Icon(Symbols.password),
             onTap: (context) {
               Navigator.of(context).popUntil((route) => route.isFirst);
-              showBlurDialog(
-                context: context,
-                builder: (context) =>
-                    ManagePasswordDialog(devicePath, oathState),
-              );
+              setManagePassword(context, ref, devicePath, oathState);
             }),
       ]),
     ],

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -30,6 +30,15 @@ import '../keys.dart' as keys;
 import '../models.dart';
 import 'utils.dart';
 
+bool oathShowActionNotifier(DeviceInfo? info) {
+  if (info == null) {
+    return false;
+  }
+
+  final (fipsCapable, fipsApproved) = info.getFipsStatus(Capability.oath);
+  return fipsCapable && !fipsApproved;
+}
+
 Widget oathBuildActions(
   BuildContext context,
   DevicePath devicePath,
@@ -61,6 +70,10 @@ Widget oathBuildActions(
     subtitle = null;
     enabled = true;
   }
+
+  final colors = Theme.of(context).buttonTheme.colorScheme ??
+      Theme.of(context).colorScheme;
+  final alertIcon = Icon(Symbols.warning_amber, color: colors.tertiary);
 
   return Column(
     children: [
@@ -102,6 +115,7 @@ Widget oathBuildActions(
                 oathState.hasKey ? l10n.s_manage_password : l10n.s_set_password,
             subtitle: l10n.l_password_protection,
             icon: const Icon(Symbols.password),
+            trailing: fipsCapable && !fipsApproved ? alertIcon : null,
             onTap: (context) {
               Navigator.of(context).popUntil((route) => route.isFirst);
               setManagePassword(context, ref, devicePath, oathState);

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -167,7 +167,8 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
     final hasFeature = ref.watch(featureProvider);
     final hasActions = hasFeature(features.actions);
     final searchText = searchController.text;
-
+    final deviceInfo =
+        ref.watch(currentDeviceDataProvider.select((s) => s.valueOrNull?.info));
     Future<void> onFileDropped(File file) async {
       final qrScanner = ref.read(qrScannerProvider);
       if (qrScanner != null) {
@@ -186,13 +187,11 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
 
     if (numCreds == 0) {
       return MessagePage(
+        keyActionsBadge: oathShowActionNotifier(deviceInfo),
         actionsBuilder: (context, expanded) {
-          final (fipsCapable, fipsApproved) = ref
-                  .watch(currentDeviceDataProvider)
-                  .valueOrNull
-                  ?.info
-                  .getFipsStatus(Capability.oath) ??
-              (false, false);
+          final (fipsCapable, fipsApproved) =
+              deviceInfo?.getFipsStatus(Capability.oath) ?? (false, false);
+
           return [
             if (!expanded && (!fipsCapable || (fipsCapable && fipsApproved)))
               ActionChip(
@@ -242,6 +241,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
         capabilities: const [Capability.oath],
         centered: true,
         delayedContent: true,
+        keyActionsBadge: oathShowActionNotifier(deviceInfo),
         builder: (context, _) => const CircularProgressIndicator(),
       );
     }
@@ -307,6 +307,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
         alternativeTitle:
             searchText != '' ? l10n.l_results_for(searchText) : null,
         capabilities: const [Capability.oath],
+        keyActionsBadge: oathShowActionNotifier(deviceInfo),
         keyActionsBuilder: hasActions
             ? (context) => oathBuildActions(
                   context,

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -186,21 +186,38 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
 
     if (numCreds == 0) {
       return MessagePage(
-        actionsBuilder: (context, expanded) => [
-          if (!expanded)
-            ActionChip(
-              label: Text(l10n.s_add_account),
-              onPressed: () async {
-                await addOathAccount(
-                  context,
-                  ref,
-                  widget.devicePath,
-                  widget.oathState,
-                );
-              },
-              avatar: const Icon(Symbols.person_add_alt),
-            )
-        ],
+        actionsBuilder: (context, expanded) {
+          final (fipsCapable, fipsApproved) = ref
+                  .watch(currentDeviceDataProvider)
+                  .valueOrNull
+                  ?.info
+                  .getFipsStatus(Capability.oath) ??
+              (false, false);
+          return [
+            if (!expanded && (!fipsCapable || (fipsCapable && fipsApproved)))
+              ActionChip(
+                label: Text(l10n.s_add_account),
+                onPressed: () async {
+                  await addOathAccount(
+                    context,
+                    ref,
+                    widget.devicePath,
+                    widget.oathState,
+                  );
+                },
+                avatar: const Icon(Symbols.person_add_alt),
+              ),
+            if (!expanded && fipsCapable && !fipsApproved)
+              ActionChip(
+                label: Text(l10n.s_set_password),
+                onPressed: () async {
+                  await setManagePassword(
+                      context, ref, widget.devicePath, widget.oathState);
+                },
+                avatar: const Icon(Symbols.person_add_alt),
+              )
+          ];
+        },
         title: l10n.s_accounts,
         capabilities: const [Capability.oath],
         key: keys.noAccountsView,

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -210,7 +210,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
               ActionChip(
                 label: Text(l10n.s_set_password),
                 onPressed: () async {
-                  await setManagePassword(
+                  await managePassword(
                       context, ref, widget.devicePath, widget.oathState);
                 },
                 avatar: const Icon(Symbols.person_add_alt),

--- a/lib/oath/views/utils.dart
+++ b/lib/oath/views/utils.dart
@@ -180,7 +180,7 @@ Future<void> addOathAccount(BuildContext context, WidgetRef ref,
   }
 }
 
-Future<void> setManagePassword(BuildContext context, WidgetRef ref,
+Future<void> managePassword(BuildContext context, WidgetRef ref,
     DevicePath devicePath, OathState oathState) async {
   await showBlurDialog(
     context: context,

--- a/lib/oath/views/utils.dart
+++ b/lib/oath/views/utils.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import '../models.dart';
 import 'add_account_dialog.dart';
 import 'add_account_page.dart';
 import 'add_multi_account_page.dart';
+import 'manage_password_dialog.dart';
 
 /// Calculates the available space for issuer and account name.
 ///
@@ -177,4 +178,12 @@ Future<void> addOathAccount(BuildContext context, WidgetRef ref,
       builder: (context) => AddAccountDialog(devicePath, oathState),
     );
   }
+}
+
+Future<void> setManagePassword(BuildContext context, WidgetRef ref,
+    DevicePath devicePath, OathState oathState) async {
+  await showBlurDialog(
+    context: context,
+    builder: (context) => ManagePasswordDialog(devicePath, oathState),
+  );
 }


### PR DESCRIPTION
This change fixes following:
- add account button visible even if the key is not FIPS approved
- adds badges and icons to actions, if a FIPS capable is not setup correctly (missing password)
- on Android, the device info is updated after reset and password change so that Flutter gets correct values for FIPS directly after the user action.

This was tested with FIPS capable keys and non-FIPS keys (so that nothing was broken) over USB and NFC connecitons.