### PR TITLE
Handle timed out FIDO reset on older keys

### DIFF
--- a/helper/helper/fido.py
+++ b/helper/helper/fido.py
@@ -186,8 +186,13 @@ class Ctap2Node(RpcNode):
         try:
             self.ctap.reset(event=event)
         except CtapError as e:
-            if e.code == CtapError.ERR.USER_ACTION_TIMEOUT:
+            if e.code in (
+                # Different keys respond with different errors here
+                CtapError.ERR.USER_ACTION_TIMEOUT,
+                CtapError.ERR.ACTION_TIMEOUT,
+            ):
                 raise InactivityException()
+            raise
         self._info = self.ctap.get_info()
         self._token = None
         return RpcResponse(dict(), ["device_info"])


### PR DESCRIPTION
Letting the factory reset for FIDO time out while waiting for touch returns different errors on different keys. Also, other exceptions were not being handled, just silently ignored.