### PR TITLE
Handle empty capabilities

### DIFF
--- a/lib/app/views/app_page.dart
+++ b/lib/app/views/app_page.dart
@@ -702,8 +702,7 @@ class _AppPageState extends ConsumerState<AppPage> {
               if (hasManage &&
                   !hasDetailsOrKeyActions &&
                   showExpandedSideMenuBar &&
-                  widget.capabilities != null &&
-                  widget.capabilities?.first != Capability.u2f)
+                  widget.capabilities?.firstOrNull != Capability.u2f)
                 // Add a placeholder for the Manage/Details column. Exceptions are:
                 // - the "Security Key" because it does not have any actions/details.
                 // - pages without Capabilities


### PR DESCRIPTION
The fix prevents errors when the capabilities list is empty by using firstOrNull.

Fixes #2023 