### PR TITLE
[Android] Keep exception names

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -75,3 +75,6 @@
 -dontwarn javax.naming.directory.InitialDirContext
 -dontwarn javax.naming.directory.SearchControls
 -dontwarn javax.naming.directory.SearchResult
+
+# don't ubfuscate exception names
+-keep class com.yubico.yubikit.core.** extends java.lang.Exception { *; }


### PR DESCRIPTION
This pull request makes a minor update to the ProGuard configuration for the Android app. The change ensures that exception class names from the `com.yubico.yubikit.core` package are preserved and not obfuscated, which can help with debugging and error reporting, our Flutter Exception class extension `Decoder` uses the names to understand what exact PlatformException it received.

* ProGuard configuration: Added a rule to keep all exception classes in `com.yubico.yubikit.core` and prevent their names from being obfuscated. (`android/app/proguard-rules.pro`)
