### PR TITLE
Use selected APP_LOCALE in native code

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/AppPreferences.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/AppPreferences.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ class AppPreferences(context: Context) {
         const val PREF_USB_OPEN_APP = "flutter.prefUsbOpenApp"
 
         const val PREF_CLIP_KBD_LAYOUT = "flutter.prefClipKbdLayout"
+        const val PREF_APP_LOCALE = "flutter.APP_LOCALE"
         const val DEFAULT_CLIP_KBD_LAYOUT = "US"
     }
 
@@ -65,6 +66,9 @@ class AppPreferences(context: Context) {
 
     val openAppOnUsb: Boolean
         get() = prefs.getBoolean(PREF_USB_OPEN_APP, false)
+
+    val appLocale: String
+        get() = prefs.getString(PREF_APP_LOCALE, "en")!!
 
     fun registerListener(listener: OnSharedPreferenceChangeListener) {
         logger.debug("registering change listener")


### PR DESCRIPTION
This PR extends language localization to the native code layer, handling scenarios where Flutter isn't yet initialized. This specifically affects OTP/password NDEF action notifications on older platforms, where we now explicitly set the context's language to match the user's `APP_LOCALE` preference, ensuring consistent localization throughout the app lifecycle.