### PR TITLE
Add required entitlements

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,6 +12,8 @@
 	<true/>
 	<key>com.apple.security.smartcard</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.smartcard</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>


### PR DESCRIPTION
Since version 8.2.0 the `file_picker` plugin needs macOS entitlements (see https://github.com/miguelpruivo/flutter_file_picker/blob/master/CHANGELOG.md#820)

We need Read/Write permissions because we also save files.
