### PR TITLE
Add icon for F-Droid 

### DIFF
--- a/android/app/src/main/play/listings/en-US/graphics/icon/icon.png
+++ b/android/app/src/main/play/listings/en-US/graphics/icon/icon.png
@@ -1,0 +1,1 @@
+../../../../../res/mipmap-xxxhdpi/ic_launcher.png

--- a/fastlane/metadata/android/en-US/images/icon.png
+++ b/fastlane/metadata/android/en-US/images/icon.png
@@ -1,0 +1,1 @@
+../../../../../android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png

--- a/fastlane/metadata/android/en-US/images/icon.png
+++ b/fastlane/metadata/android/en-US/images/icon.png
@@ -1,1 +1,0 @@
-../../../../../android/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png


### PR DESCRIPTION
Adds an icon file which will be used by F-Droid.

The used directory structure is [Triple-T](https://f-droid.org/en/docs/All_About_Descriptions_Graphics_and_Screenshots/#triple-t-structure). 