### PR TITLE
Catch exceptions during initial NFC connections

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/AppContextManager.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/AppContextManager.kt
@@ -28,7 +28,7 @@ abstract class AppContextManager {
 
     open fun onPause() {}
 
-    open fun onError() {}
+    open fun onError(e: Exception) {}
 }
 
 class ContextDisposedException : Exception()

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -349,17 +349,14 @@ class MainActivity : FlutterFragmentActivity() {
             logger.debug("Exception while getting device info and scp keys: ", e)
             contextManager?.onError(e)
             if (device is NfcYubiKeyDevice) {
-                logger.debug("Setting NFC state to failure")
                 appMethodChannel.nfcStateChanged(NfcState.FAILURE)
             }
 
-            // do not clear the device info when IOException's occur,
+            // do not clear deviceInfo on IOExceptions,
             // this allows for retries of failed actions
             if (e !is IOException) {
                 logger.debug("Resetting device info")
                 deviceManager.setDeviceInfo(null)
-            } else {
-                logger.debug("Keeping device info")
             }
 
             return

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoConnectionHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoConnectionHelper.kt
@@ -42,14 +42,6 @@ class FidoConnectionHelper(private val deviceManager: DeviceManager) {
         return requestHandled
     }
 
-    fun failPending(e: Exception) {
-        pendingAction?.let { action ->
-            logger.error("Failing pending action with {}", e.message)
-            action.invoke(Result.failure(e))
-            pendingAction = null
-        }
-    }
-
     fun cancelPending() {
         pendingAction?.let { action ->
             action.invoke(Result.failure(CancellationException()))
@@ -80,7 +72,7 @@ class FidoConnectionHelper(private val deviceManager: DeviceManager) {
         block(YubiKitFidoSession(it))
     }.also {
         if (updateDeviceInfo) {
-            deviceManager.setDeviceInfo(getDeviceInfo(device))
+            deviceManager.setDeviceInfo(runCatching { getDeviceInfo(device) }.getOrNull())
         }
     }
 

--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/data/Session.kt
@@ -41,6 +41,19 @@ data class Options(
         infoData.getOptionsBoolean("ep"),
     )
 
+    fun sameDevice(other: Options) : Boolean {
+        if (this === other) return true
+
+        if (clientPin != other.clientPin) return false
+        if (credMgmt != other.credMgmt) return false
+        if (credentialMgmtPreview != other.credentialMgmtPreview) return false
+        if (bioEnroll != other.bioEnroll) return false
+        // alwaysUv may differ
+        // ep may differ
+
+        return true
+    }
+
     companion object {
         private fun InfoData.getOptionsBoolean(
             key: String
@@ -66,6 +79,21 @@ data class SessionInfo(
         infoData.forcePinChange,
         infoData.remainingDiscoverableCredentials
     )
+
+    // this is a more permissive comparison, which does not take in an account properties,
+    // which might change by using the FIDO authenticator
+    fun sameDevice(other: SessionInfo?): Boolean {
+        if (other == null) return false
+        if (this === other) return true
+
+        if (!options.sameDevice(other.options)) return false
+        if (!aaguid.contentEquals(other.aaguid)) return false
+        // minPinLength may differ
+        // forcePinChange may differ
+        // remainingDiscoverableCredentials may differ
+
+        return true
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/DeviceInfoHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/DeviceInfoHelper.kt
@@ -47,17 +47,17 @@ class DeviceInfoHelper {
         private val restrictedNfcBytes =
             byteArrayOf(0x00, 0x1F, 0xD1.toByte(), 0x01, 0x1b, 0x55, 0x04) + uri
 
-        suspend fun getDeviceInfo(device: YubiKeyDevice): Info? {
+        suspend fun getDeviceInfo(device: YubiKeyDevice): Info {
             SessionVersionOverride.set(null)
             var deviceInfo = readDeviceInfo(device)
-            if (deviceInfo?.version?.major == 0.toByte()) {
+            if (deviceInfo.version.major == 0.toByte()) {
                 SessionVersionOverride.set(Version(5, 7, 2))
                 deviceInfo = readDeviceInfo(device)
             }
             return deviceInfo
         }
 
-        private suspend fun readDeviceInfo(device: YubiKeyDevice): Info? {
+        private suspend fun readDeviceInfo(device: YubiKeyDevice): Info {
             val pid = (device as? UsbYubiKeyDevice)?.pid
 
             val deviceInfo = runCatching {
@@ -106,8 +106,8 @@ class DeviceInfoHelper {
                         }
                 } catch (e: Exception) {
                     // no smart card connectivity
-                    logger.error("Failure getting device info", e)
-                    return null
+                    logger.error("Failure getting device info: ", e)
+                    throw e
                 }
             }
 

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -365,9 +365,8 @@ class _FidoCredentialsNotifier extends FidoCredentialsNotifier {
       var decodedException = pe.decode();
       if (decodedException is CancellationException) {
         _log.debug('User cancelled delete credential FIDO operation');
-      } else {
-        throw decodedException;
       }
+      throw decodedException;
     }
   }
 }

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -63,7 +63,8 @@ class MainPage extends ConsumerWidget {
       final prevSerial =
           prev?.hasValue == true ? prev?.value?.info.serial : null;
       if ((serial != null && serial == prevSerial) ||
-          (next.hasValue && (prev != null && prev.isLoading))) {
+          (next.hasValue && (prev != null && prev.isLoading)) ||
+          next.isLoading) {
         return;
       }
 

--- a/lib/fido/views/delete_credential_dialog.dart
+++ b/lib/fido/views/delete_credential_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2024 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/fido/views/delete_credential_dialog.dart
+++ b/lib/fido/views/delete_credential_dialog.dart
@@ -23,6 +23,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../exception/cancellation_exception.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../models.dart';
 import '../state.dart';
@@ -57,15 +58,19 @@ class DeleteCredentialDialog extends ConsumerWidget {
       actions: [
         TextButton(
           onPressed: () async {
-            await ref
-                .read(credentialProvider(devicePath).notifier)
-                .deleteCredential(credential);
-            await ref.read(withContextProvider)(
-              (context) async {
-                Navigator.of(context).pop(true);
-                showMessage(context, l10n.s_passkey_deleted);
-              },
-            );
+            try {
+              await ref
+                  .read(credentialProvider(devicePath).notifier)
+                  .deleteCredential(credential);
+              await ref.read(withContextProvider)(
+                (context) async {
+                  Navigator.of(context).pop(true);
+                  showMessage(context, l10n.s_passkey_deleted);
+                },
+              );
+            } on CancellationException catch (_) {
+              // ignored
+            }
           },
           child: Text(l10n.s_delete),
         ),

--- a/lib/oath/views/rename_account_dialog.dart
+++ b/lib/oath/views/rename_account_dialog.dart
@@ -90,7 +90,7 @@ class RenameAccountDialog extends ConsumerStatefulWidget {
               context, AppLocalizations.of(context)!.s_account_renamed));
           return renamed;
         } on CancellationException catch (_) {
-          // ignored
+          return CancellationException();
         } catch (e) {
           _log.error('Failed to rename account', e);
           final String errorMessage;
@@ -140,7 +140,9 @@ class _RenameAccountDialogState extends ConsumerState<RenameAccountDialog> {
     final nav = Navigator.of(context);
     final renamed =
         await widget.rename(_issuer.isNotEmpty ? _issuer : null, _name);
-    nav.pop(renamed);
+    if (renamed is! CancellationException) {
+      nav.pop(renamed);
+    }
   }
 
   @override


### PR DESCRIPTION
Every NFC scan begins with getting device info and SCP keys. If any of these operations fails, we cannot continue any (possibly pending) action.

For better user experience, if the failure is an IOException (such as TagLost), the current information of the OATH/FIDO sessions will be preserved so that the action can be retried. 

The failure also causes following:
- the NFC Overlay will be closed with a failure
- any pending action will be failed with CancellationException

In flutter we have to handle Cancellations by ignoring it, to avoid popping of the navigator stack - this PR adds fixes to places where this was missing.

