### PR TITLE
Use Material Design 3 appearance of ProgressIndicator introduced in December 2023

### DIFF
--- a/lib/android/overlay/nfc/views/nfc_overlay_icons.dart
+++ b/lib/android/overlay/nfc/views/nfc_overlay_icons.dart
@@ -43,7 +43,10 @@ class NfcIconProgressBar extends StatelessWidget {
         SizedBox(
           width: 50,
           height: 50,
-          child: CircularProgressIndicator(value: inProgress ? null : 1.0),
+          child: CircularProgressIndicator(
+            strokeAlign: 2,
+            value: inProgress ? null : 1.0,
+          ),
         ),
       ],
     ),

--- a/lib/app/icon_provider/icon_pack_icon.dart
+++ b/lib/app/icon_provider/icon_pack_icon.dart
@@ -79,7 +79,7 @@ class IconPackIcon extends ConsumerWidget {
               alignment: Alignment.center,
               children: [
                 Opacity(opacity: 0.5, child: defaultWidget),
-                const CircularProgressIndicator(),
+                const CircularProgressIndicator(strokeAlign: 1.0),
               ],
             ),
           ),

--- a/lib/oath/views/add_account_page.dart
+++ b/lib/oath/views/add_account_page.dart
@@ -470,6 +470,7 @@ class _OathAddAccountPageState extends ConsumerState<OathAddAccountPage>
                                                         child:
                                                             CircularProgressIndicator(
                                                               strokeWidth: 2.0,
+                                                              strokeAlign: 2.0,
                                                             ),
                                                       )
                                                       : _qrScanSuccess

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -26,6 +26,10 @@ class AppTheme {
         Brightness.dark => getDarkTheme(primaryColor),
       };
 
+  static ProgressIndicatorThemeData _progressIndicatorThemeData() =>
+  // ignore: deprecated_member_use
+  ProgressIndicatorThemeData(year2023: false);
+
   static ColorScheme _colorScheme(Brightness brightness, Color primaryColor) {
     const darkSurface = Color(0xff282828);
     return switch (brightness) {
@@ -79,6 +83,7 @@ class AppTheme {
           color: colorScheme.onSurface,
         ),
       ),
+      progressIndicatorTheme: _progressIndicatorThemeData(),
     );
   }
 
@@ -116,6 +121,7 @@ class AppTheme {
           color: colorScheme.onSurface,
         ),
       ),
+      progressIndicatorTheme: _progressIndicatorThemeData(),
     );
   }
 }


### PR DESCRIPTION
In Flutter we can use a new appearance of the Material Design 3 progress indicator widgets. The change has been described here: https://docs.flutter.dev/release/breaking-changes/updated-material-3-progress-indicators

Currently the new property `year2023` is deprecated, but I couldn't find a way how to display the new appearance without using the property (see my question in the [flutter repository](https://github.com/flutter/flutter/issues/165045)), so I use the deprecated property, but ignore the warning.

The new appearance renders smaller widgets. In places where that matters, I updated the widgets with extra properties.