### PR TITLE
Allow ECC P-384 only on supported FW

### DIFF
--- a/lib/piv/views/utils.dart
+++ b/lib/piv/views/utils.dart
@@ -27,7 +27,9 @@ List<KeyType> getSupportedKeyTypes(Version version, bool isFips) => [
         if (!isFips) KeyType.x25519,
       ],
       KeyType.eccp256,
-      KeyType.eccp384,
+      if (version.isAtLeast(4, 0)) ...[
+        KeyType.eccp384,
+      ]
     ];
 
 PinPolicy getPinPolicy(SlotId slot, bool match) {


### PR DESCRIPTION
ECC P-384 is supported from YK 4. 

With this change, users will not be able to choose ECCP384 when generating PIV key on older devices.