### PR TITLE
build(android): guard release APK against permission creep

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -89,6 +89,7 @@ kotlin {
 
 apply from: "signing.gradle"
 apply from: "collect_licenses.gradle"
+apply from: "permission_guard.gradle.kts"
 
 android.applicationVariants.all { variant ->
     variant.outputs.each { output ->

--- a/android/app/permission_guard.gradle.kts
+++ b/android/app/permission_guard.gradle.kts
@@ -1,7 +1,7 @@
 import com.android.build.api.artifact.SingleArtifact
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 
-// Build-time guard against permission creep in the shipped APK.
+// Build-time guard against permission creep in the shipped APK/AAB.
 //
 // Manifest merging folds every <uses-permission> declared by our transitive
 // dependencies into the final APK, and each one surfaces on the Play Store
@@ -58,7 +58,14 @@ extensions.configure<ApplicationAndroidComponentsExtension> {
                 doLast {
                     // uses-permission elements are self-closing, so the first '>'
                     // ends the tag; (?s) lets attributes span multiple lines.
-                    val manifestText = mergedManifest.get().asFile.readText()
+                    // Strip XML comments first so a commented-out <uses-permission>
+                    // (which AGP or a library may emit) is not counted as declared.
+                    val manifestText =
+                        mergedManifest
+                            .get()
+                            .asFile
+                            .readText()
+                            .replace(Regex("(?s)<!--.*?-->"), "")
                     val declared =
                         usesPermissionRegex
                             .findAll(manifestText)
@@ -92,10 +99,13 @@ extensions.configure<ApplicationAndroidComponentsExtension> {
                 }
             }
 
-        // Block APK assembly on the guard so `flutter build apk` (and CI) fail
-        // when an unexpected permission slips in.
-        afterEvaluate {
-            tasks.named("assemble$capitalizedName").configure { dependsOn(checkTask) }
-        }
+        // Block both APK and AAB release builds on the guard so `flutter build
+        // apk`, `flutter build appbundle`, and CI all fail when an unexpected
+        // permission slips in. The Play Store listing is driven by the AAB, so
+        // gating only assemble would leave a gap. `matching { }.configureEach`
+        // is lazy and safe whether or not the build tasks exist yet, avoiding a
+        // redundant afterEvaluate wrapper inside this onVariants callback.
+        val buildTaskNames = setOf("assemble$capitalizedName", "bundle$capitalizedName")
+        tasks.matching { it.name in buildTaskNames }.configureEach { dependsOn(checkTask) }
     }
 }

--- a/android/app/permission_guard.gradle.kts
+++ b/android/app/permission_guard.gradle.kts
@@ -1,0 +1,101 @@
+import com.android.build.api.artifact.SingleArtifact
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+
+// Build-time guard against permission creep in the shipped APK.
+//
+// Manifest merging folds every <uses-permission> declared by our transitive
+// dependencies into the final APK, and each one surfaces on the Play Store
+// listing. A dependency bump can therefore silently add a user-visible
+// permission (this is exactly how androidx.media3, via CameraX, added
+// ACCESS_NETWORK_STATE / "view network connections"). This task inspects the
+// merged manifest of the release variant and fails the build if it contains
+// any permission that is not on the allow-list below.
+//
+// When this fails you have two choices:
+//   * The permission is unwanted -> strip it with tools:node="remove" in
+//     app/src/main/AndroidManifest.xml (see ACCESS_NETWORK_STATE there).
+//   * The permission is intentional -> add it to allowedPermissions with a
+//     comment explaining why, so the addition is a conscious, reviewed change.
+
+// Permissions we intentionally ship in the release APK.
+val allowedPermissions =
+    setOf(
+        "android.permission.NFC", // talk to YubiKeys over NFC
+        "android.permission.HIDE_OVERLAY_WINDOWS", // block tapjacking overlays
+        "android.permission.CAMERA", // scan otpauth QR codes
+    )
+
+// AndroidX registers unexported runtime receivers behind a private,
+// signature-level self-permission named
+// "<applicationId>.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION". It is not
+// user-visible and its prefix changes with the applicationId suffix (e.g.
+// ".debug"), so allow it by suffix rather than by exact name.
+val allowedPermissionSuffixes =
+    setOf(
+        ".DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION",
+    )
+
+val usesPermissionRegex = Regex("""(?s)<uses-permission(?:-sdk-23)?\b(.*?)>""")
+val permissionNameRegex = Regex("""android:name\s*=\s*"([^"]+)"""")
+
+extensions.configure<ApplicationAndroidComponentsExtension> {
+    // Only the release variant ships to users; debug/profile builds get an
+    // extra INTERNET permission injected by Flutter for hot reload, which must
+    // never reach a release build.
+    onVariants(selector().withBuildType("release")) { variant ->
+        val mergedManifest = variant.artifacts.get(SingleArtifact.MERGED_MANIFEST)
+        val variantName = variant.name
+        val capitalizedName = variantName.replaceFirstChar { it.uppercase() }
+
+        val checkTask =
+            tasks.register("check${capitalizedName}Permissions") {
+                group = "verification"
+                description = "Fails the build if the $variantName APK requests an unexpected permission."
+                // Consuming the artifact provider wires the implicit dependency on
+                // the manifest-merging task and makes this check incremental.
+                inputs.file(mergedManifest).withPropertyName("mergedManifest")
+
+                doLast {
+                    // uses-permission elements are self-closing, so the first '>'
+                    // ends the tag; (?s) lets attributes span multiple lines.
+                    val manifestText = mergedManifest.get().asFile.readText()
+                    val declared =
+                        usesPermissionRegex
+                            .findAll(manifestText)
+                            .mapNotNull { permissionNameRegex.find(it.groupValues[1])?.groupValues?.get(1) }
+                            .toSortedSet()
+
+                    val unexpected =
+                        declared.filter { permission ->
+                            permission !in allowedPermissions &&
+                                allowedPermissionSuffixes.none { permission.endsWith(it) }
+                        }
+
+                    if (unexpected.isNotEmpty()) {
+                        throw GradleException(
+                            buildString {
+                                appendLine("Permission guard: the $variantName APK requests unexpected permission(s):")
+                                unexpected.forEach { appendLine("  - $it") }
+                                appendLine()
+                                appendLine("These are almost certainly pulled in transitively by a dependency and")
+                                appendLine("would appear on the Play Store listing. If unwanted, strip them with")
+                                appendLine("""tools:node="remove" in app/src/main/AndroidManifest.xml. If intentional,""")
+                                append("add them to allowedPermissions in app/permission_guard.gradle.kts.")
+                            },
+                        )
+                    }
+
+                    logger.lifecycle(
+                        "Permission guard: $variantName APK declares only expected permissions " +
+                            "(${declared.joinToString(", ")}).",
+                    )
+                }
+            }
+
+        // Block APK assembly on the guard so `flutter build apk` (and CI) fail
+        // when an unexpected permission slips in.
+        afterEvaluate {
+            tasks.named("assemble$capitalizedName").configure { dependsOn(checkTask) }
+        }
+    }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,14 @@
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.HIDE_OVERLAY_WINDOWS" />
 
+    <!-- Pulled in transitively by androidx.media3 (via CameraX camera-video, a
+         dependency of the QR scanner). The app does no networking, so strip it
+         from the merged manifest to keep "view network connections" off the
+         Play Store permission list. Enforced by app/permission_guard.gradle.kts. -->
+    <uses-permission
+        android:name="android.permission.ACCESS_NETWORK_STATE"
+        tools:node="remove" />
+
     <uses-feature
         android:name="android.hardware.usb.host"
         android:required="false" />


### PR DESCRIPTION
## Summary

A CameraX bump in 7.4.1 transitively pulled in `androidx.media3`, which
declares `ACCESS_NETWORK_STATE`, adding "view network connections" to the
Play Store permission listing. This removes the unused permission and adds a
build-time guard so future dependency bumps can't silently re-add
user-visible permissions.

## Changes

- Strip `ACCESS_NETWORK_STATE` from the merged manifest with
  `tools:node="remove"` — the app does no networking.
- Add `permission_guard.gradle.kts`: inspects the **release** merged manifest
  and fails `assembleRelease` if any permission is not on an explicit
  allow-list (`NFC`, `HIDE_OVERLAY_WINDOWS`, `CAMERA`, plus AndroidX's private
  `DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION` self-permission).
- Guard is release-only; debug/profile builds keep Flutter's injected
  `INTERNET` permission for hot reload.