### PR TITLE
Improve reset over NFC

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoResetHelper.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/fido/FidoResetHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lib/android/fido/state.dart
+++ b/lib/android/fido/state.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,12 @@ class _FidoStateNotifier extends FidoStateNotifier {
         await fido.invoke('reset');
         await controller.sink.close();
         ref.invalidateSelf();
+      } on PlatformException catch (pe) {
+        final decoded = pe.decode();
+        if (decoded is! CancellationException) {
+          _log.debug('PlatformException during reset: \'$pe\'');
+        }
+        controller.sink.addError(decoded);
       } catch (e) {
         _log.debug('Error during reset: \'$e\'');
         controller.sink.addError(e);

--- a/lib/android/oath/state.dart
+++ b/lib/android/oath/state.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,12 @@ class _AndroidOathStateNotifier extends OathStateNotifier {
     try {
       await oath.invoke('reset');
     } catch (e) {
+      if (e is PlatformException) {
+        final decoded = e.decode();
+        if (decoded is CancellationException) {
+          throw decoded;
+        }
+      }
       _log.debug('Calling reset failed with exception: $e');
     }
   }


### PR DESCRIPTION
Improves user experience when performing OATH and FIDO reset over NFC on Android.

- adds support for proper NFC overlay(and functionality) cancellation
- closes the Reset view after operation completes
