### PR TITLE
Fix NDEF discovery for Android 16

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -95,9 +95,16 @@
             android:theme="@style/NdefActivityTheme"
             android:targetActivity=".NdefActivity">
 
-            <intent-filter
-                android:autoVerify="true"
-                tools:ignore="UnusedAttribute">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data
+                    android:host="my.yubico.com"
+                    android:scheme="https" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
+
+            <intent-filter>
                 <action android:name="android.nfc.action.NDEF_DISCOVERED" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -95,7 +95,7 @@
             android:theme="@style/NdefActivityTheme"
             android:targetActivity=".NdefActivity">
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <data
                     android:host="my.yubico.com"


### PR DESCRIPTION
Adds intent filter for Android 16. 

**Important**: only apps signed with the release signing keys will react to NDEF taps on Android 16. 

See https://issuetracker.google.com/issues/409809756 for details.