### PR TITLE
Fix: YubiKey NEO NFC reading for OATH accounts with touch-eject enabled

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/Workarounds.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/yubikit/Workarounds.kt
@@ -42,6 +42,7 @@ import com.yubico.yubikit.support.DeviceUtil
 import kotlinx.coroutines.delay
 import org.slf4j.LoggerFactory
 import java.nio.ByteBuffer
+import kotlin.experimental.and
 
 object Workarounds {
     private val logger = LoggerFactory.getLogger("Workarounds")
@@ -153,7 +154,7 @@ object Workarounds {
                 val response = protocol.select(AppId.OTP)
                 if (response[0] == 3.toByte() && response.size > 6) {
                     return Mode.entries
-                        .first { it.value == response[6] }.interfaces
+                        .first { mode -> mode.value == response[6] and 0b00000111 }.interfaces
                 }
 
             } catch (_: ApplicationNotAvailableException) {


### PR DESCRIPTION
This PR fixes an issue where tapping a YubiKey NEO with touch-eject enabled over NFC fails to retrieve OATH accounts. The root cause was an internal exception occurring when the USB interface values from the YubiKey couldn't be mapped to our enumeration values. 

Solution: Modified code to use only the lowest 3 bits for interface mapping.

The issue first occurred in release 7.2.0 and affects versions 7.2.0, 7.2.1 and 7.2.2. 

Fixes #1851 