### PR TITLE
Updates to generating localized messages

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Run flutter tests
         run: |
+          flutter gen-l10n
           flutter test
           flutter analyze
         working-directory: ./app

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -39,8 +39,10 @@ jobs:
       - name: Run flutter tests
         run: |
           flutter gen-l10n
+          export PATH=$PATH:$HOME/.local/bin  # Needed to ensure pip/pre-commit on PATH
+          pipx install pre-commit
+          pre-commit run --all-files
           flutter test
-          flutter analyze
         working-directory: ./app
 
       - name: Build the App

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,10 +38,11 @@ jobs:
 
       - name: Run flutter tests
         run: |
-          flutter gen-l10n
           export PATH=$PATH:$HOME/.local/bin  # Needed to ensure pip/pre-commit on PATH
           pipx install pre-commit
-          pre-commit run --all-files
+          pre-commit run flutter-l10n-gen --all-files
+          pre-commit run dart-format --all-files
+          pre-commit run flutter-analyze --all-files
           flutter test
         working-directory: ./app
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -90,9 +90,9 @@ jobs:
         SKIP: ${{ steps.cache-helper.outputs.cache-hit == 'true' && 'mypy,flake8,black,bandit' || ''}}
       run: |
         export PATH=$PATH:$HOME/.local/bin  # Needed to ensure pip/pre-commit on PATH
+        flutter gen-l10n
         pipx install pre-commit
         pre-commit run --all-files
-        flutter gen-l10n
         flutter test
 
     - name: Build the app

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -90,7 +90,6 @@ jobs:
         SKIP: ${{ steps.cache-helper.outputs.cache-hit == 'true' && 'mypy,flake8,black,bandit' || ''}}
       run: |
         export PATH=$PATH:$HOME/.local/bin  # Needed to ensure pip/pre-commit on PATH
-        flutter gen-l10n
         pipx install pre-commit
         pre-commit run --all-files
         flutter test

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -92,6 +92,7 @@ jobs:
         export PATH=$PATH:$HOME/.local/bin  # Needed to ensure pip/pre-commit on PATH
         pipx install pre-commit
         pre-commit run --all-files
+        flutter gen-l10n
         flutter test
 
     - name: Build the app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,9 +61,9 @@ jobs:
       env:
         SKIP: ${{ steps.cache-helper.outputs.cache-hit == 'true' && 'mypy,flake8,black,bandit' || ''}}
       run: |
+        flutter gen-l10n
         pip install pre-commit
         pre-commit run --all-files
-        flutter gen-l10n
         flutter test
 
     - name: Build the app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,6 +63,7 @@ jobs:
       run: |
         pip install pre-commit
         pre-commit run --all-files
+        flutter gen-l10n
         flutter test
 
     - name: Build the app

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,7 +61,6 @@ jobs:
       env:
         SKIP: ${{ steps.cache-helper.outputs.cache-hit == 'true' && 'mypy,flake8,black,bandit' || ''}}
       run: |
-        flutter gen-l10n
         pip install pre-commit
         pre-commit run --all-files
         flutter test

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           pip install pre-commit
           pre-commit run --all-files
+          flutter gen-l10n
           flutter test
 
       - name: Build the app

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,9 +53,9 @@ jobs:
         env:
           SKIP: ${{ steps.cache-helper.outputs.cache-hit == 'true' && 'mypy,flake8,black,bandit' || ''}}
         run: |
+          flutter gen-l10n
           pip install pre-commit
           pre-commit run --all-files
-          flutter gen-l10n
           flutter test
 
       - name: Build the app

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,6 @@ jobs:
         env:
           SKIP: ${{ steps.cache-helper.outputs.cache-hit == 'true' && 'mypy,flake8,black,bandit' || ''}}
         run: |
-          flutter gen-l10n
           pip install pre-commit
           pre-commit run --all-files
           flutter test

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ app.*.map.json
 
 # Report of untranslated strings
 /missing_l10n_strings.json
+
+# Generated source files
+/lib/generated

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,11 +5,18 @@ repos:
   hooks:
     - id: dart-format
       files: \.dart$
+      exclude: lib/generated
       require_serial: true
     - id: flutter-analyze
       require_serial: true
 - repo: local
   hooks:
+    - id: flutter-l10n-gen
+      name: generate-l10n
+      language: system
+      entry: flutter gen-l10n
+      pass_filenames: false
+      require_serial: true
     - id: arb-reformatter
       name: reformat-strings
       files: \.arb$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 repos:
 # Flutter
+- repo: local
+  hooks:
+    - id: flutter-l10n-gen
+      name: generate-l10n
+      language: system
+      entry: flutter gen-l10n
+      pass_filenames: false
+      require_serial: true
 - repo: https://github.com/dluksza/flutter-analyze-pre-commit
   rev: "4afcaa82fc368d40d486256bf4edba329bf667bb"
   hooks:
@@ -12,12 +20,6 @@ repos:
       require_serial: true
 - repo: local
   hooks:
-    - id: flutter-l10n-gen
-      name: generate-l10n
-      language: system
-      entry: flutter gen-l10n
-      pass_filenames: false
-      require_serial: true
     - id: arb-reformatter
       name: reformat-strings
       files: \.arb$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
       exclude: lib/generated
       require_serial: true
     - id: flutter-analyze
+      exclude: lib/generated
       require_serial: true
 - repo: local
   hooks:

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,4 +1,6 @@
+synthetic-package: false
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
-output-localization-file: app_localizations.dart
+output-dir: lib/generated/l10n
+nullable-getter: false
 untranslated-messages-file: missing_l10n_strings.json

--- a/lib/about_page.dart
+++ b/lib/about_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -31,6 +30,7 @@ import 'app/state.dart';
 import 'app/views/keys.dart';
 import 'core/state.dart';
 import 'desktop/state.dart';
+import 'generated/l10n/app_localizations.dart';
 import 'version.dart';
 import 'widgets/choice_filter_chip.dart';
 import 'widgets/responsive_dialog.dart';
