### PR TITLE
Fix application icon in Wayland (flutter PR#154522)

### DIFF
--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -101,6 +101,12 @@ static void my_application_class_init(MyApplicationClass* klass) {
 static void my_application_init(MyApplication* self) {}
 
 MyApplication* my_application_new() {
+  // Set the program name to the application ID, which helps various systems
+  // like GTK and desktop environments map this running application to its
+  // corresponding .desktop file. This ensures better integration by allowing
+  // the application to be recognized beyond its binary name.
+  g_set_prgname(APPLICATION_ID);
+
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
                                      "flags", G_APPLICATION_NON_UNIQUE,


### PR DESCRIPTION
Port of https://github.com/flutter/flutter/pull/154522 that has already been merged in flutter. This corrects the application icon in Wayland that currently shows up as a generic "W".