### PR TITLE
[Android] set default log level on app startup

### DIFF
--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -807,5 +807,5 @@ class MainActivity : FlutterFragmentActivity() {
     private fun isPortraitOnly() = resources.getBoolean(R.bool.portrait_only)
 
     private val defaultLogLevel =
-        if (BuildConfig.DEBUG) Log.LogLevel.DEBUG else Log.LogLevel.INFO
+        if (BuildConfig.DEBUG) Log.LogLevel.TRAFFIC else Log.LogLevel.INFO
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/MainActivity.kt
@@ -49,6 +49,7 @@ import com.yubico.authenticator.device.noScp11bNfcSupport
 import com.yubico.authenticator.fido.FidoManager
 import com.yubico.authenticator.fido.FidoViewModel
 import com.yubico.authenticator.logging.FlutterLog
+import com.yubico.authenticator.logging.Log
 import com.yubico.authenticator.management.ManagementManager
 import com.yubico.authenticator.oath.AppLinkMethodChannel
 import com.yubico.authenticator.oath.OathManager
@@ -123,6 +124,9 @@ class MainActivity : FlutterFragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        Log.setLevel(defaultLogLevel)
+        logger.info("Application startup")
 
         if (isPortraitOnly()) {
             forcePortraitOrientation()
@@ -801,4 +805,7 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
     private fun isPortraitOnly() = resources.getBoolean(R.bool.portrait_only)
+
+    private val defaultLogLevel =
+        if (BuildConfig.DEBUG) Log.LogLevel.DEBUG else Log.LogLevel.INFO
 }

--- a/android/app/src/main/kotlin/com/yubico/authenticator/logging/Log.kt
+++ b/android/app/src/main/kotlin/com/yubico/authenticator/logging/Log.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2023 Yubico.
+ * Copyright (C) 2022-2025 Yubico.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.yubico.authenticator.logging
 
 import ch.qos.logback.classic.Level
-import com.yubico.authenticator.BuildConfig
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -33,11 +32,7 @@ object Log {
         ERROR
     }
 
-    private var level = if (BuildConfig.DEBUG) {
-        LogLevel.DEBUG
-    } else {
-        LogLevel.INFO
-    }
+    private var level = LogLevel.INFO
 
     init {
         setLevel(level)


### PR DESCRIPTION
This PR prevents debug and trace log messages from appearing in release builds before the configured minimum log level (INFO) is applied.

Previously, during early startup the logging system had not yet set the effective level, so initial log events were emitted at DEBUG/TRACE and reached Logcat. We now initialize logging at the earliest safe point and set a conservative default (INFO) so no low-level messages leak.