@@ -42,7 +42,7 @@ class AboutPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return ResponsiveDialog(
       title: Text(l10n.s_about),
       builder: (context, _) => Padding(
@@ -207,7 +207,7 @@ class LoggingPanel extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final logLevel = ref.watch(logLevelProvider);
     return Wrap(
       alignment: WrapAlignment.center,

--- a/lib/android/models.dart
+++ b/lib/android/models.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import '../generated/l10n/app_localizations.dart';
 
 enum NfcTapAction {
   noAction,

--- a/lib/android/oath/otp_auth_link_handler.dart
+++ b/lib/android/oath/otp_auth_link_handler.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../oath/views/utils.dart';
 
 const _appLinkMethodsChannel = MethodChannel('app.link.methods');
@@ -30,7 +30,7 @@ void setupOtpAuthLinkHandler(BuildContext context) {
     switch (call.method) {
       case 'handleOtpAuthLink':
         Navigator.popUntil(context, ModalRoute.withName('/'));
-        final l10n = AppLocalizations.of(context)!;
+        final l10n = AppLocalizations.of(context);
         final uri = args['link'];
         await handleUri(context, null, uri, null, null, l10n);
         break;

--- a/lib/android/oath/state.dart
+++ b/lib/android/oath/state.dart
@@ -19,7 +19,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -33,6 +33,7 @@ import '../../exception/apdu_exception.dart';
 import '../../exception/cancellation_exception.dart';
 import '../../exception/no_data_exception.dart';
 import '../../exception/platform_exception_decoder.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../oath/models.dart';
 import '../../oath/state.dart';
 import '../../widgets/toast.dart';
@@ -265,7 +266,7 @@ class _AndroidCredentialListNotifier extends OathCredentialListNotifier {
       void triggerTouchPrompt() async {
         controller = await _withContext(
           (context) async {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = AppLocalizations.of(context);
             return promptUserInteraction(
               context,
               icon: const Icon(Symbols.touch_app),

--- a/lib/android/qr_scanner/qr_scanner_permissions_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_permissions_view.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import 'qr_scanner_provider.dart';
 import 'qr_scanner_scan_status.dart';
 import 'qr_scanner_widgets.dart';
@@ -34,7 +34,7 @@ class QRScannerPermissionsUI extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return SafeArea(
       child: Padding(

--- a/lib/android/qr_scanner/qr_scanner_provider.dart
+++ b/lib/android/qr_scanner/qr_scanner_provider.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,13 @@ import 'dart:convert';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:qrscanner_zxing/qrscanner_zxing_method_channel.dart';
 
 import '../../app/message.dart';
 import '../../app/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../oath/views/add_account_page.dart';
 import '../../oath/views/utils.dart';
 import '../../theme.dart';

--- a/lib/android/qr_scanner/qr_scanner_ui_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_ui_view.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023   Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../keys.dart' as keys;
 import 'qr_scanner_provider.dart';
 import 'qr_scanner_scan_status.dart';
@@ -35,7 +35,7 @@ class QRScannerUI extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return Stack(
       fit: StackFit.expand,

--- a/lib/android/qr_scanner/qr_scanner_view.dart
+++ b/lib/android/qr_scanner/qr_scanner_view.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:qrscanner_zxing/qrscanner_zxing_view.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../oath/models.dart';
 import '../app_methods.dart';
 import 'qr_scanner_overlay_view.dart';
@@ -102,7 +103,7 @@ class _QrScannerViewState extends State<QrScannerView> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final screenSize = MediaQuery.of(context).size;
     final overlayWidgetKey = GlobalKey();
     return Scaffold(

--- a/lib/android/views/settings_views.dart
+++ b/lib/android/views/settings_views.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
 import '../state.dart';
@@ -30,7 +31,7 @@ class NfcTapActionView extends ConsumerWidget {
       await showDialog<NfcTapAction>(
           context: context,
           builder: (BuildContext context) {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = AppLocalizations.of(context);
             return SimpleDialog(
               title: Text(l10n.l_on_yk_nfc_tap),
               children: NfcTapAction.values
@@ -51,7 +52,7 @@ class NfcTapActionView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final tapAction = ref.watch(androidNfcTapActionProvider);
     return ListTile(
       title: Text(l10n.l_on_yk_nfc_tap),
@@ -77,7 +78,7 @@ class NfcKbdLayoutView extends ConsumerWidget {
       await showDialog<String>(
           context: context,
           builder: (BuildContext context) {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = AppLocalizations.of(context);
             return SimpleDialog(
               title: Text(l10n.s_choose_kbd_layout),
               children: available
@@ -98,7 +99,7 @@ class NfcKbdLayoutView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final tapAction = ref.watch(androidNfcTapActionProvider);
     final clipKbdLayout = ref.watch(androidNfcKbdLayoutProvider);
     return ListTile(
@@ -128,7 +129,7 @@ class NfcBypassTouchView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final nfcBypassTouch = ref.watch(androidNfcBypassTouchProvider);
     return SwitchListTile(
         title: Text(l10n.l_bypass_touch_requirement),
@@ -150,7 +151,7 @@ class NfcSilenceSoundsView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final nfcSilenceSounds = ref.watch(androidNfcSilenceSoundsProvider);
     return SwitchListTile(
         title: Text(l10n.s_silence_nfc_sounds),
@@ -172,7 +173,7 @@ class UsbOpenAppView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final usbOpenApp = ref.watch(androidUsbLaunchAppProvider);
     return SwitchListTile(
         title: Text(l10n.l_launch_app_on_usb),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -15,10 +15,11 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../generated/l10n/app_localizations.dart';
 import '../theme.dart';
 import 'logging.dart';
 import 'shortcuts.dart';

--- a/lib/app/icon_provider/icon_pack_dialog.dart
+++ b/lib/app/icon_provider/icon_pack_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/file_drop_overlay.dart';
 import '../../widgets/file_drop_target.dart';
 import '../../widgets/info_popup_button.dart';
@@ -39,7 +40,7 @@ class IconPackDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final iconPack = ref.watch(iconPackProvider);
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
@@ -144,7 +145,7 @@ class _IconPackDescription extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     return Row(
         mainAxisSize: MainAxisSize.max,
@@ -207,7 +208,7 @@ class _ImportActionChip extends ConsumerWidget {
   }
 
   void _importAction(BuildContext context, WidgetRef ref) async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final result = await FilePicker.platform.pickFiles(
         allowedExtensions: ['zip'],
         type: FileType.custom,

--- a/lib/app/icon_provider/icon_pack_manager.dart
+++ b/lib/app/icon_provider/icon_pack_manager.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,14 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:archive/archive.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../logging.dart';
 import 'icon_cache.dart';
 import 'icon_pack.dart';

--- a/lib/app/models.dart
+++ b/lib/app/models.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../management/models.dart';
 import '../core/models.dart';
 import '../core/state.dart';
+import '../generated/l10n/app_localizations.dart';
 import 'color_extension.dart';
 
 part 'models.freezed.dart';

--- a/lib/app/state.dart
+++ b/lib/app/state.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022,2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ import 'dart:convert';
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../core/state.dart';
+import '../generated/l10n/app_localizations.dart';
 import '../theme.dart';
 import 'color_extension.dart';
 import 'features.dart' as features;

--- a/lib/app/views/app_failure_page.dart
+++ b/lib/app/views/app_failure_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,14 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../core/state.dart';
 import '../../desktop/models.dart';
 import '../../desktop/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../state.dart';
 import 'elevate_fido_buttons.dart';
@@ -35,7 +36,7 @@ class AppFailurePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final reason = cause;
 
     Widget? graphic = Icon(Symbols.error,

--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,13 @@ import 'dart:io';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/delayed_visibility.dart';
 import '../../widgets/file_drop_target.dart';
@@ -516,7 +517,7 @@ class _AppPageState extends ConsumerState<AppPage> {
 
   Scaffold _buildScaffold(
       BuildContext context, bool hasDrawer, bool hasRail, bool hasManage) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final fullyExpanded = !hasDrawer && hasRail && hasManage;
     final showNavigation = ref.watch(_navigationVisibilityProvider);
     final showDetailView = ref.watch(_detailViewVisibilityProvider);
@@ -784,7 +785,7 @@ class CapabilityBadge extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final text = Text(capability.getDisplayName(l10n));
     final (fipsCapable, fipsApproved) = ref

--- a/lib/app/views/device_error_screen.dart
+++ b/lib/app/views/device_error_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../core/models.dart';
 import '../../core/state.dart';
 import '../../desktop/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../home/views/home_message_page.dart';
 import '../models.dart';
 import '../state.dart';
@@ -35,7 +35,7 @@ class DeviceErrorScreen extends ConsumerWidget {
   const DeviceErrorScreen(this.node, {this.error, super.key});
 
   Widget _buildUsbPid(BuildContext context, WidgetRef ref, UsbPid pid) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     if (pid.usbInterfaces == UsbInterface.fido.value) {
       if (Platform.isWindows &&
           !ref.watch(rpcStateProvider.select((state) => state.isAdmin))) {
@@ -65,7 +65,7 @@ class DeviceErrorScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return node.map(
       usbYubiKey: (node) => _buildUsbPid(context, ref, node.pid),
       nfcReader: (node) => switch (error) {

--- a/lib/app/views/device_picker.dart
+++ b/lib/app/views/device_picker.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../android/state.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../models.dart';
 import '../state.dart';
@@ -36,7 +37,7 @@ class DevicePickerContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hidden = ref.watch(hiddenDevicesProvider);
     final devices = ref
         .watch(attachedDevicesProvider)
@@ -114,7 +115,7 @@ class DevicePickerContent extends ConsumerWidget {
 }
 
 String _getDeviceInfoString(BuildContext context, DeviceInfo info) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   final serial = info.serial;
   return [
     if (serial != null) l10n.s_sn_serial(serial),
@@ -127,7 +128,7 @@ String _getDeviceInfoString(BuildContext context, DeviceInfo info) {
 
 List<String> _getDeviceStrings(
     BuildContext context, DeviceNode node, AsyncValue<YubiKeyData> data) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   final messages = data.whenOrNull(
         data: (data) => [data.name, _getDeviceInfoString(context, data.info)],
         error: (error, _) => switch (error) {
@@ -320,7 +321,7 @@ class _DeviceRowState extends ConsumerState<_DeviceRow> {
 
   List<PopupMenuItem> _getMenuItems(
       BuildContext context, WidgetRef ref, DeviceNode? node) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hidden = ref.watch(hiddenDevicesProvider);
 
     return [
@@ -361,7 +362,7 @@ _DeviceRow _buildDeviceRow(
   DeviceInfo? info,
   bool extended,
 ) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   final subtitle = node.when(
     usbYubiKey: (_, __, ___, info) => info == null
         ? l10n.s_yk_inaccessible

--- a/lib/app/views/elevate_fido_buttons.dart
+++ b/lib/app/views/elevate_fido_buttons.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,12 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../desktop/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../message.dart';
 import '../state.dart';
 
@@ -30,7 +31,7 @@ class ElevateFidoButtons extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return Wrap(
       spacing: 8,
       runSpacing: 4,

--- a/lib/app/views/fs_dialog.dart
+++ b/lib/app/views/fs_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import 'keys.dart' as keys;
 
 class FsDialog extends StatelessWidget {
@@ -26,7 +27,7 @@ class FsDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return Dialog.fullscreen(
       backgroundColor:
           Theme.of(context).colorScheme.surface.withValues(alpha: 0.7),

--- a/lib/app/views/main_page.dart
+++ b/lib/app/views/main_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -25,6 +24,7 @@ import '../../core/state.dart';
 import '../../fido/views/fingerprints_screen.dart';
 import '../../fido/views/passkeys_screen.dart';
 import '../../fido/views/webauthn_page.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../home/views/home_message_page.dart';
 import '../../home/views/home_screen.dart';
 import '../../oath/views/oath_screen.dart';
@@ -40,7 +40,7 @@ class MainPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     ref.listen<Function(BuildContext)?>(
       contextConsumer,
       (previous, next) {

--- a/lib/app/views/message_page_not_initialized.dart
+++ b/lib/app/views/message_page_not_initialized.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../android/app_methods.dart';
 import '../../android/state.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../state.dart';
 import 'message_page.dart';
@@ -36,7 +37,7 @@ class MessagePageNotInitialized extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final noKeyImage = Image.asset(
       'assets/graphics/no-key.png',
       filterQuality: FilterQuality.medium,

--- a/lib/app/views/navigation.dart
+++ b/lib/app/views/navigation.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../models.dart';
 import '../state.dart';
 import 'device_picker.dart';
@@ -115,7 +116,7 @@ class NavigationContent extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final supportedSections = ref.watch(supportedSectionsProvider);
     final data = ref.watch(currentDeviceDataProvider).valueOrNull;
 

--- a/lib/app/views/reset_dialog.dart
+++ b/lib/app/views/reset_dialog.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -31,6 +31,7 @@ import '../../desktop/state.dart';
 import '../../exception/cancellation_exception.dart';
 import '../../fido/models.dart';
 import '../../fido/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../management/state.dart';
 import '../../oath/state.dart';
@@ -90,7 +91,7 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
   }
 
   String _getMessage() {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final nfc = widget.data.node.transport == Transport.nfc;
     if (_currentStep == _totalSteps) {
       return l10n.l_fido_app_reset;
@@ -117,7 +118,7 @@ class _ResetDialogState extends ConsumerState<ResetDialog> {
     final isBio = [FormFactor.usbABio, FormFactor.usbCBio]
         .contains(widget.data.info.formFactor);
     final globalReset = isBio && (enabled & Capability.piv.value) != 0;
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final usbTransport = widget.data.node.transport == Transport.usb;
 
     double progress = _currentStep == -1 ? 0.0 : _currentStep / (_totalSteps);

--- a/lib/app/views/settings_page.dart
+++ b/lib/app/views/settings_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../android/state.dart';
 import '../../android/views/settings_views.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/list_title.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../icon_provider/icon_pack_dialog.dart';
@@ -59,7 +60,7 @@ class _ThemeModeView extends ConsumerWidget {
       await showDialog<ThemeMode>(
           context: context,
           builder: (BuildContext context) {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = AppLocalizations.of(context);
             return SimpleDialog(
               title: Text(l10n.s_choose_app_theme),
               children: supportedThemes
@@ -80,7 +81,7 @@ class _ThemeModeView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final themeMode = ref.watch(themeModeProvider);
     return ListTile(
       title: Text(l10n.s_app_theme),
@@ -110,7 +111,7 @@ class _LanguageView extends ConsumerWidget {
       await showDialog<Locale>(
           context: context,
           builder: (context) {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = AppLocalizations.of(context);
             final theme = Theme.of(context);
             final textTheme = theme.textTheme;
             final colorScheme = theme.colorScheme;
@@ -151,7 +152,7 @@ class _LanguageView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final currentLocale = ref.watch(currentLocaleProvider);
     return ListTile(
       title: Text(l10n.s_language),
@@ -173,7 +174,7 @@ class _IconsView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return ListTile(
       title: Text(l10n.s_custom_icons),
       subtitle: Text(l10n.l_set_icons_for_accounts),
@@ -198,7 +199,7 @@ class _ToggleReadersDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final colorScheme = theme.colorScheme;
@@ -279,7 +280,7 @@ class _ToggleReadersView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final nfcDevices = ref
         .watch(attachedDevicesProvider)
         .where((e) => e.transport == Transport.nfc);
@@ -305,7 +306,7 @@ class SettingsPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return ResponsiveDialog(
       title: Text(l10n.s_settings),

--- a/lib/desktop/init.dart
+++ b/lib/desktop/init.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import 'package:args/args.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:local_notifier/local_notifier.dart';
 import 'package:logging/logging.dart';
@@ -42,6 +42,7 @@ import '../app/views/main_page.dart';
 import '../app/views/message_page.dart';
 import '../core/state.dart';
 import '../fido/state.dart';
+import '../generated/l10n/app_localizations.dart';
 import '../management/state.dart';
 import '../oath/state.dart';
 import '../otp/state.dart';
@@ -397,7 +398,7 @@ class _HelperWaiterState extends ConsumerState<_HelperWaiter> {
   @override
   Widget build(BuildContext context) {
     if (slow) {
-      final l10n = AppLocalizations.of(context)!;
+      final l10n = AppLocalizations.of(context);
       return MessagePage(
         centered: true,
         graphic: const CircularProgressIndicator(),

--- a/lib/desktop/oath/state.dart
+++ b/lib/desktop/oath/state.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -28,6 +28,7 @@ import '../../app/logging.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/user_interaction.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../oath/models.dart';
 import '../../oath/state.dart';
@@ -275,7 +276,7 @@ class DesktopCredentialListNotifier extends OathCredentialListNotifier {
         if (signal.status == 'touch') {
           controller = await _withContext(
             (context) async {
-              final l10n = AppLocalizations.of(context)!;
+              final l10n = AppLocalizations.of(context);
               return promptUserInteraction(
                 context,
                 icon: const Icon(Symbols.touch_app),

--- a/lib/desktop/piv/state.dart
+++ b/lib/desktop/piv/state.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -28,6 +28,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/user_interaction.dart';
 import '../../core/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../piv/models.dart';
 import '../../piv/state.dart';
 import '../models.dart';
@@ -142,7 +143,7 @@ class _DesktopPivStateNotifier extends PivStateNotifier {
         if (signal.status == 'touch') {
           controller = await withContext(
             (context) async {
-              final l10n = AppLocalizations.of(context)!;
+              final l10n = AppLocalizations.of(context);
               return promptUserInteraction(
                 context,
                 icon: const Icon(Symbols.touch_app),
@@ -190,7 +191,7 @@ class _DesktopPivStateNotifier extends PivStateNotifier {
           if (signal.status == 'touch') {
             controller = await withContext(
               (context) async {
-                final l10n = AppLocalizations.of(context)!;
+                final l10n = AppLocalizations.of(context);
                 return promptUserInteraction(
                   context,
                   icon: const Icon(Symbols.touch_app),
@@ -372,7 +373,7 @@ class _DesktopPivSlotsNotifier extends PivSlotsNotifier {
         if (signal.status == 'touch') {
           controller = await withContext(
             (context) async {
-              final l10n = AppLocalizations.of(context)!;
+              final l10n = AppLocalizations.of(context);
               return promptUserInteraction(
                 context,
                 icon: const Icon(Symbols.touch_app),

--- a/lib/desktop/systray.dart
+++ b/lib/desktop/systray.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:local_notifier/local_notifier.dart';
 import 'package:logging/logging.dart';
@@ -31,6 +31,7 @@ import '../app/models.dart';
 import '../app/shortcuts.dart';
 import '../app/state.dart';
 import '../exception/cancellation_exception.dart';
+import '../generated/l10n/app_localizations.dart';
 import '../oath/models.dart';
 import '../oath/state.dart';
 import '../oath/views/utils.dart';

--- a/lib/error_page.dart
+++ b/lib/error_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import 'generated/l10n/app_localizations.dart';
 
 class ErrorPage extends StatelessWidget {
   final String error;
@@ -25,7 +26,7 @@ class ErrorPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(AppLocalizations.of(context)!.s_application_error),
+        title: Text(AppLocalizations.of(context).s_application_error),
       ),
       body: Center(
         child: Column(

--- a/lib/fido/views/actions.dart
+++ b/lib/fido/views/actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -24,6 +23,7 @@ import '../../app/models.dart';
 import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -35,6 +35,7 @@ class FidoActions extends ConsumerWidget {
   final DevicePath devicePath;
   final Map<Type, Action<Intent>> Function(BuildContext context)? actions;
   final Widget Function(BuildContext context) builder;
+
   const FidoActions(
       {super.key,
       required this.devicePath,

--- a/lib/fido/views/add_fingerprint_dialog.dart
+++ b/lib/fido/views/add_fingerprint_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -29,6 +28,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../desktop/models.dart';
 import '../../fido/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -39,6 +39,7 @@ final _log = Logger('fido.views.add_fingerprint_dialog');
 
 class AddFingerprintDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
+
   const AddFingerprintDialog(this.devicePath, {super.key});
 
   @override
@@ -126,7 +127,7 @@ class _AddFingerprintDialogState extends ConsumerState<AddFingerprintDialog>
 
       if (!mounted) return;
       Navigator.of(context).pop();
-      final l10n = AppLocalizations.of(context)!;
+      final l10n = AppLocalizations.of(context);
       final String errorMessage;
       // TODO: Make this cleaner than importing desktop specific RpcError.
       if (error is RpcError) {
@@ -149,7 +150,7 @@ class _AddFingerprintDialogState extends ConsumerState<AddFingerprintDialog>
   }
 
   String _getMessage() {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     if (_samples == 0) {
       return l10n.p_press_fingerprint_begin;
     }
@@ -161,7 +162,7 @@ class _AddFingerprintDialogState extends ConsumerState<AddFingerprintDialog>
   }
 
   void _submit() async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     try {
       await ref
           .read(fingerprintProvider(widget.devicePath).notifier)
@@ -187,7 +188,7 @@ class _AddFingerprintDialogState extends ConsumerState<AddFingerprintDialog>
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final progress = _samples == 0 ? 0.0 : _samples / (_samples + _remaining);
     return ResponsiveDialog(
       title: Text(l10n.s_add_fingerprint),

--- a/lib/fido/views/credential_dialog.dart
+++ b/lib/fido/views/credential_dialog.dart
@@ -1,5 +1,20 @@
+/*
+ * Copyright (C) 2023-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -8,6 +23,7 @@ import '../../app/state.dart';
 import '../../app/views/action_list.dart';
 import '../../app/views/fs_dialog.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../models.dart';
 import 'actions.dart';
@@ -15,6 +31,7 @@ import 'credential_info_view.dart';
 
 class CredentialDialog extends ConsumerWidget {
   final FidoCredential credential;
+
   const CredentialDialog(this.credential, {super.key});
 
   @override
@@ -27,7 +44,7 @@ class CredentialDialog extends ConsumerWidget {
       return const SizedBox();
     }
 
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
 
     return FidoActions(

--- a/lib/fido/views/credential_info_view.dart
+++ b/lib/fido/views/credential_info_view.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/info_table.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -29,7 +29,7 @@ class CredentialInfoTable extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final credential = this.credential;
     return InfoTable({

--- a/lib/fido/views/delete_credential_dialog.dart
+++ b/lib/fido/views/delete_credential_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 // ignore_for_file: sort_child_properties_last
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -25,6 +24,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../models.dart';
 import '../state.dart';
@@ -32,11 +32,12 @@ import '../state.dart';
 class DeleteCredentialDialog extends ConsumerWidget {
   final DevicePath devicePath;
   final FidoCredential credential;
+
   const DeleteCredentialDialog(this.devicePath, this.credential, {super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return BasicDialog(
       icon: Icon(Symbols.delete),

--- a/lib/fido/views/delete_fingerprint_dialog.dart
+++ b/lib/fido/views/delete_fingerprint_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,13 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../models.dart';
 import '../state.dart';
@@ -29,11 +29,12 @@ import '../state.dart';
 class DeleteFingerprintDialog extends ConsumerWidget {
   final DevicePath devicePath;
   final Fingerprint fingerprint;
+
   const DeleteFingerprintDialog(this.devicePath, this.fingerprint, {super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return BasicDialog(
       icon: Icon(Symbols.delete),

--- a/lib/fido/views/enterprise_attestation_dialog.dart
+++ b/lib/fido/views/enterprise_attestation_dialog.dart
@@ -1,11 +1,28 @@
+/*
+ * Copyright (C) 2022-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../state.dart';
 
@@ -15,7 +32,7 @@ class EnableEnterpriseAttestationDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return BasicDialog(
       icon: Icon(Symbols.local_police),
       title: Text(l10n.q_enable_ep_attestation),

--- a/lib/fido/views/fingerprint_dialog.dart
+++ b/lib/fido/views/fingerprint_dialog.dart
@@ -1,5 +1,21 @@
+/*
+ * Copyright (C) 2022-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -9,6 +25,7 @@ import '../../app/state.dart';
 import '../../app/views/action_list.dart';
 import '../../app/views/fs_dialog.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../models.dart';
 import 'actions.dart';
@@ -27,7 +44,7 @@ class FingerprintDialog extends ConsumerWidget {
       return const SizedBox();
     }
 
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     return FidoActions(
       devicePath: node.path,

--- a/lib/fido/views/fingerprints_screen.dart
+++ b/lib/fido/views/fingerprints_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -33,6 +33,7 @@ import '../../app/views/message_page_not_initialized.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
 import '../../exception/no_data_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/list_title.dart';
 import '../features.dart' as features;
@@ -60,7 +61,7 @@ class FingerprintsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final capabilities = _getCapabilities(deviceData);
     return ref.watch(fidoStateProvider(deviceData.node.path)).when(
         loading: () => AppPage(
@@ -109,7 +110,7 @@ class _FidoLockedPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     final hasActions = hasFeature(features.actions);
 
@@ -202,7 +203,7 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     final hasActions = hasFeature(features.actions);
     final capabilities = _getCapabilities(widget.deviceData);
@@ -375,7 +376,7 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
   Widget _buildLoadingPage(
           BuildContext context, List<Capability> capabilities) =>
       AppPage(
-        title: AppLocalizations.of(context)!.s_fingerprints,
+        title: AppLocalizations.of(context).s_fingerprints,
         capabilities: capabilities,
         centered: true,
         delayedContent: true,
@@ -411,7 +412,7 @@ class _FingerprintListItem extends StatelessWidget {
       tapIntent: isDesktop && !expanded ? null : OpenIntent(fingerprint),
       doubleTapIntent: isDesktop && !expanded ? OpenIntent(fingerprint) : null,
       buildPopupActions: (context) =>
-          buildFingerprintActions(fingerprint, AppLocalizations.of(context)!),
+          buildFingerprintActions(fingerprint, AppLocalizations.of(context)),
     );
   }
 }

--- a/lib/fido/views/key_actions.dart
+++ b/lib/fido/views/key_actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/views/action_list.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -46,7 +47,7 @@ Widget fingerprintsBuildActions(BuildContext context, DeviceNode node,
 
 Widget _fidoBuildActions(BuildContext context, DeviceNode node, FidoState state,
     [int? fingerprints]) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   final colors = Theme.of(context).buttonTheme.colorScheme ??
       Theme.of(context).colorScheme;
   final authBlocked = state.pinBlocked;

--- a/lib/fido/views/passkeys_screen.dart
+++ b/lib/fido/views/passkeys_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -35,6 +35,7 @@ import '../../app/views/message_page.dart';
 import '../../app/views/message_page_not_initialized.dart';
 import '../../core/state.dart';
 import '../../exception/no_data_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -58,7 +59,7 @@ class PasskeysScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return ref.watch(fidoStateProvider(deviceData.node.path)).when(
         loading: () => AppPage(
               title: l10n.s_passkeys,
@@ -107,7 +108,7 @@ class _FidoLockedPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     final hasActions = hasFeature(features.actions);
     final isBio = state.bioEnroll != null;
@@ -261,7 +262,7 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     final hasActions = hasFeature(features.actions);
     final noFingerprints = widget.state.bioEnroll == false;
@@ -641,7 +642,7 @@ class _FidoUnlockedPageState extends ConsumerState<_FidoUnlockedPage> {
   }
 
   Widget _buildLoadingPage(BuildContext context) => AppPage(
-        title: AppLocalizations.of(context)!.s_passkeys,
+        title: AppLocalizations.of(context).s_passkeys,
         capabilities: const [Capability.fido2],
         centered: true,
         delayedContent: true,
@@ -685,7 +686,7 @@ class _CredentialListItem extends StatelessWidget {
       tapIntent: isDesktop && !expanded ? null : OpenIntent(credential),
       doubleTapIntent: isDesktop && !expanded ? OpenIntent(credential) : null,
       buildPopupActions: (context) =>
-          buildCredentialActions(credential, AppLocalizations.of(context)!),
+          buildCredentialActions(credential, AppLocalizations.of(context)),
     );
   }
 }

--- a/lib/fido/views/pin_dialog.dart
+++ b/lib/fido/views/pin_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -26,6 +26,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../desktop/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -76,7 +77,7 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasPin = widget.state.hasPin;
     final minPinLength = widget.state.minPinLength;
     final currentMinPinLen = !hasPin
@@ -288,7 +289,7 @@ class _FidoPinDialogState extends ConsumerState<FidoPinDialog> {
     _newPinFocus.unfocus();
     _confirmPinFocus.unfocus();
 
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final oldPin = _currentPinController.text.isNotEmpty
         ? _currentPinController.text
         : null;

--- a/lib/fido/views/pin_entry_form.dart
+++ b/lib/fido/views/pin_entry_form.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,13 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../keys.dart';
@@ -90,7 +91,7 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
   }
 
   String? _getErrorText() {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     if (widget._state.pinBlocked || _retries == 0) {
       return l10n.l_pin_blocked_reset;
     }
@@ -105,7 +106,7 @@ class _PinEntryFormState extends ConsumerState<PinEntryForm> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final noFingerprints = widget._state.bioEnroll == false;
     final authBlocked = widget._state.pinBlocked;
     final pinRetries = widget._state.pinRetries;

--- a/lib/fido/views/rename_fingerprint_dialog.dart
+++ b/lib/fido/views/rename_fingerprint_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../desktop/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -59,7 +60,7 @@ class _RenameAccountDialogState extends ConsumerState<RenameFingerprintDialog> {
   }
 
   _submit() async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     try {
       final renamed = await ref
           .read(fingerprintProvider(widget.devicePath).notifier)
@@ -85,7 +86,7 @@ class _RenameAccountDialogState extends ConsumerState<RenameFingerprintDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final label = _labelController.text.trim();
     return ResponsiveDialog(
       title: Text(l10n.s_rename_fp),

--- a/lib/fido/views/webauthn_page.dart
+++ b/lib/fido/views/webauthn_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../../app/views/message_page.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 
 class WebAuthnScreen extends StatefulWidget {
@@ -33,7 +33,7 @@ class _WebAuthnScreenState extends State<WebAuthnScreen> {
   bool hide = true;
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     // We need this to avoid unwanted app switch animation
     if (hide) {

--- a/lib/home/views/home_message_page.dart
+++ b/lib/home/views/home_message_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,11 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/views/message_page.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import 'key_actions.dart';
 
@@ -57,7 +58,7 @@ class HomeMessagePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return MessagePage(
       title: l10n.s_home,

--- a/lib/home/views/home_screen.dart
+++ b/lib/home/views/home_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -29,6 +28,7 @@ import '../../app/state.dart';
 import '../../app/views/app_page.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/product_image.dart';
 import 'key_actions.dart';
@@ -36,6 +36,7 @@ import 'manage_label_dialog.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
   final YubiKeyData deviceData;
+
   const HomeScreen(this.deviceData, {super.key});
 
   @override
@@ -47,7 +48,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final serial = widget.deviceData.info.serial;
     final keyCustomization = ref.watch(keyCustomizationManagerProvider)[serial];
@@ -132,7 +133,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 class _FipsLegend extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return Opacity(
       opacity: 0.6,
       child: Wrap(
@@ -188,11 +189,12 @@ class _FipsLegend extends StatelessWidget {
 class _DeviceContent extends ConsumerWidget {
   final YubiKeyData deviceData;
   final KeyCustomization? initialCustomization;
+
   const _DeviceContent(this.deviceData, this.initialCustomization);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final name = deviceData.name;
     final serial = deviceData.info.serial;

--- a/lib/home/views/key_actions.dart
+++ b/lib/home/views/key_actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -29,11 +28,12 @@ import '../../app/views/keys.dart';
 import '../../app/views/reset_dialog.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/views/management_screen.dart';
 
 Widget homeBuildActions(
     BuildContext context, YubiKeyData? deviceData, WidgetRef ref) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   final hasFeature = ref.watch(featureProvider);
   final interfacesLocked = deviceData?.info.resetBlocked != 0;
   final managementAvailability = hasFeature(features.management) &&

--- a/lib/home/views/manage_label_dialog.dart
+++ b/lib/home/views/manage_label_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Yubico.
+ * Copyright (C) 2024-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/focus_utils.dart';
@@ -53,7 +53,7 @@ class _ManageLabelDialogState extends ConsumerState<ManageLabelDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final initialLabel = widget.initialCustomization.name;
     final trimmed = _labelController.text.trim();
     final label = trimmed.isEmpty ? null : trimmed;

--- a/lib/management/models.dart
+++ b/lib/management/models.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../core/models.dart';
+import '../generated/l10n/app_localizations.dart';
 
 part 'models.freezed.dart';
 part 'models.g.dart';

--- a/lib/management/views/management_screen.dart
+++ b/lib/management/views/management_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,14 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../core/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/delayed_visibility.dart';
@@ -50,7 +51,7 @@ class _CapabilityForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final keyPrefix = (type == _CapabilityType.usb)
         ? management_keys.usbCapabilityKeyPrefix
         : management_keys.nfcCapabilityKeyPrefix;
@@ -79,7 +80,7 @@ class _ModeForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
       ListTile(
         leading: const Icon(Symbols.usb),
@@ -117,7 +118,7 @@ class _CapabilitiesForm extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final usbCapabilities = supported[Transport.usb] ?? 0;
     final nfcCapabilities = supported[Transport.nfc] ?? 0;
 
@@ -201,7 +202,7 @@ class _ManagementScreenState extends ConsumerState<ManagementScreen> {
   }
 
   Widget _buildLockCodeForm(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -261,7 +262,7 @@ class _ManagementScreenState extends ConsumerState<ManagementScreen> {
   }
 
   void _submitCapabilitiesForm() async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final isLocked = widget.deviceData.info.isLocked;
 
     if (isLocked && !Format.hex.isValid(_lockCodeController.text)) {
@@ -339,7 +340,7 @@ class _ManagementScreenState extends ConsumerState<ManagementScreen> {
       );
 
   void _submitModeForm() async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     setState(() {
       _configuring = true;
     });
@@ -365,7 +366,7 @@ class _ManagementScreenState extends ConsumerState<ManagementScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     var canSave = false;
     bool hasConfig = false;
     final child = ref

--- a/lib/oath/models.dart
+++ b/lib/oath/models.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:base32/base32.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../core/models.dart';
+import '../generated/l10n/app_localizations.dart';
 
 part 'models.freezed.dart';
 part 'models.g.dart';

--- a/lib/oath/views/account_dialog.dart
+++ b/lib/oath/views/account_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/message.dart';
@@ -27,6 +27,7 @@ import '../../app/views/action_list.dart';
 import '../../app/views/fs_dialog.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/tooltip_if_truncated.dart';
 import '../features.dart' as features;
 import '../models.dart';
@@ -159,7 +160,7 @@ class AccountDialog extends ConsumerWidget {
                   ),
                   ActionListSection.fromMenuActions(
                     context,
-                    AppLocalizations.of(context)!.s_actions,
+                    AppLocalizations.of(context).s_actions,
                     actions: helper.buildActions(),
                   ),
                 ],

--- a/lib/oath/views/account_helper.dart
+++ b/lib/oath/views/account_helper.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -25,6 +25,7 @@ import '../../app/models.dart';
 import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/circle_timer.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
@@ -62,7 +63,7 @@ class AccountHelper {
               credential.touchRequired || credential.oathType == OathType.hotp;
           final ready = expired || credential.oathType == OathType.hotp;
           final pinned = _ref.watch(favoritesProvider).contains(credential.id);
-          final l10n = AppLocalizations.of(_context)!;
+          final l10n = AppLocalizations.of(_context);
           final canCopy = code != null && !expired;
 
           return [

--- a/lib/oath/views/account_list.dart
+++ b/lib/oath/views/account_list.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/flex_box.dart';
 import '../models.dart';
 import '../state.dart';
@@ -32,7 +33,7 @@ class AccountList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final labelStyle =
         theme.textTheme.bodyMedium?.copyWith(color: theme.colorScheme.primary);

--- a/lib/oath/views/actions.dart
+++ b/lib/oath/views/actions.dart
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/message.dart';
@@ -24,6 +24,7 @@ import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../core/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../models.dart';
 import '../state.dart';
@@ -92,7 +93,7 @@ class OathActions extends ConsumerWidget {
               if (!clipboard.platformGivesFeedback()) {
                 await withContext((context) async {
                   showMessage(context,
-                      AppLocalizations.of(context)!.l_code_copied_clipboard);
+                      AppLocalizations.of(context).l_code_copied_clipboard);
                 });
               }
             }

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -34,6 +34,7 @@ import '../../core/state.dart';
 import '../../desktop/models.dart';
 import '../../exception/apdu_exception.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -138,7 +139,7 @@ class _OathAddAccountPageState extends ConsumerState<OathAddAccountPage>
 
   Future<void> _doAddCredential(
       {DevicePath? devicePath, required Uri credUri}) async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     try {
       if (devicePath == null) {
         assert(isAndroid, 'devicePath is only optional for Android');
@@ -176,7 +177,7 @@ class _OathAddAccountPageState extends ConsumerState<OathAddAccountPage>
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final deviceNode = ref.watch(currentDeviceProvider);
     if (widget.devicePath != null && widget.devicePath != deviceNode?.path) {
       // If the dialog was started for a specific device and it was

--- a/lib/oath/views/add_multi_account_page.dart
+++ b/lib/oath/views/add_multi_account_page.dart
@@ -1,5 +1,21 @@
+/*
+ * Copyright (C) 2023-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -14,6 +30,7 @@ import '../../core/state.dart';
 import '../../desktop/models.dart';
 import '../../exception/apdu_exception.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../models.dart';
 import '../state.dart';
@@ -52,7 +69,7 @@ class _OathAddMultiAccountPageState
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     if (widget.devicePath != null) {
       _credentials = ref
@@ -265,7 +282,7 @@ class _OathAddMultiAccountPageState
 
   Future<void> _addCredentials(
       {required List<String> uris, required List<bool> touchRequired}) async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     try {
       await ref.read(addCredentialsToAnyProvider).call(uris, touchRequired);
       if (!mounted) return;
@@ -290,7 +307,7 @@ class _OathAddMultiAccountPageState
   }
 
   void accept(CredentialData cred, bool touch) async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final devicePath = widget.devicePath;
     try {
       if (devicePath == null) {

--- a/lib/oath/views/delete_account_dialog.dart
+++ b/lib/oath/views/delete_account_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -35,7 +36,7 @@ class DeleteAccountDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return BasicDialog(
       icon: Icon(Symbols.delete),
       title: Text(l10n.q_delete_account),

--- a/lib/oath/views/key_actions.dart
+++ b/lib/oath/views/key_actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023,2024 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/action_list.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
@@ -44,7 +45,7 @@ Widget oathBuildActions(
   WidgetRef ref, {
   int? used,
 }) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   final capacity = oathState.capacity;
   final (fipsCapable, fipsApproved) = ref
           .watch(currentDeviceDataProvider)

--- a/lib/oath/views/manage_password_dialog.dart
+++ b/lib/oath/views/manage_password_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -80,7 +81,7 @@ class _ManagePasswordDialogState extends ConsumerState<ManagePasswordDialog> {
         if (mounted) {
           await ref.read(withContextProvider)((context) async {
             Navigator.of(context).pop();
-            showMessage(context, AppLocalizations.of(context)!.s_password_set);
+            showMessage(context, AppLocalizations.of(context).s_password_set);
           });
         }
       } else {
@@ -102,7 +103,7 @@ class _ManagePasswordDialogState extends ConsumerState<ManagePasswordDialog> {
     final fipsCapable = ref.watch(currentDeviceDataProvider).maybeWhen(
         data: (data) => data.info.getFipsStatus(Capability.oath).$1,
         orElse: () => false);
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final isValid = !_currentIsWrong &&
         _newPassword.isNotEmpty &&
         _newPassword == _confirmPassword &&

--- a/lib/oath/views/oath_screen.dart
+++ b/lib/oath/views/oath_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -35,6 +35,7 @@ import '../../app/views/message_page.dart';
 import '../../app/views/message_page_not_initialized.dart';
 import '../../core/state.dart';
 import '../../exception/no_data_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -73,10 +74,10 @@ class OathScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return ref.watch(oathStateProvider(devicePath)).when(
         loading: () => MessagePage(
-              title: AppLocalizations.of(context)!.s_accounts,
+              title: AppLocalizations.of(context).s_accounts,
               capabilities: const [Capability.oath],
               centered: true,
               graphic: const CircularProgressIndicator(),
@@ -106,7 +107,7 @@ class _LockedView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final hasActions = ref.watch(featureProvider)(features.actions);
     return AppPage(
-      title: AppLocalizations.of(context)!.s_accounts,
+      title: AppLocalizations.of(context).s_accounts,
       capabilities: const [Capability.oath],
       keyActionsBuilder: hasActions
           ? (context) => oathBuildActions(context, devicePath, oathState, ref)
@@ -176,7 +177,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     // ONLY rebuild if the number of credentials changes.
     final numCreds = ref.watch(credentialListProvider(widget.devicePath)
         .select((value) => value?.length));
@@ -253,7 +254,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
 
     if (numCreds == null) {
       return AppPage(
-        title: AppLocalizations.of(context)!.s_accounts,
+        title: AppLocalizations.of(context).s_accounts,
         capabilities: const [Capability.oath],
         centered: true,
         delayedContent: true,
@@ -401,7 +402,7 @@ class _UnlockedViewState extends ConsumerState<_UnlockedView> {
                     ),
                     ActionListSection.fromMenuActions(
                       context,
-                      AppLocalizations.of(context)!.s_actions,
+                      AppLocalizations.of(context).s_actions,
                       actions: helper.buildActions(),
                     ),
                   ],

--- a/lib/oath/views/rename_account_dialog.dart
+++ b/lib/oath/views/rename_account_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -26,6 +26,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../desktop/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -120,8 +121,8 @@ class _RenameAccountDialogState extends ConsumerState<RenameAccountDialog> {
           .read(favoritesProvider.notifier)
           .renameCredential(renamed.id, renamed.id);
 
-      await withContext((context) async => showMessage(
-          context, AppLocalizations.of(context)!.s_account_renamed));
+      await withContext((context) async =>
+          showMessage(context, AppLocalizations.of(context).s_account_renamed));
 
       nav.pop(renamed);
     } on CancellationException catch (_) {
@@ -137,7 +138,7 @@ class _RenameAccountDialogState extends ConsumerState<RenameAccountDialog> {
       }
       await withContext((context) async => showMessage(
             context,
-            AppLocalizations.of(context)!.l_rename_account_failed(errorMessage),
+            AppLocalizations.of(context).l_rename_account_failed(errorMessage),
             duration: const Duration(seconds: 4),
           ));
     }
@@ -145,7 +146,7 @@ class _RenameAccountDialogState extends ConsumerState<RenameAccountDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final issuer = _issuerController.text.trim();
     final name = _nameController.text.trim();
 

--- a/lib/oath/views/unlock_form.dart
+++ b/lib/oath/views/unlock_form.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../keys.dart' as keys;
@@ -74,8 +75,7 @@ class _UnlockFormState extends ConsumerState<UnlockForm> {
           _passwordIsWrong = true;
         });
       } else if (_remember && !remembered) {
-        showMessage(
-            context, AppLocalizations.of(context)!.l_remember_pw_failed);
+        showMessage(context, AppLocalizations.of(context).l_remember_pw_failed);
       }
     } on CancellationException catch (_) {
       // ignored
@@ -84,7 +84,7 @@ class _UnlockFormState extends ConsumerState<UnlockForm> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final keystoreFailed = widget.keystore == KeystoreState.failed;
     return Column(
       children: [

--- a/lib/oath/views/utils.dart
+++ b/lib/oath/views/utils.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../android/qr_scanner/qr_scanner_provider.dart';
@@ -29,6 +29,7 @@ import '../../app/state.dart';
 import '../../core/state.dart';
 import '../../desktop/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/utf8_utils.dart';
 import '../keys.dart';
 import '../models.dart';
@@ -112,7 +113,7 @@ const maxQrFileSize = 5 * 1024 * 1024;
 
 Future<String?> handleQrFile(File file, BuildContext context,
     WithContext withContext, QrScanner qrScanner) async {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
   if (await file.length() > maxQrFileSize) {
     await withContext((context) async {
       showMessage(
@@ -156,7 +157,7 @@ Future<String?> handleQrFile(File file, BuildContext context,
 Future<void> addOathAccount(BuildContext context, WidgetRef ref,
     [DevicePath? devicePath, OathState? oathState]) async {
   if (isAndroid) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final withContext = ref.read(withContextProvider);
     final qrScanner = ref.read(qrScannerProvider);
     if (qrScanner != null) {

--- a/lib/otp/models.dart
+++ b/lib/otp/models.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../generated/l10n/app_localizations.dart';
 
 part 'models.freezed.dart';
 part 'models.g.dart';
@@ -26,6 +27,7 @@ enum SlotId {
 
   final String id;
   final int numberId;
+
   const SlotId(this.id, this.numberId);
 
   String getDisplayName(AppLocalizations l10n) {
@@ -42,6 +44,7 @@ enum SlotId {
 @freezed
 class OtpState with _$OtpState {
   const OtpState._();
+
   factory OtpState({
     required bool slot1Configured,
     required bool slot2Configured,

--- a/lib/otp/views/access_code_dialog.dart
+++ b/lib/otp/views/access_code_dialog.dart
@@ -1,10 +1,26 @@
+/*
+ * Copyright (C) 2024-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../core/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -14,6 +30,7 @@ class AccessCodeDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
   final OtpSlot otpSlot;
   final Future<void> Function(String accessCode) action;
+
   const AccessCodeDialog(
       {super.key,
       required this.devicePath,
@@ -40,7 +57,7 @@ class _AccessCodeDialogState extends ConsumerState<AccessCodeDialog> {
   }
 
   void _submit() async {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     if (!Format.hex.isValid(_accessCodeController.text)) {
       _accessCodeController.selection = TextSelection(
           baseOffset: 0, extentOffset: _accessCodeController.text.length);
@@ -69,7 +86,7 @@ class _AccessCodeDialogState extends ConsumerState<AccessCodeDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final accessCode = _accessCodeController.text.replaceAll(' ', '');
     final accessCodeLengthValid =
         accessCode.isNotEmpty && accessCode.length == accessCodeLength;

--- a/lib/otp/views/actions.dart
+++ b/lib/otp/views/actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -24,6 +23,7 @@ import '../../app/models.dart';
 import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -36,21 +36,25 @@ import 'delete_slot_dialog.dart';
 
 class ConfigureChalRespIntent extends Intent {
   final OtpSlot slot;
+
   const ConfigureChalRespIntent(this.slot);
 }
 
 class ConfigureHotpIntent extends Intent {
   final OtpSlot slot;
+
   const ConfigureHotpIntent(this.slot);
 }
 
 class ConfigureStaticIntent extends Intent {
   final OtpSlot slot;
+
   const ConfigureStaticIntent(this.slot);
 }
 
 class ConfigureYubiOtpIntent extends Intent {
   final OtpSlot slot;
+
   const ConfigureYubiOtpIntent(this.slot);
 }
 
@@ -58,6 +62,7 @@ class OtpActions extends ConsumerWidget {
   final DevicePath devicePath;
   final Map<Type, Action<Intent>> Function(BuildContext context)? actions;
   final Widget Function(BuildContext context) builder;
+
   const OtpActions(
       {super.key,
       required this.devicePath,

--- a/lib/otp/views/configure_chalresp_dialog.dart
+++ b/lib/otp/views/configure_chalresp_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -28,6 +27,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -42,6 +42,7 @@ final _log = Logger('otp.view.configure_chalresp_dialog');
 class ConfigureChalrespDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
   final OtpSlot otpSlot;
+
   const ConfigureChalrespDialog(this.devicePath, this.otpSlot, {super.key});
 
   @override
@@ -64,7 +65,7 @@ class _ConfigureChalrespDialogState
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final secret = _secretController.text;
     final secretLengthValid = secret.isNotEmpty &&

--- a/lib/otp/views/configure_hotp_dialog.dart
+++ b/lib/otp/views/configure_hotp_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -26,6 +25,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../oath/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -42,6 +42,7 @@ final _log = Logger('otp.view.configure_hotp_dialog');
 class ConfigureHotpDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
   final OtpSlot otpSlot;
+
   const ConfigureHotpDialog(this.devicePath, this.otpSlot, {super.key});
 
   @override
@@ -65,7 +66,7 @@ class _ConfigureHotpDialogState extends ConsumerState<ConfigureHotpDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final secret = _secretController.text.replaceAll(' ', '');
     final secretLengthValid = secret.isNotEmpty && secret.length * 5 % 8 < 5;
@@ -147,7 +148,8 @@ class _ConfigureHotpDialogState extends ConsumerState<ConfigureHotpDialog> {
               decoration: AppInputDecoration(
                   border: const OutlineInputBorder(),
                   labelText: l10n.s_secret_key,
-                  helperText: '', // Prevents resizing when errorText shown
+                  helperText: '',
+                  // Prevents resizing when errorText shown
                   errorText: _validateSecret && !secretFormatValid
                       ? l10n.l_invalid_format_allowed_chars(
                           Format.base32.allowedCharacters)

--- a/lib/otp/views/configure_static_dialog.dart
+++ b/lib/otp/views/configure_static_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -25,6 +24,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/choice_filter_chip.dart';
@@ -41,6 +41,7 @@ class ConfigureStaticDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
   final OtpSlot otpSlot;
   final Map<String, List<String>> keyboardLayouts;
+
   const ConfigureStaticDialog(
       this.devicePath, this.otpSlot, this.keyboardLayouts,
       {super.key});
@@ -83,7 +84,7 @@ class _ConfigureStaticDialogState extends ConsumerState<ConfigureStaticDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final password = _passwordController.text;
     final passwordLengthValid =

--- a/lib/otp/views/configure_yubiotp_dialog.dart
+++ b/lib/otp/views/configure_yubiotp_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import 'dart:math';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:material_symbols_icons/symbols.dart';
@@ -32,6 +31,7 @@ import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../core/models.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/choice_filter_chip.dart';
@@ -61,6 +61,7 @@ final uploadOtpUri = Uri.parse('https://upload.yubico.com');
 class ConfigureYubiOtpDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
   final OtpSlot otpSlot;
+
   const ConfigureYubiOtpDialog(this.devicePath, this.otpSlot, {super.key});
 
   @override
@@ -92,7 +93,7 @@ class _ConfigureYubiOtpDialogState
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final info = ref.watch(currentDeviceDataProvider).valueOrNull?.info;
 

--- a/lib/otp/views/delete_slot_dialog.dart
+++ b/lib/otp/views/delete_slot_dialog.dart
@@ -15,13 +15,13 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -31,11 +31,12 @@ import 'access_code_dialog.dart';
 class DeleteSlotDialog extends ConsumerWidget {
   final DevicePath devicePath;
   final OtpSlot otpSlot;
+
   const DeleteSlotDialog(this.devicePath, this.otpSlot, {super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return BasicDialog(
       icon: Icon(Symbols.delete),
       title: Text(l10n.q_delete_slot),

--- a/lib/otp/views/key_actions.dart
+++ b/lib/otp/views/key_actions.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../app/views/action_list.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -28,7 +28,7 @@ import 'swap_slots_dialog.dart';
 
 Widget otpBuildActions(BuildContext context, DevicePath devicePath,
     OtpState otpState, WidgetRef ref) {
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
 
   return Column(
     children: [

--- a/lib/otp/views/otp_screen.dart
+++ b/lib/otp/views/otp_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -30,6 +30,7 @@ import '../../app/views/app_list_item.dart';
 import '../../app/views/app_page.dart';
 import '../../app/views/message_page.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/list_title.dart';
 import '../features.dart' as features;
@@ -54,7 +55,7 @@ class _OtpScreenState extends ConsumerState<OtpScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     return ref.watch(otpStateProvider(widget.devicePath)).when(
         loading: () => MessagePage(
@@ -210,7 +211,7 @@ class _SlotListItem extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final slot = otpSlot.slot;
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final isConfigured = otpSlot.isConfigured;
     final hasFeature = ref.watch(featureProvider);

--- a/lib/otp/views/overwrite_confirm_dialog.dart
+++ b/lib/otp/views/overwrite_confirm_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../models.dart';
 
@@ -29,7 +30,7 @@ class _OverwriteConfirmDialog extends StatelessWidget {
   });
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return BasicDialog(
       icon: Icon(Symbols.warning),
       title: Text(l10n.q_overwrite_slot),

--- a/lib/otp/views/slot_dialog.dart
+++ b/lib/otp/views/slot_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -24,6 +24,7 @@ import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../app/views/action_list.dart';
 import '../../app/views/fs_dialog.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../models.dart';
 import '../state.dart';
 import 'actions.dart';
@@ -42,7 +43,7 @@ class SlotDialog extends ConsumerWidget {
       return const SizedBox();
     }
 
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
 
     final otpState = ref.watch(otpStateProvider(node.path)).valueOrNull;

--- a/lib/otp/views/swap_slots_dialog.dart
+++ b/lib/otp/views/swap_slots_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../keys.dart';
 import '../state.dart';
@@ -32,7 +33,7 @@ class SwapSlotsDialog extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return BasicDialog(
       icon: Icon(Symbols.swap_vert),
       title: Text(l10n.q_swap_slots),

--- a/lib/piv/models.dart
+++ b/lib/piv/models.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../core/models.dart';
+import '../generated/l10n/app_localizations.dart';
 
 part 'models.freezed.dart';
 part 'models.g.dart';

--- a/lib/piv/views/actions.dart
+++ b/lib/piv/views/actions.dart
@@ -18,7 +18,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -27,6 +27,7 @@ import '../../app/models.dart';
 import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -130,7 +131,7 @@ class PivActions extends ConsumerWidget {
             }
 
             return await withContext((context) async {
-              final l10n = AppLocalizations.of(context)!;
+              final l10n = AppLocalizations.of(context);
               final PivGenerateResult? result = await showBlurDialog(
                 context: context,
                 builder: (context) => GenerateKeyDialog(
@@ -181,7 +182,7 @@ class PivActions extends ConsumerWidget {
 
             final picked = await withContext(
               (context) async {
-                final l10n = AppLocalizations.of(context)!;
+                final l10n = AppLocalizations.of(context);
                 return await FilePicker.platform.pickFiles(
                     allowedExtensions: [
                       'pem',
@@ -215,7 +216,7 @@ class PivActions extends ConsumerWidget {
           }),
         if (hasFeature(features.slotsExport))
           ExportIntent: CallbackAction<ExportIntent>(onInvoke: (intent) async {
-            final l10n = AppLocalizations.of(context)!;
+            final l10n = AppLocalizations.of(context);
             final (metadata, cert) = await ref
                 .read(pivSlotsProvider(devicePath).notifier)
                 .read(intent.slot.slot);

--- a/lib/piv/views/authentication_dialog.dart
+++ b/lib/piv/views/authentication_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../core/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -55,7 +56,7 @@ class _AuthenticationDialogState extends ConsumerState<AuthenticationDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasMetadata = widget.pivState.metadata != null;
     final keyLen = (widget.pivState.metadata?.managementKeyMetadata.keyType ??
                 ManagementKeyType.tdes)

--- a/lib/piv/views/cert_info_view.dart
+++ b/lib/piv/views/cert_info_view.dart
@@ -15,11 +15,11 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/info_table.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -35,7 +35,7 @@ class CertInfoTable extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final dateFormat =
         DateFormat.yMMMEd(ref.watch(currentLocaleProvider).toString());
 

--- a/lib/piv/views/delete_certificate_dialog.dart
+++ b/lib/piv/views/delete_certificate_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../keys.dart' as keys;
 import '../models.dart';
@@ -55,7 +56,7 @@ class _DeleteCertificateDialogState
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final canDeleteCertificate = widget.pivSlot.certInfo != null;
     final canDeleteKey = widget.pivSlot.metadata != null &&
         widget.pivState.version.isAtLeast(5, 7);

--- a/lib/piv/views/generate_key_dialog.dart
+++ b/lib/piv/views/generate_key_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../core/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/choice_filter_chip.dart';
@@ -74,7 +75,7 @@ class _GenerateKeyDialogState extends ConsumerState<GenerateKeyDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final colorScheme = theme.colorScheme;

--- a/lib/piv/views/import_file_dialog.dart
+++ b/lib/piv/views/import_file_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,13 +17,13 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -40,6 +40,7 @@ class ImportFileDialog extends ConsumerStatefulWidget {
   final PivSlot pivSlot;
   final File file;
   final bool showMatch;
+
   ImportFileDialog(this.devicePath, this.pivState, this.pivSlot, this.file,
       {super.key})
       : showMatch = pivSlot.slot != SlotId.cardAuth && pivState.supportsBio;
@@ -92,7 +93,7 @@ class _ImportFileDialogState extends ConsumerState<ImportFileDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     final colorScheme = Theme.of(context).colorScheme;
     // This is what ListTile uses for subtitle

--- a/lib/piv/views/key_actions.dart
+++ b/lib/piv/views/key_actions.dart
@@ -15,7 +15,7 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +23,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../app/views/action_list.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../features.dart' as features;
 import '../keys.dart' as keys;
@@ -43,7 +44,7 @@ Widget pivBuildActions(BuildContext context, DevicePath devicePath,
     PivState pivState, WidgetRef ref) {
   final colors = Theme.of(context).buttonTheme.colorScheme ??
       Theme.of(context).colorScheme;
-  final l10n = AppLocalizations.of(context)!;
+  final l10n = AppLocalizations.of(context);
 
   final usingDefaultPin = pivState.metadata?.pinMetadata.defaultValue == true;
   final usingDefaultPuk = pivState.metadata?.pukMetadata.defaultValue == true;

--- a/lib/piv/views/manage_key_dialog.dart
+++ b/lib/piv/views/manage_key_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -25,6 +25,7 @@ import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../core/models.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -159,7 +160,7 @@ class _ManageKeyDialogState extends ConsumerState<ManageKeyDialog> {
         managementKeyType: _keyType, storeKey: _storeKey);
     if (!mounted) return;
 
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     showMessage(context, l10n.l_management_key_changed);
 
     Navigator.of(context).pop();
@@ -167,7 +168,7 @@ class _ManageKeyDialogState extends ConsumerState<ManageKeyDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
     final textTheme = theme.textTheme;

--- a/lib/piv/views/manage_pin_puk_dialog.dart
+++ b/lib/piv/views/manage_pin_puk_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
@@ -89,7 +90,7 @@ class _ManagePinPukDialogState extends ConsumerState<ManagePinPukDialog> {
 
   _submit() async {
     final notifier = ref.read(pivStateProvider(widget.path).notifier);
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     final result = await switch (widget.target) {
       ManageTarget.pin =>
@@ -139,7 +140,7 @@ class _ManagePinPukDialogState extends ConsumerState<ManagePinPukDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final currentPin = _currentPinController.text;
     final currentPinLen = byteLength(currentPin);
     final newPin = _newPinController.text;

--- a/lib/piv/views/move_key_dialog.dart
+++ b/lib/piv/views/move_key_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,14 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../app/message.dart';
 import '../../app/models.dart';
 import '../../app/state.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/choice_filter_chip.dart';
 import '../../widgets/responsive_dialog.dart';
 import '../keys.dart' as keys;
@@ -52,7 +53,7 @@ class _MoveKeyDialogState extends ConsumerState<MoveKeyDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
 
     return ResponsiveDialog(
       title: Text(l10n.l_move_key),

--- a/lib/piv/views/overwrite_confirm_dialog.dart
+++ b/lib/piv/views/overwrite_confirm_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,10 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/basic_dialog.dart';
 import '../models.dart';
 
@@ -33,7 +34,7 @@ class _OverwriteConfirmDialog extends StatelessWidget {
   });
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return BasicDialog(
       icon: Icon(Symbols.warning),
       title: Text(l10n.q_overwrite_slot),

--- a/lib/piv/views/pin_dialog.dart
+++ b/lib/piv/views/pin_dialog.dart
@@ -15,12 +15,12 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../app/models.dart';
 import '../../exception/cancellation_exception.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../widgets/app_input_decoration.dart';
 import '../../widgets/app_text_field.dart';
 import '../../widgets/responsive_dialog.dart';
@@ -30,6 +30,7 @@ import '../state.dart';
 
 class PinDialog extends ConsumerStatefulWidget {
   final DevicePath devicePath;
+
   const PinDialog(this.devicePath, {super.key});
 
   @override
@@ -82,7 +83,7 @@ class _PinDialogState extends ConsumerState<PinDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final version = ref.watch(pivStateProvider(widget.devicePath)).valueOrNull;
     final minPinLen = version?.version.isAtLeast(4, 3, 1) == true ? 6 : 4;
     final currentPinLen = byteLength(_pinController.text);

--- a/lib/piv/views/piv_screen.dart
+++ b/lib/piv/views/piv_screen.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -31,6 +30,7 @@ import '../../app/views/app_list_item.dart';
 import '../../app/views/app_page.dart';
 import '../../app/views/message_page.dart';
 import '../../core/state.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../../widgets/list_title.dart';
 import '../features.dart' as features;
@@ -56,7 +56,7 @@ class _PivScreenState extends ConsumerState<PivScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final hasFeature = ref.watch(featureProvider);
     final (fipsCapable, fipsApproved) = ref
             .watch(currentDeviceDataProvider)
@@ -287,7 +287,7 @@ class _CertificateListItem extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final slot = pivSlot.slot;
     final certInfo = pivSlot.certInfo;
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final hasFeature = ref.watch(featureProvider);
 

--- a/lib/piv/views/slot_dialog.dart
+++ b/lib/piv/views/slot_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
@@ -23,6 +22,7 @@ import '../../app/shortcuts.dart';
 import '../../app/state.dart';
 import '../../app/views/action_list.dart';
 import '../../app/views/fs_dialog.dart';
+import '../../generated/l10n/app_localizations.dart';
 import '../../management/models.dart';
 import '../models.dart';
 import '../state.dart';
@@ -31,6 +31,7 @@ import 'cert_info_view.dart';
 
 class SlotDialog extends ConsumerWidget {
   final SlotId pivSlot;
+
   const SlotDialog(this.pivSlot, {super.key});
 
   @override
@@ -44,7 +45,7 @@ class SlotDialog extends ConsumerWidget {
     }
     final devicePath = keyData.node.path;
 
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     // This is what ListTile uses for subtitle
     final subtitleStyle = textTheme.bodyMedium!.copyWith(

--- a/lib/widgets/basic_dialog.dart
+++ b/lib/widgets/basic_dialog.dart
@@ -1,5 +1,22 @@
+/*
+ * Copyright (C) 2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../generated/l10n/app_localizations.dart';
 
 class BasicDialog extends StatefulWidget {
   final Widget content;
@@ -34,7 +51,7 @@ class _BasicDialogState extends State<BasicDialog> {
   }
 
   String _getCancelText(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return widget.onCancel == null && widget.actions.isEmpty
         ? l10n.s_close
         : l10n.s_cancel;

--- a/lib/widgets/flex_box.dart
+++ b/lib/widgets/flex_box.dart
@@ -1,7 +1,25 @@
+/*
+ * Copyright (C) 2024-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
+
+import '../generated/l10n/app_localizations.dart';
 
 enum FlexLayout {
   list,

--- a/lib/widgets/info_popup_button.dart
+++ b/lib/widgets/info_popup_button.dart
@@ -1,7 +1,24 @@
+/*
+ * Copyright (C) 2025-2025 Yubico.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 
+import '../generated/l10n/app_localizations.dart';
 import 'basic_dialog.dart';
 
 class InfoPopupButton extends StatelessWidget {
@@ -23,7 +40,7 @@ class InfoPopupButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     if (!displayDialog) {
       return PopupMenuButton(
         tooltip: l10n.s_more_info,

--- a/lib/widgets/info_table.dart
+++ b/lib/widgets/info_table.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Yubico.
+ * Copyright (C) 2023-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../app/message.dart';
 import '../app/state.dart';
+import '../generated/l10n/app_localizations.dart';
 import 'tooltip_if_truncated.dart';
 
 class InfoTable extends ConsumerWidget {
@@ -29,7 +30,7 @@ class InfoTable extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     final textTheme = Theme.of(context).textTheme;
     // This is what ListTile uses for subtitle
     final subtitleStyle = textTheme.bodyMedium!.copyWith(

--- a/lib/widgets/responsive_dialog.dart
+++ b/lib/widgets/responsive_dialog.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,11 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../core/state.dart';
+import '../generated/l10n/app_localizations.dart';
 
 class ResponsiveDialog extends StatefulWidget {
   final Widget? title;
@@ -54,7 +55,7 @@ class _ResponsiveDialogState extends State<ResponsiveDialog> {
   }
 
   String _getCancelText(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
+    final l10n = AppLocalizations.of(context);
     return widget.onCancel == null && widget.actions.isEmpty
         ? l10n.s_close
         : l10n.s_cancel;

--- a/lib/widgets/utf8_utils.dart
+++ b/lib/widgets/utf8_utils.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,8 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+import '../generated/l10n/app_localizations.dart';
 
 /// Get the number of bytes used by a String when encoded to UTF-8.
 int byteLength(String value) => utf8.encode(value).length;
@@ -38,7 +39,7 @@ InputCounterWidgetBuilder buildByteCounterFor(String currentValue) =>
       return Text(
         maxLength != null ? '${byteLength(currentValue)}/$maxLength' : '',
         style: style,
-        semanticsLabel: AppLocalizations.of(context)!.s_character_count,
+        semanticsLabel: AppLocalizations.of(context).s_character_count,
       );
     };
 

--- a/test/android_settings_page_test.dart
+++ b/test/android_settings_page_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -28,6 +28,7 @@ import 'package:yubico_authenticator/app/state.dart';
 import 'package:yubico_authenticator/app/views/keys.dart' as app_keys;
 import 'package:yubico_authenticator/app/views/settings_page.dart';
 import 'package:yubico_authenticator/core/state.dart';
+import 'package:yubico_authenticator/generated/l10n/app_localizations.dart';
 
 Widget createMaterialApp({required Widget child}) {
   return MaterialApp(


### PR DESCRIPTION
The use of synthetic package is deprecated and will be removed, see [this breaking change description](https://docs.flutter.dev/release/breaking-changes/flutter-generate-i10n-source). Instead apps should generate the localized messages into source and PR fixes this.

These changes will not affect the way how we work with localizations. When we need to add a new string, let's just put it into `app_en.arb` and build the app to be able to use it in code.

Changes:
1. Updated l10n.yaml with options to not use the synthetic package an pointed out where the new sources should be generated.
2. Updated all sources to include correct `app_localizations.dart` file.
3. the `generated` folder is ignored in git and will be always created during build, but for making sure that nothing is broken, the pre-commit hook is updated so that it always regenerates the localized messages sources.
4. `AppLocalization.of(context)` now returns no-nullable getter.
5. Updated license header years and added missing license headers.

This has been tested on desktop and Android on both Flutter 3.27.4 and 3.29.0 versions.