### PR TITLE
[Android] Update device info after FIDO setPin and reset

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoManager.kt
@@ -30,6 +30,7 @@ import com.yubico.authenticator.fido.data.Session
 import com.yubico.authenticator.fido.data.SessionInfo
 import com.yubico.authenticator.fido.data.YubiKitFidoSession
 import com.yubico.authenticator.setHandler
+import com.yubico.authenticator.yubikit.DeviceInfoHelper.Companion.getDeviceInfo
 import com.yubico.authenticator.yubikit.withConnection
 import com.yubico.yubikit.android.transport.nfc.NfcYubiKeyDevice
 import com.yubico.yubikit.core.YubiKeyConnection
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory
 import java.io.IOException
 import java.util.Arrays
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
 
 typealias FidoAction = (Result<YubiKitFidoSession, Exception>) -> Unit
 
@@ -80,6 +82,7 @@ class FidoManager(
     }
 
     companion object {
+        val updateDeviceInfo = AtomicBoolean(false)
         fun getPreferredPinUvAuthProtocol(infoData: InfoData): PinUvAuthProtocol {
             val pinUvAuthProtocols = infoData.pinUvAuthProtocols
             val pinSupported = infoData.options["clientPin"] != null
@@ -119,6 +122,8 @@ class FidoManager(
             connectionHelper,
             pinStore
         )
+
+
 
     init {
         pinRetries = null
@@ -186,6 +191,10 @@ class FidoManager(
                 device.withConnection<SmartCardConnection, Unit> { connection ->
                     processYubiKey(connection, device)
                 }
+            }
+
+            if (updateDeviceInfo.getAndSet(false)) {
+                deviceManager.setDeviceInfo(getDeviceInfo(device))
             }
         } catch (e: Exception) {
             // something went wrong, try to get DeviceInfo from any available connection type
@@ -380,7 +389,7 @@ class FidoManager(
     }
 
     private suspend fun setPin(pin: CharArray?, newPin: CharArray): String =
-        connectionHelper.useSession(FidoActionDescription.SetPin) { fidoSession ->
+        connectionHelper.useSession(FidoActionDescription.SetPin, updateDeviceInfo = true) { fidoSession ->
             try {
                 val clientPin =
                     ClientPin(fidoSession, getPreferredPinUvAuthProtocol(fidoSession.cachedInfo))

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoResetHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoResetHelper.kt
@@ -162,8 +162,9 @@ class FidoResetHelper(
         coroutineScope.launch(Dispatchers.Main) {
             fidoViewModel.updateResetState(FidoResetState.Touch)
             logger.debug("Waiting for touch")
-            deviceManager.withKey { usbYubiKeyDevice ->
-                connectionHelper.useSessionUsb(usbYubiKeyDevice) { fidoSession ->
+            deviceManager.withKey {
+                usbYubiKeyDevice ->
+                connectionHelper.useSessionUsb(usbYubiKeyDevice, updateDeviceInfo = true) { fidoSession ->
                     resetCommandState = CommandState()
                     try {
                         if (cancelReset) {
@@ -211,6 +212,7 @@ class FidoResetHelper(
         coroutineScope.launch {
             fidoViewModel.updateResetState(FidoResetState.Touch)
             try {
+                FidoManager.updateDeviceInfo.set(true)
                 connectionHelper.useSessionNfc(FidoActionDescription.Reset) { fidoSession ->
                     doReset(fidoSession)
                     continuation.resume(Unit)


### PR DESCRIPTION
Reset and set PIN FIDO operations can change properties in device info. To avoid second tap, we read the device info after these two operations.

Tested over NFC and USB.